### PR TITLE
Implement a standalone assertions library 

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -10,7 +10,22 @@ ignore = {
 	"213", -- unused loop variable (kept for readability's sake)
 }
 globals = {
-	-- Builtin BDD-style test runner
+	-- assertions library
+	"assertTrue",
+	"assertFalse",
+	"assertNil",
+	"assertThrows",
+	"assertDoesNotThrow",
+	"assertFailure",
+	"assertCallsFunction",
+	"assertEqualStrings",
+	"assertEqualNumbers",
+	"assertEqualTables",
+	"assertEqualBooleans",
+	"assertEqualPointers",
+	"assertEqualBytes",
+	"assertEquals",
+
 	"describe",
 	"it",
 }

--- a/Runtime/Libraries/assertions.lua
+++ b/Runtime/Libraries/assertions.lua
@@ -1,0 +1,302 @@
+local debug = require("debug")
+local ffi = require("ffi")
+
+local error = error
+local pairs = pairs
+local pcall = pcall
+local tostring = tostring
+local type = type
+local format = string.format
+local debug_getinfo = debug.getinfo
+local debug_sethook = debug.sethook
+local ffi_string = ffi.string
+
+local assertions = {}
+
+function assertions.assertTrue(conditionToCheck)
+	if conditionToCheck == true then
+		return true
+	end
+
+	error("ASSERTION FAILURE: " .. tostring(conditionToCheck) .. " should be true", 0)
+end
+
+function assertions.assertFalse(conditionToCheck)
+	if conditionToCheck == false then
+		return true
+	end
+
+	error("ASSERTION FAILURE: " .. tostring(conditionToCheck) .. " should be false", 0)
+end
+
+function assertions.assertNil(conditionToCheck)
+	if conditionToCheck == nil then
+		return true
+	end
+
+	error("ASSERTION FAILURE: " .. tostring(conditionToCheck) .. " should be nil", 0)
+end
+
+function assertions.assertThrows(codeUnderTest, expectedErrorMessage)
+	local success, errorMessage = pcall(codeUnderTest)
+
+	if success == true then
+		error("ASSERTION FAILURE: Function did not raise an error", 0)
+	end
+
+	if errorMessage ~= expectedErrorMessage then
+		error(
+			'ASSERTION FAILURE: Thrown error "'
+				.. tostring(errorMessage)
+				.. '" should be "'
+				.. tostring(expectedErrorMessage)
+				.. '"',
+			0
+		)
+	end
+end
+
+function assertions.assertDoesNotThrow(codeUnderTest)
+	local success, errorMessage = pcall(codeUnderTest)
+	if not success then
+		error("ASSERTION FAILURE: Expected function to not throw an error but it threw " .. tostring(errorMessage), 0)
+	end
+
+	return true
+end
+
+function assertions.assertFailure(codeUnderTest, message)
+	local success, status, value = pcall(codeUnderTest)
+	if not success then
+		error("ASSERTION FAILURE: Expected a failure but got an error", 0)
+	end
+
+	if status ~= nil then
+		error(format("ASSERTION FAILURE: Expected a failure but got success with value %s", tostring(value)), 0)
+	end
+
+	if message and value ~= message then
+		error(
+			format("ASSERTION FAILURE: Expected failure message '%s' but got '%s'", tostring(message), tostring(value)),
+			0
+		)
+	end
+end
+
+function assertions.assertCallsFunction(fn, expectedCalledFn)
+	local calledFn = nil
+	local function hook(event)
+		local calledFunction = debug_getinfo(2, "f").func
+		if calledFunction == expectedCalledFn then
+			calledFn = calledFunction
+		end
+	end
+	debug_sethook(hook, "c")
+	fn()
+	debug_sethook()
+	if calledFn ~= expectedCalledFn then
+		error(
+			"ASSERTION FAILURE: Expected function " .. tostring(expectedCalledFn) .. " to be called but it was not",
+			0
+		)
+	end
+end
+
+local function assertEqualLuastring(firstValue, secondValue)
+	if firstValue ~= secondValue then
+		error("ASSERTION FAILURE: Expected " .. firstValue .. " but got " .. secondValue)
+	end
+	return true
+end
+
+local function assertEqualBuffer(firstValue, secondValue)
+	local firstString = ffi_string(firstValue)
+	local secondString = ffi_string(secondValue)
+	if firstString ~= secondString then
+		error("ASSERTION FAILURE: Expected " .. firstString .. " but got " .. secondString)
+	end
+	return true
+end
+
+function assertions.assertEqualStrings(firstValue, secondValue)
+	if type(firstValue) == "string" and type(secondValue) == "string" then
+		return assertEqualLuastring(firstValue, secondValue)
+	elseif type(firstValue) == "cdata" and type(secondValue) == "cdata" then
+		return assertEqualBuffer(firstValue, secondValue)
+	elseif type(firstValue) == "string" and type(secondValue) == "cdata" then
+		local firstString = ffi_string(firstValue)
+		local secondString = ffi_string(secondValue)
+		return assertEqualLuastring(firstString, secondString)
+	elseif type(firstValue) == "cdata" and type(secondValue) == "string" then
+		local firstString = ffi_string(firstValue)
+		return assertEqualLuastring(firstString, secondValue)
+	else
+		return nil
+	end
+end
+
+function assertions.assertEqualNumbers(firstValue, secondValue)
+	if type(firstValue) ~= "number" or type(secondValue) ~= "number" then
+		error("ASSERTION FAILURE: Expected numbers but got " .. type(firstValue) .. " and " .. type(secondValue), 0)
+	elseif firstValue ~= secondValue then
+		error("ASSERTION FAILURE: Expected " .. tostring(firstValue) .. " but got " .. tostring(secondValue), 0)
+	end
+	return true
+end
+
+function assertions.assertEqualTables(firstValue, secondValue)
+	if type(firstValue) == "table" then
+		local firstValueKeys, secondValueKeys = {}, {}
+		for key in pairs(firstValue) do
+			table.insert(firstValueKeys, key)
+		end
+		for key in pairs(secondValue) do
+			table.insert(secondValueKeys, key)
+		end
+		table.sort(firstValueKeys)
+		table.sort(secondValueKeys)
+
+		if #firstValueKeys ~= #secondValueKeys then
+			error("ASSERTION FAILURE: Expected " .. tostring(firstValue) .. " but got " .. tostring(secondValue), 0)
+		else
+			for i = 1, #firstValueKeys do
+				if firstValueKeys[i] ~= secondValueKeys[i] then
+					error(
+						"ASSERTION FAILURE: Expected " .. tostring(firstValue) .. " but got " .. tostring(secondValue),
+						0
+					)
+				end
+				assertions.assertEquals(firstValue[firstValueKeys[i]], secondValue[secondValueKeys[i]])
+			end
+		end
+	end
+end
+
+function assertions.assertEqualBooleans(firstValue, secondValue)
+	if type(firstValue) ~= "boolean" or type(secondValue) ~= "boolean" then
+		return
+	end
+
+	if firstValue ~= secondValue then
+		error("ASSERTION FAILURE: Expected " .. tostring(firstValue) .. " but got " .. tostring(secondValue), 0)
+	end
+
+	return true
+end
+
+function assertions.assertEqualPointers(firstValue, secondValue)
+	if type(firstValue) == "cdata" and type(secondValue) == "cdata" then
+		if firstValue == secondValue then
+			return true
+		else
+			error("ASSERTION FAILURE: Expected " .. tostring(firstValue) .. " but got " .. tostring(secondValue), 0)
+		end
+	else
+		error(
+			"ASSERTION FAILURE: Both values must be cdata pointers, but got "
+				.. tostring(firstValue)
+				.. " and "
+				.. tostring(secondValue),
+			0
+		)
+	end
+end
+
+function assertions.assertEqualBytes(firstValue, secondValue)
+	if type(firstValue) ~= "cdata" or type(secondValue) ~= "cdata" then
+		error(
+			"ASSERTION FAILURE: Expected two cdata values, got " .. type(firstValue) .. " and " .. type(secondValue),
+			0
+		)
+	end
+
+	local firstLength = ffi.sizeof(firstValue)
+	local secondLength = ffi.sizeof(secondValue)
+
+	if ffi_string(firstValue, firstLength) ~= ffi_string(secondValue, secondLength) then
+		error(
+			"ASSERTION FAILURE: Expected "
+				.. tostring(firstValue, firstLength)
+				.. " but got "
+				.. tostring(secondValue, secondLength),
+			0
+		)
+	end
+
+	return true
+end
+
+function assertions.assertEquals(firstValue, secondValue)
+	local firstType = type(firstValue)
+	local secondType = type(secondValue)
+
+	local areBothValuesBooleans = (firstType == "boolean" and secondType == "boolean")
+	local areBothValuesStrings = (firstType == "string" and secondType == "string")
+	local areBothValuesNumbers = (firstType == "number" and secondType == "number")
+	local areBothValuesUserdata = (firstType == "userdata" and secondType == "userdata")
+	local areBothValuesTables = (firstType == "table" and secondType == "table")
+	local areBothValuesNil = (firstType == "nil" and secondType == "nil")
+	local areBothValuesStructs = (firstType == "cdata" and secondType == "cdata")
+
+	if areBothValuesNil then
+		return true
+	end -- Short-circuit since there's no point in comparing them (nil is unique)
+
+	if areBothValuesBooleans then
+		return assertions.assertEqualBooleans(firstValue, secondValue)
+	end
+
+	if areBothValuesStrings then
+		return assertions.assertEqualStrings(firstValue, secondValue)
+	end
+
+	if areBothValuesNumbers then
+		return assertions.assertEqualNumbers(firstValue, secondValue)
+	end
+
+	if areBothValuesUserdata then
+		return assertions.assertEqualFFI(firstValue, secondValue)
+	end
+
+	if areBothValuesTables then
+		return assertions.assertEqualTables(firstValue, secondValue)
+	end
+
+	if areBothValuesStructs then
+		return assertions.assertEqualPointers(firstValue, secondValue)
+	end
+
+	local errorMessage = format(
+		"ASSERTION FAILURE: Expected %s (a %s value) but got %s (a %s value)",
+		firstValue,
+		firstType,
+		secondValue,
+		secondType
+	)
+	error(errorMessage, 0)
+end
+
+function assertions.export()
+	local functionsToExport = {
+		"assertTrue",
+		"assertFalse",
+		"assertNil",
+		"assertThrows",
+		"assertDoesNotThrow",
+		"assertFailure",
+		"assertCallsFunction",
+		"assertEqualStrings",
+		"assertEqualNumbers",
+		"assertEqualTables",
+		"assertEqualBooleans",
+		"assertEqualPointers",
+		"assertEqualBytes",
+		"assertEquals",
+	}
+
+	for index, functionName in ipairs(functionsToExport) do
+		_G[functionName] = assertions[functionName]
+	end
+end
+
+return assertions

--- a/Tests/SmokeTests/assertions-library/test-assert-calls-function.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-calls-function.lua
@@ -1,0 +1,53 @@
+local assertions = require("assertions")
+local assertCallsFunction = assertions.assertCallsFunction
+
+local function testFunctionCallsFunctionCase()
+	local function NOOP_FUNCTION() end
+
+	local function functionThatCallsTheExpectedFunction()
+		NOOP_FUNCTION()
+	end
+
+	local success, errorMessage = pcall(assertCallsFunction, functionThatCallsTheExpectedFunction, NOOP_FUNCTION)
+	assert(success, "assertCallsFunction should not throw if the expected function is called")
+	assert(errorMessage == nil, "assertCallsFunction should not throw an error if the expected function is called")
+end
+
+local function testFunctionDoesNotCallAnyFunctionCase()
+	local function NOOP_FUNCTION() end
+
+	local success, errorMessage = pcall(assertCallsFunction, function() end, NOOP_FUNCTION)
+	assert(not success, "assertCallsFunction should throw if no function is called")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected function .* to be called but it was not$"),
+		"assertCallsFunction should throw the expected error if no function is called"
+	)
+end
+
+local function testFunctionCallsDifferentFunctionCase()
+	local function NOOP_FUNCTION() end
+	local function someOtherFunction()
+		return 42
+	end
+
+	local function functionThatCallsSomeOtherFunction()
+		someOtherFunction()
+	end
+
+	local success, errorMessage = pcall(assertCallsFunction, functionThatCallsSomeOtherFunction, NOOP_FUNCTION)
+	assert(not success, "assertCallsFunction should throw if the expected function is not called")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected function .* to be called but it was not$"),
+		"assertCallsFunction should throw the expected error if the expected function is not called"
+	)
+end
+
+local function testAssertCallsFunction()
+	testFunctionCallsFunctionCase()
+	testFunctionDoesNotCallAnyFunctionCase()
+	testFunctionCallsDifferentFunctionCase()
+end
+
+testAssertCallsFunction()
+
+print("OK", "assertions", "assertCallsFunction")

