### PR TITLE
Add human-readable table diffs in case of assertEqualTables failures

### DIFF
--- a/Runtime/Extensions/stringx.lua
+++ b/Runtime/Extensions/stringx.lua
@@ -1,0 +1,53 @@
+local transform = require("transform")
+local transform_green = transform.green
+local transform_red = transform.red
+
+local validation = require("validation")
+local validateString = validation.validateString
+
+local ipairs = ipairs
+local table_concat = table.concat
+local table_insert = table.insert
+
+local TOKENS_SEPARATED_BY_NEWLINES_PATTERN = "[^\n]+"
+local SKIP_AFTER_FIRST_DIFFERENCE = true -- The changesets will get out of whack because this algorithm is too simple otherwise
+
+local function diffByLines(before, after)
+	validateString(before, "before")
+	validateString(after, "after")
+
+	local lines = {}
+
+	local beforeTokens = {}
+	local afterTokens = {}
+	for line in before:gmatch(TOKENS_SEPARATED_BY_NEWLINES_PATTERN) do
+		table_insert(beforeTokens, line)
+	end
+
+	for line in after:gmatch(TOKENS_SEPARATED_BY_NEWLINES_PATTERN) do
+		table_insert(afterTokens, line)
+	end
+
+	for lineNumber, lineBefore in ipairs(beforeTokens) do
+		local lineAfter = afterTokens[lineNumber]
+		if lineBefore ~= lineAfter then
+			table_insert(lines, transform_red("- " .. lineBefore))
+			table_insert(lines, transform_green("+ " .. lineAfter))
+
+			-- If we continue here, some lines might get eaten. There's not much of a point, either...
+			local hasMoreLines = (lineNumber < #beforeTokens)
+			if SKIP_AFTER_FIRST_DIFFERENCE and hasMoreLines then
+				table_insert(lines, "  ... (additional lines skipped)")
+				return table_concat(lines, "\n")
+			end
+		else
+			table_insert(lines, "  " .. lineBefore)
+		end
+	end
+
+	return table_concat(lines, "\n")
+end
+
+function string.diff(firstValue, secondValue)
+	return diffByLines(firstValue, secondValue)
+end

--- a/Runtime/Libraries/assertions.lua
+++ b/Runtime/Libraries/assertions.lua
@@ -144,6 +144,18 @@ function assertions.assertEqualNumbers(firstValue, secondValue)
 	return true
 end
 
+local diff = string.diff
+local dump = debug.dump
+
+local diffOptions = {
+	silent = true,
+	separator = "\t",
+}
+
+local function computeDiffString(firstValue, secondValue)
+	return diff(dump(firstValue, diffOptions), dump(secondValue, diffOptions))
+end
+
 function assertions.assertEqualTables(firstValue, secondValue)
 	if type(firstValue) == "table" then
 		local firstValueKeys, secondValueKeys = {}, {}
@@ -157,12 +169,25 @@ function assertions.assertEqualTables(firstValue, secondValue)
 		table.sort(secondValueKeys)
 
 		if #firstValueKeys ~= #secondValueKeys then
-			error("ASSERTION FAILURE: Expected " .. tostring(secondValue) .. " but got " .. tostring(firstValue), 0)
+			error(
+				"ASSERTION FAILURE: Expected "
+					.. tostring(secondValue)
+					.. " but got "
+					.. tostring(firstValue)
+					.. "\n"
+					.. computeDiffString(firstValue, secondValue),
+				0
+			)
 		else
 			for i = 1, #firstValueKeys do
 				if firstValueKeys[i] ~= secondValueKeys[i] then
 					error(
-						"ASSERTION FAILURE: Expected " .. tostring(secondValue) .. " but got " .. tostring(firstValue),
+						"ASSERTION FAILURE: Expected "
+							.. tostring(secondValue)
+							.. " but got "
+							.. tostring(firstValue)
+							.. "\n"
+							.. computeDiffString(firstValue, secondValue),
 						0
 					)
 				end

--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -11,6 +11,7 @@ end
 
 function evo.loadNonstandardExtensions()
 	require("debugx")
+	require("stringx")
 end
 
 return evo

--- a/Tests/SmokeTests/test-string-extensions.lua
+++ b/Tests/SmokeTests/test-string-extensions.lua
@@ -1,0 +1,76 @@
+local transform = require("transform")
+local diff = string.diff
+
+local function testNilValuesCase()
+	local success, errorMessage = pcall(diff, nil, nil)
+	assertFalse(success)
+	assertEquals(errorMessage, "Expected argument before to be a string value, but received a nil value instead")
+end
+
+local function testEmptyStringsCase()
+	local firstString = ""
+	local secondString = ""
+	local expectedDiff = ""
+
+	local actualDiff = diff(firstString, secondString)
+	assertEquals(actualDiff, expectedDiff)
+end
+
+local function testSingleLinesWithoutChangesCase()
+	local firstString = "This line was not changed."
+	local secondString = "This line was not changed."
+	local expectedDiff = "  This line was not changed."
+
+	local actualDiff = diff(firstString, secondString)
+	assertEquals(actualDiff, expectedDiff)
+end
+
+local function testSingleLinesWithChangesCase()
+	local firstString = "This line will be removed."
+	local secondString = "This line will be added."
+	local expectedDiff = transform.red("- This line will be removed.")
+		.. "\n"
+		.. transform.green("+ This line will be added.")
+
+	local actualDiff = diff(firstString, secondString)
+	assertEquals(actualDiff, expectedDiff)
+end
+
+local function testMultiLinesWithoutChangesCase()
+	local firstString = "This line will be unchanged.\nThis line will be unchanged.\nThis line will be unchanged."
+	local secondString = "This line will be unchanged.\nThis line will be unchanged.\nThis line will be unchanged."
+	local expectedDiff = "  This line will be unchanged."
+		.. "\n"
+		.. "  This line will be unchanged."
+		.. "\n"
+		.. "  This line will be unchanged."
+
+	local actualDiff = diff(firstString, secondString)
+	assertEquals(actualDiff, expectedDiff)
+end
+
+local function testMultiLinesWithChangesCase()
+	local firstString = "This line will be removed.\nThis line will be unchanged."
+	local secondString = "This line will be added.\nThis line will be unchanged."
+	local expectedDiff = transform.red("- This line will be removed.")
+		.. "\n"
+		.. transform.green("+ This line will be added.")
+		.. "\n"
+		.. "  ... (additional lines skipped)"
+
+	local actualDiff = diff(firstString, secondString)
+	assertEquals(actualDiff, expectedDiff)
+end
+
+local function testStringDiff()
+	testNilValuesCase()
+	testEmptyStringsCase()
+	testSingleLinesWithoutChangesCase()
+	testSingleLinesWithChangesCase()
+	testMultiLinesWithoutChangesCase()
+	testMultiLinesWithChangesCase()
+end
+
+testStringDiff()
+
+print("OK", "string", "diff")

--- a/Tests/smoke-test.lua
+++ b/Tests/smoke-test.lua
@@ -52,6 +52,7 @@ dofile("Tests/SmokeTests/test-inspect-library.lua")
 dofile("Tests/SmokeTests/test-validation-library.lua")
 
 dofile("Tests/SmokeTests/test-debug-extensions.lua")
+dofile("Tests/SmokeTests/test-string-extensions.lua")
 
 print()
 print("Good news, everyone! There's at least a chance that the runtime isn't completely broken - time to celebrate:")

--- a/ninjabuild.lua
+++ b/ninjabuild.lua
@@ -19,6 +19,7 @@ local EvoBuildTarget = {
 		"deps/kikito/inspect.lua/inspect.lua",
 		"Runtime/evo.lua",
 		"Runtime/Extensions/debugx.lua",
+		"Runtime/Extensions/stringx.lua",
 		"Runtime/Libraries/assertions.lua",
 		"Runtime/Libraries/transform.lua",
 		"Runtime/Libraries/validation.lua",


### PR DESCRIPTION
This is a bit of a stopgap measure and has several limitations:

* Diffs only indicate the very first changed line and are cut off after that
* The output may not always make it clear that the line has changed if a new one was inserted before
* Extended diffs are super buggy, and therefore hidden behind an invisible feature flag (turned off by default)

A much more powerful (and complex) solution would be required for better diffs, but that isn't really needed right now.