### PR TITLE
Add some missing initialization code for certain libuv APIs

### DIFF
--- a/Runtime/main.cpp
+++ b/Runtime/main.cpp
@@ -11,6 +11,7 @@ int main(int argc, char* argv[]) {
 	LuaVirtualMachine* luaVM = new LuaVirtualMachine();
 
 	luaVM->SetGlobalArgs(argc, argv);
+	argv = uv_setup_args(argc, argv); // Required on Linux (see https://github.com/libuv/libuv/issues/2845)
 
 	// luv sets up its metatables when initialized; deferring this may break some internals (not sure why)
 	luaVM->PreloadPackage("uv", luaopen_luv);

--- a/Tests/BDD/uv-library.spec.lua
+++ b/Tests/BDD/uv-library.spec.lua
@@ -1,0 +1,11 @@
+local uv = require("uv")
+
+describe("uv", function()
+	describe("get_process_title", function()
+		it("should not fail with UV_ENOBUFS due to missing uv_setup_args", function()
+			local processTitle, libuvErrorMessage = uv.get_process_title()
+			assertEquals(type(processTitle), "string") -- Will be nil in case of failure
+			assertNil(libuvErrorMessage) -- Will be ENOBUFFS if the argv memory wasn't set up
+		end)
+	end)
+end)

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -7,6 +7,7 @@ local format = string.format
 -- All paths are relative to the project root, since that's where the CI run will start
 local specFiles = {
 	"Tests/BDD/placeholder.spec.lua",
+	"Tests/BDD/uv-library.spec.lua",
 }
 
 local function runBasicTests()


### PR DESCRIPTION
I've put off adding this since I wanted to set up the testing framework first, but it's a trivial fix and needn't be delayed.