--- a/Tests/SmokeTests/assertions-library/test-assert-does-not-throw.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-does-not-throw.lua
@@ -1,0 +1,29 @@
+local assertions = require("assertions")
+local assertDoesNotThrow = assertions.assertDoesNotThrow
+
+local function testFunctionDoesNotThrowCase()
+	local function NOOP_FUNCTION() end
+	local success, returnValue = pcall(assertDoesNotThrow, NOOP_FUNCTION)
+	assert(success, "assertDoesNotThrow should not raise an error when the function doesn't throw an error")
+	assert(returnValue, "assertDoesNotThrow should return true when the function doesn't throw an error")
+end
+
+local function testFunctionThrowsCase()
+	local status, errorMessage = pcall(assertDoesNotThrow, function()
+		error("Test error", 0)
+	end)
+	assert(status == false, "assertDoesNotThrow should throw an error when the function throws an error")
+	assert(
+		string.match(errorMessage, "ASSERTION FAILURE: Expected function to not throw an error but it threw Test error"),
+		errorMessage
+	)
+end
+
+local function testAssertDoesNotThrow()
+	testFunctionDoesNotThrowCase()
+	testFunctionThrowsCase()
+end
+
+testAssertDoesNotThrow()
+
+print("OK", "assertions", "assertDoesNotThrow")

