### PR TITLE
Implement some basic unit testing hooks for registered setup and teardown functions

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -36,6 +36,8 @@ globals = {
 	"it",
 
 	-- global aliases
+	"after",
+	"before",
 	"buffer",
 	"dump",
 	"printf",

--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -48,6 +48,8 @@ function evo.registerGlobalAliases()
 	_G.buffer = require("string.buffer")
 	_G.path = require("path")
 
+	_G.after = bdd.after
+	_G.before = bdd.before
 	_G.describe = bdd.describe
 	_G.dump = debug.dump
 	_G.format = string.format


### PR DESCRIPTION
This is effectively beforeEach/afterEach, but nesting sections can be used to simulate before/after anyway, so more likely isn't needed.

Testing is implicit since any test that relies on fixtures will fail. I'll likely replace this with proper events (that can be tested properly) later, but right now there's no standardized event system yet.