### PR TITLE
Fix the order of actual and expected parameters in the assertions library

### DIFF
--- a/Runtime/Libraries/assertions.lua
+++ b/Runtime/Libraries/assertions.lua
@@ -104,7 +104,7 @@ end
 
 local function assertEqualLuastring(firstValue, secondValue)
 	if firstValue ~= secondValue then
-		error("ASSERTION FAILURE: Expected " .. firstValue .. " but got " .. secondValue)
+		error("ASSERTION FAILURE: Expected " .. secondValue .. " but got " .. firstValue)
 	end
 	return true
 end
@@ -113,7 +113,7 @@ local function assertEqualBuffer(firstValue, secondValue)
 	local firstString = ffi_string(firstValue)
 	local secondString = ffi_string(secondValue)
 	if firstString ~= secondString then
-		error("ASSERTION FAILURE: Expected " .. firstString .. " but got " .. secondString)
+		error("ASSERTION FAILURE: Expected " .. secondString .. " but got " .. firstString)
 	end
 	return true
 end
@@ -139,7 +139,7 @@ function assertions.assertEqualNumbers(firstValue, secondValue)
 	if type(firstValue) ~= "number" or type(secondValue) ~= "number" then
 		error("ASSERTION FAILURE: Expected numbers but got " .. type(firstValue) .. " and " .. type(secondValue), 0)
 	elseif firstValue ~= secondValue then
-		error("ASSERTION FAILURE: Expected " .. tostring(firstValue) .. " but got " .. tostring(secondValue), 0)
+		error("ASSERTION FAILURE: Expected " .. tostring(secondValue) .. " but got " .. tostring(firstValue), 0)
 	end
 	return true
 end
@@ -157,12 +157,12 @@ function assertions.assertEqualTables(firstValue, secondValue)
 		table.sort(secondValueKeys)
 
 		if #firstValueKeys ~= #secondValueKeys then
-			error("ASSERTION FAILURE: Expected " .. tostring(firstValue) .. " but got " .. tostring(secondValue), 0)
+			error("ASSERTION FAILURE: Expected " .. tostring(secondValue) .. " but got " .. tostring(firstValue), 0)
 		else
 			for i = 1, #firstValueKeys do
 				if firstValueKeys[i] ~= secondValueKeys[i] then
 					error(
-						"ASSERTION FAILURE: Expected " .. tostring(firstValue) .. " but got " .. tostring(secondValue),
+						"ASSERTION FAILURE: Expected " .. tostring(secondValue) .. " but got " .. tostring(firstValue),
 						0
 					)
 				end
@@ -178,7 +178,7 @@ function assertions.assertEqualBooleans(firstValue, secondValue)
 	end
 
 	if firstValue ~= secondValue then
-		error("ASSERTION FAILURE: Expected " .. tostring(firstValue) .. " but got " .. tostring(secondValue), 0)
+		error("ASSERTION FAILURE: Expected " .. tostring(secondValue) .. " but got " .. tostring(firstValue), 0)
 	end
 
 	return true
@@ -189,7 +189,7 @@ function assertions.assertEqualPointers(firstValue, secondValue)
 		if firstValue == secondValue then
 			return true
 		else
