### PR TITLE
Create a new C_Runtime namespace for the command line interface

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -37,4 +37,6 @@ globals = {
 	"printf",
 	"format",
 
+	-- API namespaces
+	"C_Runtime",
 }

--- a/Runtime/API/C_Runtime.lua
+++ b/Runtime/API/C_Runtime.lua
@@ -1,0 +1,78 @@
+local assertions = require("assertions")
+local bdd = require("bdd")
+local transform = require("transform")
+local validation = require("validation")
+
+-- This namespace is created in C++ land, so just assume it exists here
+local C_Runtime = _G.C_Runtime
+
+function C_Runtime.RunBasicTests(specFiles)
+	validation.validateTable(specFiles, "specFiles")
+
+	assertions.export() -- Should probably remove this after global aliases are set up by the runtime
+
+	bdd.setBasicReportMode()
+	local numFailedTests = bdd.startTestRunner(specFiles)
+
+	print(bdd.getReport())
+
+	local errorDetails = bdd.getErrorDetails()
+	for index, errorInfo in ipairs(errorDetails) do
+		print(format("(Error #%d) in %s", index, transform.bold(errorInfo.specFile)))
+		print(transform.brightRed(errorInfo.stackTrace))
+		print()
+	end
+
+	return numFailedTests
+end
+
+function C_Runtime.RunMinimalTests(specFiles)
+	validation.validateTable(specFiles, "specFiles")
+
+	assertions.export() -- Should probably remove this after global aliases are set up by the runtime
+
+	bdd.setMinimalReportMode()
+	local numFailedTests = bdd.startTestRunner(specFiles)
+
+	print(bdd.getReport())
+
+	local errorDetails = bdd.getErrorDetails()
+	for index, errorInfo in ipairs(errorDetails) do
+		print(format("(Error #%d) in %s", index, transform.bold(errorInfo.specFile)))
+		print(transform.brightRed(errorInfo.stackTrace))
+		print()
+	end
+
+	return numFailedTests
+end
+
+function C_Runtime.RunDetailedTests(specFiles)
+	validation.validateTable(specFiles, "specFiles")
+
+	assertions.export() -- Should probably remove this after global aliases are set up by the runtime
+
+	bdd.setDetailedReportMode()
+	local numFailedTests = bdd.startTestRunner(specFiles)
+
+	print(bdd.getReport())
+
+	local errorDetails = bdd.getErrorDetails()
+	for index, errorInfo in ipairs(errorDetails) do
+		print(format("(Error #%d) in %s", index, transform.bold(errorInfo.specFile)))
+		print(transform.brightRed(errorInfo.stackTrace))
+		print()
+	end
+
+	return numFailedTests
+end
+
+function C_Runtime.EvaluateString(luaCode)
+	validation.validateString(luaCode, "luaCode")
+	return load(luaCode)()
+end
+
+function C_Runtime.PrintVersionString()
+	print(_G.EVO_VERSION)
+end
+
+return C_Runtime

--- a/Runtime/LuaVirtualMachine.cpp
+++ b/Runtime/LuaVirtualMachine.cpp
@@ -124,6 +124,11 @@ void LuaVirtualMachine::CreateGlobalNamespace(std::string name) {
 	lua_setglobal(m_luaState, name.c_str());
 }
 