--- a/Tests/SmokeTests/assertions-library/test-assert-equal-booleans.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equal-booleans.lua
@@ -1,0 +1,47 @@
+local assertions = require("assertions")
+local assertEqualBooleans = assertions.assertEqualBooleans
+
+local function testTrueCase()
+	assert(assertEqualBooleans(true, true), "assertEqualBooleans(true, true) should return true and not throw")
+end
+
+local function testFalseCase()
+	assert(assertEqualBooleans(false, false), "assertEqualBooleans(false, false) should return true and not throw")
+end
+
+local function testFalseNilCase()
+	local success, errorMessage = assertEqualBooleans(false, nil)
+
+	assert(not success, "assertEqualBooleans(false, nil) should return nil")
+	assert(errorMessage == nil, "assertEqualBooleans(false, nil) should not throw")
+end
+
+local function testTrueFalseCase()
+	local success, errorMessage = pcall(assertEqualBooleans, true, false)
+	assert(not success, "assertEqualBooleans(true, false) should return nil")
+	assert(
+		errorMessage == "ASSERTION FAILURE: Expected true but got false",
+		"assertEqualBooleans(true, false) should throw"
+	)
+end
+
+local function testFalseTrueCase()
+	local success, errorMessage = pcall(assertEqualBooleans, false, true)
+	assert(not success, "assertEqualBooleans(false, true) should return nil")
+	assert(
+		errorMessage == "ASSERTION FAILURE: Expected false but got true",
+		"assertEqualBooleans(false, true) should throw"
+	)
+end
+
+local function testAssertEqualBooleans()
+	testTrueCase()
+	testFalseCase()
+	testFalseNilCase()
+	testFalseTrueCase()
+	testTrueFalseCase()
+end
+
+testAssertEqualBooleans()
+
+print("OK", "assertions", "assertEqualBooleans")

--- a/Tests/SmokeTests/assertions-library/test-assert-equal-bytes.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equal-bytes.lua
@@ -1,0 +1,94 @@
+local assertions = require("assertions")
+local assertEqualBytes = assertions.assertEqualBytes
+
+local ffi = require("ffi")
+
+ffi.cdef([[
+    typedef struct {
+        int x;
+        int y;
+    } point;
+
+	typedef struct {
+		int a;
+		int b;
+	} totally_not_a_point;
+]])
+
+local point1 = ffi.new("point", { x = 1, y = 2 })
+local point2 = ffi.new("point", { x = 1, y = 2 })
+local point3 = ffi.new("point", { x = 2, y = 3 })
+local notPoint = ffi.new("totally_not_a_point", { a = 1, b = 2 })
+
+local function testSameStructsCase()
+	assert(assertEqualBytes(point1, point1), "Expected assertEqualBytes(point1, point1) to be equal")
+end
+
+local function testClonedStructsCase()
+	assert(assertEqualBytes(point1, point2), "Expected assertEqualBytes(point1, point2) to be equal")
+end
+
+local function testNonEqualPointersCase()
+	local success, errorMessage = pcall(assertEqualBytes, point1, point3)
+	assert(
+		not success,
+		"Expected assertEqualBytes(point1, point3) to raise an error but it returned " .. tostring(errorMessage)
+	)
+	assert(
+		string.match(
+			errorMessage,
+			"^ASSERTION FAILURE: Expected " .. tostring(point1) .. " but got " .. tostring(point3)
+		),
+		errorMessage
+	)
+end
+
+local function testFirstParameterIsLuaTypeCase()
+	local success, errorMessage = pcall(assertEqualBytes, "huh?", point3)
+	assert(not success, "assertEqualBytes should throw if a cdata parameter was passed alongside a  non-cdata one")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected two cdata values, got string and cdata$"),
+		errorMessage
+	)
+end
+
+local function testSecondParameterIsLuaTypeCase()
+	local success, errorMessage = pcall(assertEqualBytes, point3, "meh")
+	assert(not success, "assertEqualBytes should throw if a non-cdata parameter was passed alongside a cdata one")
+
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected two cdata values, got cdata and string$"),
+		errorMessage
+	)
+end
+
+local function testBothParametersAreLuaTypesCase()
+	local success, errorMessage = pcall(assertEqualBytes, "hello", "goodbye")
+	assert(not success, "assertEqualBytes should throw if two non-cdata parameters were passed")
+
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected two cdata values, got string and string$"),
+		errorMessage
+	)
+end
+
+local function testDifferentNativeTypesWithSameSizeCase()
+	assert(
+		assertEqualBytes(point1, notPoint),
+		"assertEqualBytes should return true when two distinct byte-equal structs are passed"
+	)
+end
+
+local function testAssertEqualBytes()
+	testSameStructsCase()
+	testClonedStructsCase()
+	testNonEqualPointersCase()
+	testFirstParameterIsLuaTypeCase()
+	testSecondParameterIsLuaTypeCase()
+	testBothParametersAreLuaTypesCase()
+	testDifferentNativeTypesWithSameSizeCase()
+end
+
+testAssertEqualBytes()
+
+print("OK", "assertions", "assertEqualBytes")

