### PR TITLE
 Add a default NuGet package source to the WebView2 download script

### DIFF
--- a/deps/fetch-mswebview2.sh
+++ b/deps/fetch-mswebview2.sh
@@ -1,5 +1,7 @@
 # Should probably be the same that webview uses
 MSWEBVIEW_VERSION=1.0.1150.38
+# If nuget isn't installed, it doesn't seem to use the default source on first startup
+DEFAULT_NUGET_SOURCE=https://api.nuget.org/v3/index.json
 
 echo "Fetching NuGet command line"
 wget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
@@ -7,7 +9,7 @@ wget https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
 echo "Fetching WebView2 $MSWEBVIEW_VERSION"
 
 echo "Installing WebView2 headers"
-./nuget install Microsoft.Web.Webview2 -Version $MSWEBVIEW_VERSION -OutputDirectory ninjabuild-windows
+./nuget install Microsoft.Web.Webview2 -Version $MSWEBVIEW_VERSION -Source $DEFAULT_NUGET_SOURCE -OutputDirectory ninjabuild-windows
 cp $(find ninjabuild-windows/Microsoft.Web.WebView* -name "WebView2.h") ninjabuild-windows
 
 echo "Cleaning up..."


### PR DESCRIPTION
When NuGet is first run on a fresh system, there might not be a local package config to fall back on. For some reason the default source appears to not be used in this case unless explicitly specified.

This problem could potentially be very confusing, so let's just forcibly set the package source (even if that may need updating in the future) to make sure it always works on the first try.