### PR TITLE
Add support for function types to the assertions library

### DIFF
--- a/Runtime/Libraries/assertions.lua
+++ b/Runtime/Libraries/assertions.lua
@@ -226,6 +226,21 @@ function assertions.assertEqualBytes(firstValue, secondValue)
 	return true
 end
 
+function assertions.assertEqualFunctions(firstValue, secondValue)
+	if type(firstValue) ~= "function" or type(secondValue) ~= "function" then
+		error(
+			"ASSERTION FAILURE: Expected two function values, got " .. type(firstValue) .. " and " .. type(secondValue),
+			0
+		)
+	end
+
+	if firstValue ~= secondValue then
+		error("ASSERTION FAILURE: Expected " .. tostring(secondValue) .. " but got " .. tostring(firstValue), 0)
+	end
+
+	return true
+end
+
 function assertions.assertEquals(firstValue, secondValue)
 	local firstType = type(firstValue)
 	local secondType = type(secondValue)
@@ -237,6 +252,7 @@ function assertions.assertEquals(firstValue, secondValue)
 	local areBothValuesTables = (firstType == "table" and secondType == "table")
 	local areBothValuesNil = (firstType == "nil" and secondType == "nil")
 	local areBothValuesStructs = (firstType == "cdata" and secondType == "cdata")
+	local areBothValuesFunctions = (firstType == "function" and secondType == "function")
 
 	if areBothValuesNil then
 		return true
@@ -264,6 +280,10 @@ function assertions.assertEquals(firstValue, secondValue)
 
 	if areBothValuesStructs then
 		return assertions.assertEqualPointers(firstValue, secondValue)
+	end
+
+	if areBothValuesFunctions then
+		return assertions.assertEqualFunctions(firstValue, secondValue)
 	end
 
 	local errorMessage = format(

--- a/Tests/SmokeTests/assertions-library/test-assert-equal-functions.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equal-functions.lua
@@ -1,0 +1,68 @@
+local assertions = require("assertions")
+local assertEqualFunctions = assertions.assertEqualFunctions
+
+local function testEqualFunctionsCase()
+	local success, returnValue = pcall(assertEqualFunctions, print, print)
+	assert(success, "assertEqualFunctions(print, print) should not throw")
+	assert(returnValue == true, "assertEqualFunctions(print, print) should return true")
+end
+
+local function testDifferentFunctionsCase()
+	local success, errorMessage = pcall(assertEqualFunctions, print, tostring)
+	local expectedErrorMessage = "^ASSERTION FAILURE: Expected "
+		.. tostring(tostring)
+		.. " but got "
+		.. tostring(print)
+		.. "$"
+
+	assert(not success, "assertEqualFunctions(print, tostring) should throw")
+	assert(
+		string.match(errorMessage, expectedErrorMessage),
+		"assertEqualFunctions(print, tostring) should throw the expected error"
+	)
+end
+
+local function testFirstArgumentNotFunctionCase()
+	local success, errorMessage = pcall(assertEqualFunctions, 42, tostring)
+	local expectedErrorMessage = "^ASSERTION FAILURE: Expected two function values, got number and function$"
+
+	assert(not success, "assertEqualFunctions(print, 42) should throw")
+	assert(
+		string.match(errorMessage, expectedErrorMessage),
+		"assertEqualFunctions(print, 42) should throw the expected error"
+	)
+end
+
+local function testSecondArgumentNotFunctionCase()
+	local success, errorMessage = pcall(assertEqualFunctions, print, 42)
+	local expectedErrorMessage = "^ASSERTION FAILURE: Expected two function values, got function and number$"
+
+	assert(not success, "assertEqualFunctions(42, tostring) should throw")
+	assert(
+		string.match(errorMessage, expectedErrorMessage),
+		"assertEqualFunctions(42, tostring) should throw the expected error"
+	)
+end
+
+local function testBothArgumentsNotFunctionCase()
+	local success, errorMessage = pcall(assertEqualFunctions, 42, 42)
+	local expectedErrorMessage = "^ASSERTION FAILURE: Expected two function values, got number and number$"
+
+	assert(not success, "assertEqualFunctions(42, 42) should throw")
+	assert(
+		string.match(errorMessage, expectedErrorMessage),
+		"assertEqualFunctions(42, 42) should throw the expected error"
+	)
+end
+
+local function testassertEqualFunctions()
+	testEqualFunctionsCase()
+	testDifferentFunctionsCase()
+	testFirstArgumentNotFunctionCase()
+	testSecondArgumentNotFunctionCase()
+	testBothArgumentsNotFunctionCase()
+end
+
+testassertEqualFunctions()
+
+print("OK", "assertions", "assertEqualFunctions")

--- a/Tests/SmokeTests/assertions-library/test-assert-equals.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equals.lua
@@ -11,6 +11,7 @@ dofile("Tests/SmokeTests/assertions-library/test-assert-equal-strings.lua")
 dofile("Tests/SmokeTests/assertions-library/test-assert-equal-tables.lua")
 dofile("Tests/SmokeTests/assertions-library/test-assert-equal-pointers.lua")
 dofile("Tests/SmokeTests/assertions-library/test-assert-equal-bytes.lua")
+dofile("Tests/SmokeTests/assertions-library/test-assert-equal-functions.lua")
 
 local function testEqualNumbersCase()
 	local status = pcall(assertEquals, 1, 1)
@@ -107,6 +108,10 @@ local function testDistinctStructsCase()
 	)
 end
 
+local function testBuiltinFunctionsCase()
+	assertEquals(print, print)
+end
+
 local function testAssertEquals()
 	testEqualNumbersCase()
 	testDistinctNumbersCase()
@@ -126,6 +131,8 @@ local function testAssertEquals()
 	testDistinctStringBuffersCase()
 
 	testDistinctStructsCase()
+
+	testBuiltinFunctionsCase()
 end
 
 testAssertEquals()


### PR DESCRIPTION
Looks like I forgot to include this, but it's useful for the alias smoke tests.