--- a/Tests/SmokeTests/assertions-library/test-assert-equal-numbers.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equal-numbers.lua
@@ -1,0 +1,55 @@
+local assertions = require("assertions")
+local assertEqualNumbers = assertions.assertEqualNumbers
+
+local num1 = 1
+local num2 = 1
+local num3 = 2
+local num4 = 0
+
+local function testEqualNumbersCase()
+	assert(assertEqualNumbers(num1, num2) == true, "assertEqualNumbers(num1, num2) should return true")
+	local success, errorMessage = pcall(assertEqualNumbers, num1, num3)
+	assert(success == false, "assertEqualNumbers(num1, num3) should raise an error")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected 1 but got 2$"),
+		"assertEqualNumbers(num1, num3) should raise an error with the correct message"
+	)
+end
+
+local function testDifferentNumbersCase()
+	local success, errorMessage = pcall(assertEqualNumbers, num1, num4)
+	assert(success == false, "assertEqualNumbers(num1, num4) should raise an error")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected 1 but got 0$"),
+		"assertEqualNumbers(num1, num4) should raise an error with the correct message"
+	)
+end
+
+local function testNumberAndStringCase()
+	local success, errorMessage = pcall(assertEqualNumbers, num1, tostring(num1))
+	assert(success == false, "assertEqualNumbers(num1, tostring(num1) should raise an error")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected numbers but got number and string$"),
+		"assertEqualNumbers(num1, 'string') should raise an error with the correct message"
+	)
+end
+
+local function testAlmostEqualNumbersCase()
+	local success, errorMessage = pcall(assertEqualNumbers, num1, num2 + 0.1)
+	assert(success == false, "assertEqualNumbers(num1, num2 + 0.1) should raise an error")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected 1 but got 1.1$"),
+		"assertEqualNumbers(num1, num2 + 0.1) should raise an error with the correct message"
+	)
+end
+
+local function testAssertEqualNumbers()
+	testEqualNumbersCase()
+	testDifferentNumbersCase()
+	testNumberAndStringCase()
+	testAlmostEqualNumbersCase()
+end
+
+testAssertEqualNumbers()
+
+print("OK", "assertions", "assertEqualNumbers")

--- a/Tests/SmokeTests/assertions-library/test-assert-equal-pointers.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equal-pointers.lua
@@ -1,0 +1,59 @@
+local assertions = require("assertions")
+local assertEqualPointers = assertions.assertEqualPointers
+
+local ffi = require("ffi")
+
+ffi.cdef([[
+    typedef struct {
+        int x;
+        int y;
+    } point;
+]])
+
+local point1 = ffi.new("point", { x = 1, y = 2 })
+local point2 = ffi.new("point", { x = 1, y = 2 })
+local point3 = ffi.new("point", { x = 2, y = 3 })
+
+local function testSameStructsCase()
+	assert(assertEqualPointers(point1, point1), "Expected assertEqualPointers(point1, point1) to be equal")
+end
+
+local function testClonedStructsCase()
+	local success, errorMessage = pcall(assertEqualPointers, point1, point2)
+	assert(
+		not success,
+		"Expected assertEqualPointers(point1, point2) to raise an error but it returned " .. tostring(errorMessage)
+	)
+	assert(
+		string.match(
+			errorMessage,
+			"^ASSERTION FAILURE: Expected " .. tostring(point1) .. " but got " .. tostring(point2)
+		),
+		errorMessage
+	)
+end
+
+local function testNonEqualPointersCase()
+	local success, errorMessage = pcall(assertEqualPointers, point1, point3)
+	assert(
+		not success,
+		"Expected assertEqualPointers(point1, point3) to raise an error but it returned " .. tostring(errorMessage)
+	)
+	assert(
+		string.match(
+			errorMessage,
+			"^ASSERTION FAILURE: Expected " .. tostring(point1) .. " but got " .. tostring(point3)
+		),
+		errorMessage
+	)
+end
+
+local function testAssertEqualPointers()
+	testSameStructsCase()
+	testClonedStructsCase()
+	testNonEqualPointersCase()
+end
+
+testAssertEqualPointers()
+
+print("OK", "assertions", "assertEqualPointers")