+void LuaVirtualMachine::AssignGlobalVariable(std::string key, std::string value) {
+	lua_pushstring(m_luaState, value.c_str());
+	lua_setglobal(m_luaState, key.c_str());
+}
+
 bool LuaVirtualMachine::CheckStack() {
 	// The most basic of checks, to make sure all symmetrical PUSH/POP operations are in alignment...
 	if(m_relativeStackOffset != 0) {

--- a/Runtime/LuaVirtualMachine.cpp
+++ b/Runtime/LuaVirtualMachine.cpp
@@ -119,6 +119,11 @@ void LuaVirtualMachine::BindStaticLibraryExports(std::string fieldName, void* st
 	lua_setfield(m_luaState, -2, fieldName.c_str());
 }
 
+void LuaVirtualMachine::CreateGlobalNamespace(std::string name) {
+	lua_newtable(m_luaState);
+	lua_setglobal(m_luaState, name.c_str());
+}
+
 bool LuaVirtualMachine::CheckStack() {
 	// The most basic of checks, to make sure all symmetrical PUSH/POP operations are in alignment...
 	if(m_relativeStackOffset != 0) {

--- a/Runtime/LuaVirtualMachine.hpp
+++ b/Runtime/LuaVirtualMachine.hpp
@@ -18,6 +18,7 @@ class LuaVirtualMachine {
 		bool RunCompiledChunk();
 		bool SetGlobalArgs(int argc, char* argv[]);
 		void BindStaticLibraryExports(std::string fieldName, void* staticExportsTable);
+		void CreateGlobalNamespace(std::string name);
 		bool CheckStack();
 
 	private:

--- a/Runtime/LuaVirtualMachine.hpp
+++ b/Runtime/LuaVirtualMachine.hpp
@@ -19,6 +19,7 @@ class LuaVirtualMachine {
 		bool SetGlobalArgs(int argc, char* argv[]);
 		void BindStaticLibraryExports(std::string fieldName, void* staticExportsTable);
 		void CreateGlobalNamespace(std::string name);
+		void AssignGlobalVariable(std::string key, std::string value);
 		bool CheckStack();
 
 	private:

--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -9,6 +9,7 @@ function evo.run()
 	evo.loadNonstandardExtensions()
 	evo.initializeStaticLibraryExports()
 	evo.registerGlobalAliases()
+	evo.initializeGlobalNamespaces()
 
 	print("Hello from evo.lua!")
 
@@ -45,6 +46,10 @@ function evo.registerGlobalAliases()
 	_G.it = bdd.it
 
 	_G.printf = evo.printf
+end
+
+function evo.initializeGlobalNamespaces()
+	require("C_Runtime")
 end
 
 function evo.printf(...)

--- a/Runtime/main.cpp
+++ b/Runtime/main.cpp
@@ -22,6 +22,8 @@ int main(int argc, char* argv[]) {
 
 	// Some namespaces cannot be created from Lua because they store info only available in C++ land (like #defines)
 	luaVM->CreateGlobalNamespace("C_Runtime");
+	luaVM->AssignGlobalVariable("EVO_VERSION", "" EVO_VERSION "");
+
 	std::string mainChunk = "local evo = require('evo'); return evo.run()";
 	std::string chunkName = "=(Lua entry point, at " FROM_HERE ")";
 

--- a/Runtime/main.cpp
+++ b/Runtime/main.cpp
@@ -20,6 +20,8 @@ int main(int argc, char* argv[]) {
 	// The embedded libraries are statically linked in, so we require some glue code to access them via FFI
 	luaVM->BindStaticLibraryExports("webview", webview_ffi::getExportsTable());
 
+	// Some namespaces cannot be created from Lua because they store info only available in C++ land (like #defines)
+	luaVM->CreateGlobalNamespace("C_Runtime");
 	std::string mainChunk = "local evo = require('evo'); return evo.run()";
 	std::string chunkName = "=(Lua entry point, at " FROM_HERE ")";
 

--- a/Tests/BDD/globals.spec.lua
+++ b/Tests/BDD/globals.spec.lua
@@ -29,4 +29,14 @@ describe("_G", function()
 		end)
 	end
 
+	it("should export important defines from the native entry point", function()
+		local runtimeVersionDefinedAtBuildTime = _G.EVO_VERSION
+		-- Technically git describe adds more information in between releases, but it's still "semver-like" enough
+		assertEquals(type(runtimeVersionDefinedAtBuildTime), "string")
+
+		local expectedVersionStringPattern = "(v%d+%.%d+%.%d+.*)" --vMAJOR.MINOR.PATCH-optionalGitDescribeSuffix
+		local versionString = string.match(runtimeVersionDefinedAtBuildTime, expectedVersionStringPattern)
+
+		assertEquals(type(versionString), "string")
+	end)
 end)

--- a/Tests/BDD/globals.spec.lua
+++ b/Tests/BDD/globals.spec.lua
@@ -10,11 +10,23 @@ local globalAliases = {
 	["printf"] = evo.printf,
 }
 
-describe("globals", function()
+local globalNamespaces = {
+	["C_Runtime"] = C_Runtime,
+}
+
+describe("_G", function()
 	for globalName, target in pairs(globalAliases) do
 		it("should export global alias " .. globalName, function()
 			local alias = _G[globalName]
 			assertEquals(alias, target)
 		end)
 	end
+
+	for globalName, target in pairs(globalNamespaces) do
+		it("should export global namespace " .. globalName, function()
+			local alias = _G[globalName]
+			assertEquals(alias, target)
+		end)
+	end
+
 end)

--- a/Tests/BDD/runtime-namespace.spec.lua
+++ b/Tests/BDD/runtime-namespace.spec.lua
@@ -1,0 +1,41 @@
+describe("C_Runtime", function()
+	-- Ideally there should be some high-level snapshot tests, but more plumbing is needed
+	-- Not great, but for the time being this will have to do - will revisit later, when it makes sense
+	local commandLineAPI = {
+		"EvaluateString",
+		"PrintVersionString",
+		"RunBasicTests",
+		"RunDetailedTests",
+		"RunMinimalTests",
+	}
+	for _, exportedFunctionName in ipairs(commandLineAPI) do
+		it("should export " .. exportedFunctionName, function()
+			assertEquals(type(C_Runtime[exportedFunctionName]), "function")
+		end)
+	end
+
+	describe("EvaluateString", function()
+		it("should evaluate the input as a Lua chunk if given a string value", function()
+			local function throwsWhileEvaluating()
+				C_Runtime.EvaluateString('error("42", 0)')
+			end
+			assertThrows(throwsWhileEvaluating, "42")
+		end)
+
+		it("should throw if a non-string value was passed", function()
+			local function throwsWhileEvaluating()
+				C_Runtime.EvaluateString(nil)
+			end
+			assertThrows(
+				throwsWhileEvaluating,
+				"Expected argument luaCode to be a string value, but received a nil value instead"
+			)
+		end)
+
+		it("should return the result of the evaluation", function()
+			local returnedValue, anotherReturnedValue = C_Runtime.EvaluateString('return 42, "hello"')
+			assertEquals(returnedValue, 42)
+			assertEquals(anotherReturnedValue, "hello")
+		end)
+	end)
+end)

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -1,9 +1,3 @@
-local assertions = require("assertions")
-local bdd = require("bdd")
-local transform = require("transform")
-
-local format = string.format
-
 -- All paths are relative to the project root, since that's where the CI run will start
 local specFiles = {
 	"Tests/BDD/globals.spec.lua",
@@ -12,41 +6,6 @@ local specFiles = {
 	"Tests/BDD/runtime-namespace.spec.lua",
 }
 
-local function runBasicTests()
-	bdd.setBasicReportMode()
-	local numFailedTests = bdd.startTestRunner(specFiles)
+local numFailedSections = C_Runtime.RunDetailedTests(specFiles)
 
-	print(bdd.getReport())
-
-	local errorDetails = bdd.getErrorDetails()
-	for index, errorInfo in ipairs(errorDetails) do
-		print(format("(Error #%d) in %s", index, transform.bold(errorInfo.specFile)))
-		print(transform.brightRed(errorInfo.stackTrace))
-		print()
-	end
-
-	return numFailedTests
-end
-
-local function runDetailedTests()
-	bdd.setDetailedReportMode()
-	local numFailedTests = bdd.startTestRunner(specFiles)
-
-	print(bdd.getReport())
-
-	local errorDetails = bdd.getErrorDetails()
-	for index, errorInfo in ipairs(errorDetails) do
-		print(format("(Error #%d) in %s", index, transform.bold(errorInfo.specFile)))
-		print(transform.brightRed(errorInfo.stackTrace))
-		print()
-	end
-
-	return numFailedTests
-end
-
-assertions.export() -- Should probably remove this after global aliases are set up by the runtime
-
-local numFailedSpecFiles = runBasicTests()
-local numFailedSections = runDetailedTests()
-
-os.exit(math.max(numFailedSpecFiles, numFailedSections))
+os.exit(numFailedSections)

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -9,6 +9,7 @@ local specFiles = {
 	"Tests/BDD/globals.spec.lua",
 	"Tests/BDD/uv-library.spec.lua",
 	"Tests/BDD/webview-library.spec.lua",
+	"Tests/BDD/runtime-namespace.spec.lua",
 }
 
 local function runBasicTests()

--- a/ninjabuild.lua
+++ b/ninjabuild.lua
@@ -23,6 +23,7 @@ local EvoBuildTarget = {
 	luaSources = {
 		"deps/kikito/inspect.lua/inspect.lua",
 		"Runtime/evo.lua",
+		"Runtime/API/C_Runtime.lua",
 		"Runtime/Bindings/webview.lua",
 		"Runtime/Extensions/debugx.lua",
 		"Runtime/Extensions/stringx.lua",


### PR DESCRIPTION
This should mirror the CLI interface closely, so that it becomes trivial to run the actual commands after parsing the input (NYI).