### PR TITLE
Remove the hardcoded default value for MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -23,6 +23,8 @@ jobs:
     if: github.event.pull_request.draft == false
     name: Build for Mac OS
     runs-on: macos-latest
+    env:
+        MACOSX_DEPLOYMENT_TARGET: 10.12
 
     steps:
       - name: Check out Git repository

--- a/deps/fetch-mswebview2.sh
+++ b/deps/fetch-mswebview2.sh
@@ -1,3 +1,5 @@
+set -e
+
 # Should probably be the same that webview uses
 MSWEBVIEW_VERSION=1.0.1150.38
 # If nuget isn't installed, it doesn't seem to use the default source on first startup

--- a/deps/llhttp-unixbuild.sh
+++ b/deps/llhttp-unixbuild.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "Building target llhttp"
 
 SRC_DIR=deps/nodejs/llhttp

--- a/deps/llhttp-windowsbuild.sh
+++ b/deps/llhttp-windowsbuild.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "Building target llhttp"
 
 SRC_DIR=deps/nodejs/llhttp

--- a/deps/luajit-unixbuild.sh
+++ b/deps/luajit-unixbuild.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo Building target luajit
 
 LUAJIT_DIR=deps/LuaJIT/LuaJIT

--- a/deps/luajit-unixbuild.sh
+++ b/deps/luajit-unixbuild.sh
@@ -8,8 +8,6 @@ mkdir -p $BUILD_DIR/jit
 
 cd $LUAJIT_DIR
 
-# TBD Use whatever is available in GH Actions?
-export MACOSX_DEPLOYMENT_TARGET="10.12"
 make clean
 make BUILDMODE=static XCFLAGS=-DLUAJIT_ENABLE_LUA52COMPAT
 

--- a/deps/luajit-windowsbuild.sh
+++ b/deps/luajit-windowsbuild.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo Building target luajit
 
 LUAJIT_DIR=deps/LuaJIT/LuaJIT

--- a/deps/luaopenssl-unixbuild.sh
+++ b/deps/luaopenssl-unixbuild.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "Building target lua-openssl"
 
 SRC_DIR=deps/lua-openssl

--- a/deps/luaopenssl-windowsbuild.sh
+++ b/deps/luaopenssl-windowsbuild.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "Building target lua-openssl"
 
 SRC_DIR=deps/lua-openssl

--- a/deps/luv-unixbuild.sh
+++ b/deps/luv-unixbuild.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "Building target luv"
 
 SRC_DIR=deps/luvit/luv

--- a/deps/luv-windowsbuild.sh
+++ b/deps/luv-windowsbuild.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "Building target luv"
 
 SRC_DIR=deps/luvit/luv

--- a/deps/openssl-unixbuild.sh
+++ b/deps/openssl-unixbuild.sh
@@ -1,3 +1,5 @@
+set -e
+
 NUM_PARALLEL_JOBS=$(nproc)
 
 echo "Building target openssl with $NUM_PARALLEL_JOBS jobs"

--- a/deps/openssl-windowsbuild.sh
+++ b/deps/openssl-windowsbuild.sh
@@ -1,3 +1,5 @@
+set -e
+
 # All this MUST be ran from MSYS2! OpenSSL's build system is the stuff of nightmares, and doesn't work with native perl
 #The standard gcc won't work either, so make sure to install this one first (and all the other tools required):
 # pacman -S git make mingw-w64-x86_64-gcc ninja mingw-w64-x86_64-cmake --noconfirm

--- a/deps/pcre-unixbuild.sh
+++ b/deps/pcre-unixbuild.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "Building target pcre2"
 
 OUT_DIR=ninjabuild-unix

--- a/deps/pcre-windowsbuild.sh
+++ b/deps/pcre-windowsbuild.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "Building target pcre2"
 
 OUT_DIR=ninjabuild-windows

--- a/deps/unixbuild-all.sh
+++ b/deps/unixbuild-all.sh
@@ -1,3 +1,5 @@
+set -e
+
 deps/luajit-unixbuild.sh
 # deps/llhttp-unixbuild.sh
 # deps/openssl-unixbuild.sh

--- a/deps/windowsbuild-all.sh
+++ b/deps/windowsbuild-all.sh
@@ -1,3 +1,5 @@
+set -e
+
 deps/fetch-mswebview2.sh
 deps/luajit-windowsbuild.sh
 # deps/llhttp-windowsbuild.sh

--- a/deps/zlib-unixbuild.sh
+++ b/deps/zlib-unixbuild.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "Building target zlib"
 
 OUT_DIR=ninjabuild-unix

--- a/deps/zlib-windowsbuild.sh
+++ b/deps/zlib-windowsbuild.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "Building target zlib"
 
 OUT_DIR=ninjabuild-windows


### PR DESCRIPTION
It must be set by the user anyway in order to propagate correctly to the static libraries at build time.