--- a/Tests/SmokeTests/assertions-library/test-assert-equal-strings.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equal-strings.lua
@@ -1,0 +1,63 @@
+local assertions = require("assertions")
+local assertEqualStrings = assertions.assertEqualStrings
+
+-- Lua strings
+local string1 = "hello"
+local string2 = "hello"
+local string3 = "world"
+local string4 = ""
+
+local function testEqualStringsCase()
+	assert(assertEqualStrings(string1, string2), "Expected string1 and string2 to be equal")
+end
+
+local function testNonEqualStringsCase()
+	local success, error = pcall(assertEqualStrings, string1, string3)
+	assert(
+		not success,
+		"Expected assertEqualStrings(string1, string3) to raise an error but it returned " .. tostring(error)
+	)
+end
+
+local function testEmptyStringCase()
+	local success, error = pcall(assertEqualStrings, string1, string4)
+	assert(
+		not success,
+		"Expected assertEqualStrings(string1, string4) to raise an error but it returned " .. tostring(error)
+	)
+end
+
+-- String buffers
+local ffi = require("ffi")
+local buffer1 = ffi.new("char[?]", 6)
+ffi.copy(buffer1, "hello\0", 6)
+
+local buffer2 = ffi.new("char[?]", 6)
+ffi.copy(buffer2, "hello\0", 6)
+
+local buffer3 = ffi.new("char[?]", 6)
+ffi.copy(buffer3, "world\0", 6)
+
+local function testEqualStringBuffersCase()
+	assert(assertEqualStrings(buffer1, buffer2), "Expected buffer1 and buffer2 to be equal")
+end
+
+local function testNonEqualStringBuffersCase()
+	local success, error = pcall(assertEqualStrings, buffer1, buffer3)
+	assert(
+		not success,
+		"Expected assertEqualStrings(buffer1, buffer3) to raise an error but it returned " .. tostring(error)
+	)
+end
+
+local function testAssertEqualStrings()
+	testEqualStringsCase()
+	testNonEqualStringsCase()
+	testEmptyStringCase()
+	testEqualStringBuffersCase()
+	testNonEqualStringBuffersCase()
+end
+
+testAssertEqualStrings()
+
+print("OK", "assertions", "assertEqualStrings")

--- a/Tests/SmokeTests/assertions-library/test-assert-equal-tables.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equal-tables.lua
@@ -1,0 +1,65 @@
+local assertions = require("assertions")
+local assertEqualTables = assertions.assertEqualTables
+
+-- Flat tables
+local table1 = { x = 1, y = 2 }
+local table2 = { x = 1, y = 2 }
+local table3 = { x = 2, y = 3 }
+local table4 = { x = 1, y = 2, z = 3 }
+
+local function testFlatTablesEqualCase()
+	local success, errorMessage = pcall(assertEqualTables, table1, table2)
+	assert(success, "assertEqualTables should return true when both tables are flat and equal")
+	assert(errorMessage == nil, "assertEqualTables should not throw when both tables are flat and equal")
+end
+
+local function testFlatTablesNotEqualCase()
+	local success, errorMessage = pcall(assertEqualTables, table1, table3)
+	assert(not success, "Expected assertEqualTables to raise an error but it did not")
+	assert(
+		string.match(errorMessage, "ASSERTION FAILURE: Expected .* but got .*") ~= nil,
+		"Error message not as expected"
+	)
+end
+
+local function testFlatTablesWithDifferentLengthCase()
+	local success, errorMessage = pcall(assertEqualTables, table1, table4)
+	assert(not success, "Expected assertEqualTables to raise an error but it did not")
+	assert(
+		string.match(errorMessage, "ASSERTION FAILURE: Expected .* but got .*") ~= nil,
+		"Error message not as expected"
+	)
+end
+
+-- Nested tables
+table1 = { x = 1, y = 2, subtable = { a = 1, b = 2 } }
+table2 = { x = 1, y = 2, subtable = { a = 1, b = 2 } }
+table3 = { x = 1, y = 2, subtable = { a = 1, b = 3, c = { 42 } } }
+table4 = { x = 1, y = 2, subtable = { a = 1, b = 3, c = { 42 } } }
+
+local function testNestedTablesEqualCase()
+	local success, errorMessage = pcall(assertEqualTables, table3, table4)
+	assert(success, "assertEqualTables should return true when both tables are nested and equal")
+	assert(errorMessage == nil, "assertEqualTables should not throw when both tables are nested and equal")
+end
+
+local function testNestedTablesNotEqualCase()
+	local success, errorMessage = pcall(assertEqualTables, table1, table3) -- should raise an error
+	assert(not success, "Expected assertEqualTables to raise an error but it did not")
+	assert(
+		string.match(errorMessage, "ASSERTION FAILURE: Expected .* but got .*") ~= nil,
+		"Error message not as expected"
+	)
+end
+
+local function testAssertEqualTables()
+	testFlatTablesEqualCase()
+	testFlatTablesNotEqualCase()
+	testFlatTablesWithDifferentLengthCase()
+	testNestedTablesEqualCase()
+	testNestedTablesNotEqualCase()
+end
+
+testAssertEqualTables()
+
+print("OK", "assertions", "assertEqualTables")

