### PR TITLE
Set up ccache for GitHub Actions

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -31,6 +31,9 @@ jobs:
           submodules: recursive
           fetch-depth: "0" # Required so that git describe actually works (and we can embed the version tag)
 
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+
       - name: Update apt cache
         run: sudo apt-get update
 
@@ -40,6 +43,12 @@ jobs:
       # Can't actually be used on CI runners, but we need the headers for embedding webview
       - name: Install WebKitGTK
         run: sudo apt-get install gtk+-3.0-dev webkit2gtk-4.0-dev --yes
+
+      - name: Configure environment
+        run: |
+            export PATH="/usr/lib/ccache:$PATH"
+            echo "CC=/usr/lib/ccache/gcc" >> $GITHUB_ENV
+            echo "CXX=/usr/lib/ccache/g++" >> $GITHUB_ENV
 
       - name: Build luajit
         run: deps/luajit-unixbuild.sh && ls ninjabuild-unix

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: macos-latest
     env:
         MACOSX_DEPLOYMENT_TARGET: 10.13
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1 # Prevent brew updates in the ccache setup step (~2GB download ...)
 
     steps:
       - name: Check out Git repository
@@ -33,9 +34,16 @@ jobs:
           submodules: recursive
           fetch-depth: "0" # Required so that git describe actually works (and we can embed the version tag)
 
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+
       - name: Install Ninja
         run: brew install ninja
 
+      - name: Configure environment
+        run: |
+          echo "CC=ccache gcc" >> $GITHUB_ENV
+          echo "CXX=ccache g++" >> $GITHUB_ENV
       - name: Build luajit
         run: deps/luajit-unixbuild.sh && ls ninjabuild-unix
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -23,6 +23,8 @@ jobs:
     if: github.event.pull_request.draft == false
     name: Build for Windows
     runs-on: windows-latest
+    env:
+      SCCACHE_GHA_ENABLED: "true"
 
     defaults:
       run:
@@ -40,8 +42,19 @@ jobs:
         with:
           install: git make mingw-w64-x86_64-gcc ninja mingw-w64-x86_64-cmake
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.3
+
       - name: Download Webview2 SDK
         run: deps/fetch-mswebview2.sh && ls ninjabuild-windows
+
+      - name: Configure environment
+        run: |
+          export SCCACHE_WINDOWS_PATH=${SCCACHE_PATH}
+          export SCCACHE_UNIX_PATH=$(cygpath -u "$SCCACHE_WINDOWS_PATH")
+          echo "SCCACHE_UNIX_PATH=$SCCACHE_UNIX_PATH" >> $GITHUB_ENV
+          echo "CC=${SCCACHE_UNIX_PATH} gcc" >> $GITHUB_ENV
+          echo "CXX=${SCCACHE_UNIX_PATH} g++" >> $GITHUB_ENV
 
       - name: Build luajit
         run: deps/luajit-windowsbuild.sh && ls ninjabuild-windows


### PR DESCRIPTION
Not sure if this will work, since the build system is based on Ninja and I don't want to require ccache for regular builds.

If it speeds up OpenSSL builds, that's probably enough for now since that's the main bottleneck currently.