### PR TITLE
Fix a stack misalignment error on Mac OS

### DIFF
--- a/Runtime/LuaVirtualMachine.cpp
+++ b/Runtime/LuaVirtualMachine.cpp
@@ -21,6 +21,8 @@ int onLuaError(lua_State* m_luaState) {
 }
 
 LuaVirtualMachine::LuaVirtualMachine() {
+	m_relativeStackOffset = 0;
+
 	// Standard Lua module convention: Return a single table with the module's exports
 	m_numExpectedArgsFromLuaMain = 1;
 


### PR DESCRIPTION
It seems that I forgot to initialize the member, which went unnoticed because it's set to 0 on Windows and WSL.

On Mac OS, however, this triggers the CheckStack error and even failed the CI (but only when building webview... which is odd).

"Error" is a bit of a misnomer here because the stack isn't actually misaligned - the error just says that it is, which is the actual error...