--- a/Tests/SmokeTests/assertions-library/test-assert-equals.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equals.lua
@@ -1,0 +1,133 @@
+local assertions = require("assertions")
+local assertEquals = assertions.assertEquals
+
+local ffi = require("ffi")
+local buffer = ffi.new("char[10]")
+ffi.copy(buffer, "hello", #"hello")
+
+dofile("Tests/SmokeTests/assertions-library/test-assert-equal-booleans.lua")
+dofile("Tests/SmokeTests/assertions-library/test-assert-equal-numbers.lua")
+dofile("Tests/SmokeTests/assertions-library/test-assert-equal-strings.lua")
+dofile("Tests/SmokeTests/assertions-library/test-assert-equal-tables.lua")
+dofile("Tests/SmokeTests/assertions-library/test-assert-equal-pointers.lua")
+dofile("Tests/SmokeTests/assertions-library/test-assert-equal-bytes.lua")
+
+local function testEqualNumbersCase()
+	local status = pcall(assertEquals, 1, 1)
+	assert(status == true, "assertEquals should not throw an error when the values match")
+end
+
+local function testDistinctNumbersCase()
+	local status, errorMessage = pcall(assertEquals, 1, 2)
+	assert(status == false, "assertEquals should throw an error when the values don't match")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected .* but got .*") ~= nil,
+		"assertEquals should throw an error message with the proper format"
+	)
+end
+
+local function testEqualStringsCase()
+	local status = pcall(assertEquals, "hello", "hello")
+	assert(status == true, "assertEquals should not throw an error when the values match")
+end
+
+local function testDistinctStringsCase()
+	local status, errorMessage = pcall(assertEquals, "hello", "world")
+	assert(status == false, "assertEquals should throw an error when the values don't match")
+	assert(
+		string.match(errorMessage, "ASSERTION FAILURE: Expected hello but got world") ~= nil,
+		"assertEquals should throw an error message with the proper format"
+	)
+end
+
+local function testEqualFlatTablesCase()
+	local status = pcall(assertEquals, { a = 1, b = 2 }, { a = 1, b = 2 })
+	assert(status == true, "assertEquals should not throw an error when the values match")
+
+	status = pcall(assertEquals, { a = 1, b = 2 }, { b = 2, a = 1 })
+	assert(status == true, "assertEquals should not throw an error when the tables match, regardless of order")
+end
+
+local function testDistinctFlatTablesCase()
+	local status, errorMessage = pcall(assertEquals, { a = 1, b = 2, c = 3 }, { a = 1, b = 2 })
+	assert(status == false, "assertEquals should throw an error when the tables do not match")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected .* but got .*") ~= nil,
+		"assertEquals should throw an error message with the proper format"
+	)
+end
+
+local function testEqualNestedTablesCase()
+	local status = pcall(assertEquals, { a = 1, b = { c = 2 } }, { a = 1, b = { c = 2 } })
+	assert(status == true, "assertEquals should not throw an error when the nested table values match")
+end
+
+local function testEqualStringBuffersCase()
+	local sb1 = string.dump(function() end)
+	local status = pcall(assertEquals, sb1, sb1)
+	assert(status == true, "assertEquals should not throw an error when comparing equal stringbuffer values")
+
+	local buf1 = string.rep("a", 100)
+	local buf2 = string.rep("a", 100)
+	status = pcall(assertEquals, buf1, buf2)
+	assert(status == true, "assertEquals should not throw an error when the string buffer contents match")
+end
+
+local function testDistinctStringBuffersCase()
+	local sb1, sb2 = string.dump(function() end), string.dump(function() end)
+	sb2 = string.sub(sb2, 1, -2) .. "a"
+	local status, errorMessage = pcall(assertEquals, sb1, sb2)
+	assert(status == false, "assertEquals should throw an error when comparing different stringbuffer values")
+	assert(
+		string.match(errorMessage, "ASSERTION FAILURE: Expected .* but got .*") ~= nil,
+		"assertEquals should throw an error message with the proper format"
+	)
+end
+
+local function testNilAndNilCase()
+	local status = pcall(assertEquals, nil, nil)
+	assert(status == true, "assertEquals should not throw an error when the values match")
+end
+
+local function testNumberAndNilCase()
+	local status, errorMessage = pcall(assertEquals, 1, nil)
+	assert(status == false, "assertEquals should throw an error when the values don't match")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected .* but got .*") ~= nil,
+		"assertEquals should throw an error message with the proper format"
+	)
+end
+
+local function testDistinctStructsCase()
+	local status, errorMessage = pcall(assertEquals, ffi.new("int[1]", 1), ffi.new("int[1]", 2))
+	assert(status == false, "assertEquals should throw an error when comparing different cdata values")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected .* but got .*") ~= nil,
+		"assertEquals should throw an error message with the proper format"
+	)
+end
+
+local function testAssertEquals()
+	testEqualNumbersCase()
+	testDistinctNumbersCase()
+
+	testEqualStringsCase()
+	testDistinctStringsCase()
+
+	testEqualFlatTablesCase()
+	testDistinctFlatTablesCase()
+
+	testEqualNestedTablesCase()
+
+	testNilAndNilCase()
+	testNumberAndNilCase()
+
+	testEqualStringBuffersCase()
+	testDistinctStringBuffersCase()
+
+	testDistinctStructsCase()
+end
+
+testAssertEquals()
+
+print("OK", "assertions", "assertEquals")

--- a/Tests/SmokeTests/assertions-library/test-assert-failure.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-failure.lua
@@ -1,0 +1,59 @@
+local assertions = require("assertions")
+local assertFailure = assertions.assertFailure
+
+local function testFunctionReturnsFailureCase()
+	local function functionThatReturnsFailure()
+		return nil, "some error message"
+	end
+
+	local success = pcall(assertFailure, functionThatReturnsFailure)
+	assert(success, "assertFailure should return true if the code under test returns a failure type")
+end
+
+local function testFunctionDoesNotReturnNilCase()
+	local success, errorMessage = pcall(assertFailure, function()
+		return "not nil", "error message"
+	end)
+	assert(not success, "Expected assertFailure to raise an error but it did not")
+	assert(
+		string.match(errorMessage, "ASSERTION FAILURE: Expected a failure but got success with value error message")
+			~= nil,
+		"Error message not as expected"
+	)
+end
+
+local function testFunctionReturnsUnexpectedFailureMessageCase()
+	local function functionThatReturnsUnexpectedFailureMessage()
+		return nil, "meep"
+	end
+	local success, errorMessage = pcall(assertFailure, functionThatReturnsUnexpectedFailureMessage, "something else")
+	assert(not success, "Expected assertFailure to raise an error but it did not")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected failure message 'something else' but got 'meep'$")
+			~= nil,
+		"Error message not as expected"
+	)
+end
+
+local function testFunctionThrowsInsteadOfReturningFailureCase()
+	local function functionThatThrows()
+		error("error message", 0)
+	end
+	local success, errorMessage = pcall(assertFailure, functionThatThrows)
+	assert(not success, "Expected assertFailure to raise an error but it did not")
+	assert(
+		string.match(errorMessage, "ASSERTION FAILURE: Expected a failure but got an error") ~= nil,
+		"Error message not as expected"
+	)
+end
+
+local function testAssertFailure()
+	testFunctionReturnsFailureCase()
+	testFunctionDoesNotReturnNilCase()
+	testFunctionReturnsUnexpectedFailureMessageCase()
+	testFunctionThrowsInsteadOfReturningFailureCase()
+end
+
+testAssertFailure()
+
+print("OK", "assertions", "assertFailure")