-			error("ASSERTION FAILURE: Expected " .. tostring(firstValue) .. " but got " .. tostring(secondValue), 0)
+			error("ASSERTION FAILURE: Expected " .. tostring(secondValue) .. " but got " .. tostring(firstValue), 0)
 		end
 	else
 		error(
@@ -216,9 +216,9 @@ function assertions.assertEqualBytes(firstValue, secondValue)
 	if ffi_string(firstValue, firstLength) ~= ffi_string(secondValue, secondLength) then
 		error(
 			"ASSERTION FAILURE: Expected "
-				.. tostring(firstValue, firstLength)
+				.. tostring(secondValue, secondLength)
 				.. " but got "
-				.. tostring(secondValue, secondLength),
+				.. tostring(firstValue, firstLength),
 			0
 		)
 	end
@@ -268,10 +268,10 @@ function assertions.assertEquals(firstValue, secondValue)
 
 	local errorMessage = format(
 		"ASSERTION FAILURE: Expected %s (a %s value) but got %s (a %s value)",
-		firstValue,
-		firstType,
 		secondValue,
-		secondType
+		secondType,
+		firstValue,
+		firstType
 	)
 	error(errorMessage, 0)
 end

--- a/Tests/SmokeTests/assertions-library/test-assert-equal-booleans.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equal-booleans.lua
@@ -20,8 +20,8 @@ local function testTrueFalseCase()
 	local success, errorMessage = pcall(assertEqualBooleans, true, false)
 	assert(not success, "assertEqualBooleans(true, false) should return nil")
 	assert(
-		errorMessage == "ASSERTION FAILURE: Expected true but got false",
-		"assertEqualBooleans(true, false) should throw"
+		errorMessage == "ASSERTION FAILURE: Expected false but got true",
+		"assertEqualBooleans(true, false) should throw with the expected error message"
 	)
 end
 
@@ -29,8 +29,8 @@ local function testFalseTrueCase()
 	local success, errorMessage = pcall(assertEqualBooleans, false, true)
 	assert(not success, "assertEqualBooleans(false, true) should return nil")
 	assert(
-		errorMessage == "ASSERTION FAILURE: Expected false but got true",
-		"assertEqualBooleans(false, true) should throw"
+		errorMessage == "ASSERTION FAILURE: Expected true but got false",
+		"assertEqualBooleans(false, true) should throw with the expected error message"
 	)
 end
 

--- a/Tests/SmokeTests/assertions-library/test-assert-equal-bytes.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equal-bytes.lua
@@ -37,7 +37,7 @@ local function testNonEqualPointersCase()
 	assert(
 		string.match(
 			errorMessage,
-			"^ASSERTION FAILURE: Expected " .. tostring(point1) .. " but got " .. tostring(point3)
+			"^ASSERTION FAILURE: Expected " .. tostring(point3) .. " but got " .. tostring(point1)
 		),
 		errorMessage
 	)

--- a/Tests/SmokeTests/assertions-library/test-assert-equal-numbers.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equal-numbers.lua
@@ -11,7 +11,7 @@ local function testEqualNumbersCase()
 	local success, errorMessage = pcall(assertEqualNumbers, num1, num3)
 	assert(success == false, "assertEqualNumbers(num1, num3) should raise an error")
 	assert(
-		string.match(errorMessage, "^ASSERTION FAILURE: Expected 1 but got 2$"),
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected 2 but got 1$"),
 		"assertEqualNumbers(num1, num3) should raise an error with the correct message"
 	)
 end
@@ -20,7 +20,7 @@ local function testDifferentNumbersCase()
 	local success, errorMessage = pcall(assertEqualNumbers, num1, num4)
 	assert(success == false, "assertEqualNumbers(num1, num4) should raise an error")
 	assert(
-		string.match(errorMessage, "^ASSERTION FAILURE: Expected 1 but got 0$"),
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected 0 but got 1$"),
 		"assertEqualNumbers(num1, num4) should raise an error with the correct message"
 	)
 end
@@ -38,7 +38,7 @@ local function testAlmostEqualNumbersCase()
 	local success, errorMessage = pcall(assertEqualNumbers, num1, num2 + 0.1)
 	assert(success == false, "assertEqualNumbers(num1, num2 + 0.1) should raise an error")
 	assert(
-		string.match(errorMessage, "^ASSERTION FAILURE: Expected 1 but got 1.1$"),
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected 1.1 but got 1$"),
 		"assertEqualNumbers(num1, num2 + 0.1) should raise an error with the correct message"
 	)
 end

--- a/Tests/SmokeTests/assertions-library/test-assert-equal-pointers.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equal-pointers.lua
@@ -27,7 +27,7 @@ local function testClonedStructsCase()
 	assert(
 		string.match(
 			errorMessage,
-			"^ASSERTION FAILURE: Expected " .. tostring(point1) .. " but got " .. tostring(point2)
+			"^ASSERTION FAILURE: Expected " .. tostring(point2) .. " but got " .. tostring(point1)
 		),
 		errorMessage
 	)
@@ -42,7 +42,7 @@ local function testNonEqualPointersCase()
 	assert(
 		string.match(
 			errorMessage,
-			"^ASSERTION FAILURE: Expected " .. tostring(point1) .. " but got " .. tostring(point3)
+			"^ASSERTION FAILURE: Expected " .. tostring(point3) .. " but got " .. tostring(point1)
 		),
 		errorMessage
 	)

--- a/Tests/SmokeTests/assertions-library/test-assert-equals.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equals.lua
@@ -35,7 +35,7 @@ local function testDistinctStringsCase()
 	local status, errorMessage = pcall(assertEquals, "hello", "world")
 	assert(status == false, "assertEquals should throw an error when the values don't match")
 	assert(
-		string.match(errorMessage, "ASSERTION FAILURE: Expected hello but got world") ~= nil,
+		string.match(errorMessage, "ASSERTION FAILURE: Expected world but got hello") ~= nil,
 		"assertEquals should throw an error message with the proper format"
 	)
 end


### PR DESCRIPTION
It seems counter-intuitive to list expected before actual, and this is also different from what the legacy assertions used to do. For consistency's sake, all assertions should likely use the same format, if only so that the legacy code can easily be ported here.