### PR TITLE
Remove the now-obsolete placeholder test

### DIFF
--- a/Tests/BDD/placeholder.spec.lua
+++ b/Tests/BDD/placeholder.spec.lua
@@ -1,5 +1,0 @@
-describe("placeholder test", function()
-	it("should do nothing", function()
-		-- Should be removed later
-	end)
-end)

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -6,7 +6,6 @@ local format = string.format
 
 -- All paths are relative to the project root, since that's where the CI run will start
 local specFiles = {
-	"Tests/BDD/placeholder.spec.lua",
 	"Tests/BDD/uv-library.spec.lua",
 }
 


### PR DESCRIPTION
It was only needed temporarily, to get the unit tests into the CI runs.