### PR TITLE
Fix an error in the reporting of detailed test runs

### DIFF
--- a/Runtime/Libraries/bdd.lua
+++ b/Runtime/Libraries/bdd.lua
@@ -133,7 +133,7 @@ function bdd.executeSpecFile(specFile)
 		end
 	end
 
-	if bdd.isMinimalReportingMode() and not success then
+	if not success and (bdd.isMinimalReportingMode() or bdd.isDetailedReportingMode()) then
 		-- Relying on just the exit code may be a bit too minimal, so let's fail loudly here
 		error(errorMessage, 0)
 	end

--- a/Tests/SmokeTests/bdd-library/test-start-runner.lua
+++ b/Tests/SmokeTests/bdd-library/test-start-runner.lua
@@ -247,6 +247,23 @@ end
 local function testDetailedFailingTestCase()
 	bdd.setDetailedReportMode()
 
+	local function runFailingTest()
+		startTestRunner({ "Tests/Fixtures/failing.spec.lua" })
+	end
+
+	assertThrows(runFailingTest, "meep")
+
+	local errorDetails = bdd.getErrorDetails()
+	assertEquals(#errorDetails, 1)
+
+	assertEquals(errorDetails[1].specFile, "Tests/Fixtures/failing.spec.lua")
+	assertEquals(errorDetails[1].message, "meep")
+	assertEquals(type(errorDetails[1].stackTrace), "string")
+end
+
+local function testDetailedFailingSectionsCase()
+	bdd.setDetailedReportMode()
+
 	local numFailingTests = startTestRunner({ "Tests/Fixtures/failing-sections.spec.lua" })
 	assertEquals(numFailingTests, 3)
 	local icon = brightRed("✗")
@@ -288,6 +305,7 @@ local function testStartTestRunner()
 	testMinimalEmptyTestCase()
 	testMinimalPassingTestCase()
 	testMinimalFailingTestCase()
+	testDetailedFailingSectionsCase()
 	testBasicEmptyTestCase()
 	testBasicEmptyTestCases()
 	testBasicPassingTestCase()


### PR DESCRIPTION
When the spec file itself contains an error outside of any BDD section, such as trying to require a module that doesn't exist at the top level, the error will be eaten by the `xpcall` and not reported.

The error is still recognized and added to the error details table, but since there's no sections to report as failing it will report the remaining sections as passing, leading to strange oddities like "all tests are passing" being displayed and then dumping the error details on the user.

The easiest way to fix this is to just fail loudly, as there's no point in continuing with evaluating sections if the error is critical. I'm assuming here that an error that's not a failed assertion is critical, of course...