### PR TITLE
Add some package.path setup code to the build script

### DIFF
--- a/ninjabuild.lua
+++ b/ninjabuild.lua
@@ -1,3 +1,6 @@
+-- The default path settings may not be sufficient to find the build tools
+package.path = package.path .. ";./?.lua"
+
 -- CAUTION: This script MUST run as-is in stock LuaJIT, so that the runtime can be bootstrapped from source
 -- That means you can only use standard LuaJIT functionality here, or the few dedicated modules designed to be portable
 local ffi = require("ffi")


### PR DESCRIPTION
The path seems to be set correctly in the CI, as well as on my system. But when trying out a "fresh" MSYS2 install on my laptop I noticed LUA_PATH wasn't set - presumably because I haven't installed Lua for Windows or anything else.

I suppose it could be set in the shell scripts directly, but the code should be portable and so this seems a bit easier to manage.