### PR TITLE
Improve the consistency of uuid function names

### DIFF
--- a/Runtime/Libraries/uuid.lua
+++ b/Runtime/Libraries/uuid.lua
@@ -13,7 +13,7 @@ local uuid = {
 	RFC_STRING_PATTERN = "^%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x$",
 }
 
-function uuid.create_v4()
+function uuid.createBasicUUID()
 	local guid = ffi_new("uuid_rfc_string_t")
 	local guidPointer = ffi_cast("uuid_rfc_string_t*", guid)
 
@@ -23,7 +23,7 @@ function uuid.create_v4()
 	return guid
 end
 
-function uuid.create_mersenne_twisted()
+function uuid.createMersenneTwistedUUID()
 	local guid = ffi_new("uuid_rfc_string_t")
 	local guidPointer = ffi_cast("uuid_rfc_string_t*", guid)
 
@@ -33,11 +33,11 @@ function uuid.create_mersenne_twisted()
 	return guid
 end
 
-function uuid.create_v5(namespace, name)
+function uuid.createNameBasedUUID(namespace, name)
 	validateString(namespace, "namespace")
 	validateString(name, "name")
 
-	if not uuid.is_valid(namespace) then
+	if not uuid.isCanonical(namespace) then
 		error("Expected argument namespace to be a valid RFC UUID string", 0)
 	end
 
@@ -50,7 +50,7 @@ function uuid.create_v5(namespace, name)
 	return guid
 end
 
-function uuid.create_system_guid()
+function uuid.createSystemUUID()
 	local guid = ffi_new("uuid_rfc_string_t")
 	local guidPointer = ffi_cast("uuid_rfc_string_t*", guid)
 
@@ -60,7 +60,7 @@ function uuid.create_system_guid()
 	return guid
 end
 
-function uuid.is_valid(input)
+function uuid.isCanonical(input)
 	if type(input) ~= "string" then
 		return false
 	end

--- a/Tests/BDD/uuid-library.spec.lua
+++ b/Tests/BDD/uuid-library.spec.lua
@@ -7,31 +7,31 @@ describe("uuid", function()
 		assertEquals(uuid.RFC_STRING_PATTERN, UUID_PATTERN)
 	end)
 
-	describe("create_v4", function()
+	describe("createBasicUUID", function()
 		it("should generate a UUID string in the expected format", function()
-			local guid = uuid.create_v4()
+			local guid = uuid.createBasicUUID()
 
 			local isValidUUID = string.match(guid, UUID_PATTERN) ~= nil
 			assertTrue(isValidUUID)
 		end)
 	end)
 
-	describe("create_mersenne_twisted", function()
+	describe("createMersenneTwistedUUID", function()
 		it("should generate a UUID string in the expected format", function()
-			local guid = uuid.create_mersenne_twisted()
+			local guid = uuid.createMersenneTwistedUUID()
 
 			local isValidUUID = string.match(guid, UUID_PATTERN) ~= nil
 			assertTrue(isValidUUID)
 		end)
 	end)
 
-	describe("create_v5", function()
+	describe("createNameBasedUUID", function()
 		it("should generate a UUID string in the expected format", function()
 			local namespace = "47183823-2574-4bfd-b411-99ed177d3e43"
 			local name = "john"
 			local expectedGUID = "0dbbd6be-b274-536b-b356-c22d8ea30a0e"
 
-			local guid = uuid.create_v5(namespace, name)
+			local guid = uuid.createNameBasedUUID(namespace, name)
 
 			local isValidUUID = string.match(guid, UUID_PATTERN) ~= nil
 			assertTrue(isValidUUID)
@@ -40,44 +40,44 @@ describe("uuid", function()
 
 		it("should throw if an invalid namespace is passed", function()
 			assertThrows(function()
-				uuid.create_v5(nil, "test")
+				uuid.createNameBasedUUID(nil, "test")
 			end, "Expected argument namespace to be a string value, but received a nil value instead")
 		end)
 
 		it("should throw if an invalid name is passed", function()
 			assertThrows(function()
-				uuid.create_v5("47183823-2574-4bfd-b411-99ed177d3e43", nil)
+				uuid.createNameBasedUUID("47183823-2574-4bfd-b411-99ed177d3e43", nil)
 			end, "Expected argument name to be a string value, but received a nil value instead")
 		end)
 
 		it("should throw if the namespace passed is not a valid RFC UUID", function()
 			assertThrows(function()
-				uuid.create_v5("47183823-2574-4bfd-b411-99ed177d3e43xxx", "test123")
+				uuid.createNameBasedUUID("47183823-2574-4bfd-b411-99ed177d3e43xxx", "test123")
 			end, "Expected argument namespace to be a valid RFC UUID string")
 		end)
 	end)
 
-	describe("create_system_guid", function()
+	describe("createSystemUUID", function()
 		it("should generate a UUID string in the expected format", function()
-			local guid = uuid.create_system_guid()
+			local guid = uuid.createSystemUUID()
 
 			local isValidUUID = string.match(guid, UUID_PATTERN) ~= nil
 			assertTrue(isValidUUID)
 		end)
 	end)
 
-	describe("is_valid", function()
+	describe("isCanonical", function()
 		it("should return false if an invalid type is passed", function()
-			local isValidUUID = uuid.is_valid(42)
+			local isValidUUID = uuid.isCanonical(42)
 			assertFalse(isValidUUID)
 		end)
 
 		it("should return false if the value passed is not a valid RFC UUID", function()
-			local isValidUUID = uuid.is_valid("47183823-2574-4bfd-b411-99ed177d3e43xxx")
+			local isValidUUID = uuid.isCanonical("47183823-2574-4bfd-b411-99ed177d3e43xxx")
 			assertFalse(isValidUUID)
 		end)
 		it("should return true if the value passed is a valid RFC UUID", function()
-			local isValidUUID = uuid.is_valid("47183823-2574-4bfd-b411-99ed177d3e43")
+			local isValidUUID = uuid.isCanonical("47183823-2574-4bfd-b411-99ed177d3e43")
 			assertTrue(isValidUUID)
 		end)
 	end)


### PR DESCRIPTION
Camel case is used by the other Lua libraries. so snake case should be reserved for the actual FFI bindings (stduuid module) instead.