--- a/Tests/SmokeTests/assertions-library/test-assert-false.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-false.lua
@@ -1,0 +1,50 @@
+local assertions = require("assertions")
+local assertFalse = assertions.assertFalse
+
+local function testFalseCase()
+	assert(assertFalse(false), "assertFalse(false) should return true and not raise an error")
+end
+
+local function testTrueCase()
+	local status, errorMessage = pcall(assertFalse, true)
+	assert(status == false, "assertFalse(true) should raise an error")
+	assert(
+		errorMessage == "ASSERTION FAILURE: true should be false",
+		"assertFalse(true) should throw with error [[ASSERTION FAILURE: true should be false]] and not [["
+			.. tostring(errorMessage)
+			.. "]]"
+	)
+end
+
+local function testNilCase()
+	local status, errorMessage = pcall(assertFalse, nil)
+	assert(status == false, "assertFalse(nil) should raise an error")
+	assert(
+		errorMessage == "ASSERTION FAILURE: nil should be false",
+		"assertFalse(nil) should throw with error [[ASSERTION FAILURE: nil should be false]] and not [["
+			.. tostring(errorMessage)
+			.. "]]"
+	)
+end
+
+local function testZeroCase()
+	local status, errorMessage = pcall(assertFalse, 0)
+	assert(status == false, "assertFalse(0) should raise an error")
+	assert(
+		errorMessage == "ASSERTION FAILURE: 0 should be false",
+		"assertFalse(0) should throw with error [[ASSERTION FAILURE: 0 should be false]] and not [["
+			.. tostring(errorMessage)
+			.. "]]"
+	)
+end
+
+local function testAssertFalse()
+	testFalseCase()
+	testTrueCase()
+	testNilCase()
+	testZeroCase()
+end
+
+testAssertFalse()
+
+print("OK", "assertions", "assertFalse")

--- a/Tests/SmokeTests/assertions-library/test-assert-nil.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-nil.lua
@@ -1,0 +1,50 @@
+local assertions = require("assertions")
+local assertNil = assertions.assertNil
+
+local function testNilCase()
+	assert(assertNil(nil), "assertNil(nil) should return true and not raise an error")
+end
+
+local function testTrueCase()
+	local status, errorMessage = pcall(assertNil, true)
+	assert(status == false, "assertNil(true) should raise an error")
+	assert(
+		errorMessage == "ASSERTION FAILURE: true should be nil",
+		"assertNil(true) should throw with error [[ASSERTION FAILURE: true should be nil]] and not [["
+			.. tostring(errorMessage)
+			.. "]]"
+	)
+end
+
+local function testFalseCase()
+	local status, errorMessage = pcall(assertNil, false)
+	assert(status == false, "assertNil(false) should raise an error")
+	assert(
+		errorMessage == "ASSERTION FAILURE: false should be nil",
+		"assertNil(false) should throw with error [[ASSERTION FAILURE: false should be nil]] and not [["
+			.. tostring(errorMessage)
+			.. "]]"
+	)
+end
+
+local function testZeroCase()
+	local status, errorMessage = pcall(assertNil, 0)
+	assert(status == false, "assertNil(0) should raise an error")
+	assert(
+		errorMessage == "ASSERTION FAILURE: 0 should be nil",
+		"assertNil(0) should throw with error [[ASSERTION FAILURE: 0 should be nil]] and not [["
+			.. tostring(errorMessage)
+			.. "]]"
+	)
+end
+
+local function testAssertNil()
+	testNilCase()
+	testTrueCase()
+	testFalseCase()
+	testZeroCase()
+end
+
+testAssertNil()
+
+print("OK", "assertions", "assertNil")

--- a/Tests/SmokeTests/assertions-library/test-assert-throws.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-throws.lua
@@ -1,0 +1,78 @@
+local assertions = require("assertions")
+local assertThrows = assertions.assertThrows
+
+local function testExpectedErrorIsThrownCase()
+	local expectedErrorMessage = "some error message"
+
+	local function functionThatThrowsTheExpectedError()
+		error(expectedErrorMessage, 0)
+	end
+	local status = pcall(assertThrows, functionThatThrowsTheExpectedError, expectedErrorMessage)
+
+	assert(status == true, "assertThrows should not throw an error when the error message matches the expected message")
+end
+
+local function testNoErrorIsThrownCase()
+	local NOOP_FUNCTION = function() end
+	local status, errorMessage = pcall(assertThrows, NOOP_FUNCTION, "some error message")
+	assert(status == false, "assertThrows should throw an error when the function doesn't throw an error")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Function did not raise an error$") ~= nil,
+		"assertThrows should throw an error message with the proper format"
+	)
+end
+
+local function testTheWrongErrorIsThrownCase()
+	local functionThatThrowsAnUnexpectedError = function()
+		error("unexpected error message", 0)
+	end
+
+	local status, errorMessage = pcall(assertThrows, functionThatThrowsAnUnexpectedError, "some error message")
+	assert(
+		status == false,
+		"assertThrows should throw an error when the error message doesn't match the expected message"
+	)
+	assert(
+		string.match(
+			errorMessage,
+			'^ASSERTION FAILURE: Thrown error "unexpected error message" should be "some error message"$'
+		) ~= nil,
+		"assertThrows should throw an error message with the proper format"
+	)
+end
+
+local function testFunctionReturnsFailureInsteadOfThrowingCase()
+	local functionThatReturnsFailure = function()
+		return nil, "some failure message"
+	end
+	local status, errorMessage = pcall(assertThrows, functionThatReturnsFailure, "unexpected error message")
+	assert(status == false, "assertThrows should throw an error when the function returns nil")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Function did not raise an error") ~= nil,
+		"assertThrows should throw an error message with the proper format"
+	)
+end
+
+local function testFunctionThrowsWithEmptyErrorMessageCase()
+	local functionThatThrowsWithEmptyString = function()
+		error("", 0)
+	end
+	local status, errorMessage = pcall(assertThrows, functionThatThrowsWithEmptyString, "unexpected error message")
+	assert(status == false, "assertThrows should throw an error when the error message is empty")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Thrown error .* should be .*") ~= nil,
+		"assertThrows should throw an error message with the proper format"
+	)
+end
+
+local function testAssertThrows()
+	testExpectedErrorIsThrownCase()
+	testNoErrorIsThrownCase()
+	testTheWrongErrorIsThrownCase()
+	testFunctionReturnsFailureInsteadOfThrowingCase()
+	testFunctionThrowsWithEmptyErrorMessageCase()
+end
+
+testAssertThrows()
+
+print("OK", "assertions", "assertThrows")

--- a/Tests/SmokeTests/assertions-library/test-assert-true.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-true.lua
@@ -1,0 +1,50 @@
+local assertions = require("assertions")
+local assertTrue = assertions.assertTrue
+
+local function testTrueCase()
+	assert(assertTrue(true), "assertTrue(true) should return true and not raise an error")
+end
+
+local function testFalseCase()
+	local status, errorMessage = pcall(assertTrue, false)
+	assert(status == false, "assertTrue(false) should raise an error")
+	assert(
+		errorMessage == "ASSERTION FAILURE: false should be true",
+		"assertTrue(false) should throw with error [[ASSERTION FAILURE: false should be true]] and not [["
+			.. tostring(errorMessage)
+			.. "]]"
+	)
+end
+
+local function testNilCase()
+	local status, errorMessage = pcall(assertTrue, nil)
+	assert(status == false, "assertTrue(nil) should raise an error")
+	assert(
+		errorMessage == "ASSERTION FAILURE: nil should be true",
+		"assertTrue(nil) should throw with error [[ASSERTION FAILURE: nil should be true]] and not [["
+			.. tostring(errorMessage)
+			.. "]]"
+	)
+end
+
+local function testZeroCase()
+	local status, errorMessage = pcall(assertTrue, 0)
+	assert(status == false, "assertTrue(0) should raise an error")
+	assert(
+		errorMessage == "ASSERTION FAILURE: 0 should be true",
+		"assertTrue(0) should throw with error [[ASSERTION FAILURE: 0 should be true]] and not [["
+			.. tostring(errorMessage)
+			.. "]]"
+	)
+end
+
+local function testAssertTrue()
+	testTrueCase()
+	testFalseCase()
+	testNilCase()
+	testZeroCase()
+end
+
+testAssertTrue()
+
+print("OK", "assertions", "assertTrue")

--- a/Tests/SmokeTests/assertions-library/test-export.lua
+++ b/Tests/SmokeTests/assertions-library/test-export.lua
@@ -1,0 +1,38 @@
+local assertions = require("assertions")
+
+local expectedGlobalAssertions = {
+	"assertTrue",
+	"assertFalse",
+	"assertNil",
+	"assertThrows",
+	"assertDoesNotThrow",
+	"assertFailure",
+	"assertCallsFunction",
+	"assertEqualStrings",
+	"assertEqualNumbers",
+	"assertEqualTables",
+	"assertEqualBooleans",
+	"assertEqualPointers",
+	"assertEqualBytes",
+	"assertEquals",
+}
+
+for index, globalAssertionName in ipairs(expectedGlobalAssertions) do
+	local globalAssertionFunction = _G[globalAssertionName]
+	assert(
+		globalAssertionFunction == nil,
+		globalAssertionName .. " should NOT be exported to the global environment before assertions.export was called"
+	)
+end
+
+assertions.export()
+
+for index, globalAssertionName in ipairs(expectedGlobalAssertions) do
+	local globalAssertionFunction = _G[globalAssertionName]
+	assert(
+		globalAssertionFunction == assertions[globalAssertionName],
+		globalAssertionName .. " should be exported to the global environment after assertions.export was called"
+	)
+end
+
+print("OK", "assertions", "export")

--- a/Tests/SmokeTests/test-assertions-library.lua
+++ b/Tests/SmokeTests/test-assertions-library.lua
@@ -1,0 +1,11 @@
+dofile("Tests/SmokeTests/assertions-library/test-assert-equals.lua")
+dofile("Tests/SmokeTests/assertions-library/test-assert-false.lua")
+dofile("Tests/SmokeTests/assertions-library/test-assert-true.lua")
+dofile("Tests/SmokeTests/assertions-library/test-assert-nil.lua")
+dofile("Tests/SmokeTests/assertions-library/test-assert-throws.lua")
+dofile("Tests/SmokeTests/assertions-library/test-assert-does-not-throw.lua")
+dofile("Tests/SmokeTests/assertions-library/test-assert-failure.lua")
+dofile("Tests/SmokeTests/assertions-library/test-assert-calls-function.lua")
+dofile("Tests/SmokeTests/assertions-library/test-export.lua")
+
+print("OK", "The assertions library should be functional")

--- a/Tests/smoke-test.lua
+++ b/Tests/smoke-test.lua
@@ -1,15 +1,20 @@
--- If there's an issue with the native bootstrapping code that initializes the Lua environment, all bets are off
+local assertions = require("assertions")
 local transform = require("transform")
 
 print()
 print("Running basic smoke tests ...")
 print()
 
-local assertions = {
+local testCases = {
 	{
 		actual = arg[0],
 		expected = "Tests/smoke-test.lua",
 		description = "The global arg table should contain the script name at index 0",
+	},
+	{
+		actual = type(assertions),
+		expected = "table",
+		description = "The assertions library should be preloaded",
 	},
 	{
 		actual = type(transform),
@@ -18,10 +23,13 @@ local assertions = {
 	},
 }
 
-for _, assertionInfo in ipairs(assertions) do
+for _, assertionInfo in ipairs(testCases) do
 	assert(assertionInfo.actual == assertionInfo.expected, assertionInfo.description)
 	print("OK", assertionInfo.description)
 end
+
+-- Since there's no import library available at this stage, let's just assume this script always runs from the project root
+dofile("Tests/SmokeTests/test-assertions-library.lua")
 
 print()
 print("Good news, everyone! There's at least a chance that the runtime isn't completely broken - time to celebrate:")

--- a/ninjabuild.lua
+++ b/ninjabuild.lua
@@ -17,6 +17,7 @@ local EvoBuildTarget = {
 	-- Note that ninja doesn't care about path separators and the mingw toolchain supports forward slashes; no \ required
 	luaSources = {
 		"Runtime/evo.lua",
+		"Runtime/Libraries/assertions.lua",
 		"Runtime/Libraries/transform.lua",
 	},
 	cppSources = {


### PR DESCRIPTION
This only relies on the standard ``assert`` function so that everything just works without causing interdependency issues.