### PR TITLE
Replace sccache with ccache for Windows builds

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -47,12 +47,15 @@ jobs:
         run: deps/fetch-mswebview2.sh && ls ninjabuild-windows
 
       - name: Configure environment
-        # These directories are way out there, but it's what ccache-action uses ...
         run: |
           echo $PATH
           export PATH="${{ env.USERPROFILE }}\\.cargo\\bin:$PATH"
           echo $PATH
-          export PATH=$(cygpath -u "${{ env.USERPROFILE }}\\.cargo\\bin"):$PATH
+          if [ -n "$MSYSTEM" ]; then
+            export PATH="/c/Users/$(basename ${USERPROFILE})/.cargo/bin:$PATH"
+          else
+            export PATH=$(cygpath -u "${{ env.USERPROFILE }}\\.cargo\\bin"):$PATH
+          fi
           echo $PATH
           echo "CC=ccache gcc" >> $GITHUB_ENV
           echo "CXX=ccache g++" >> $GITHUB_ENV

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -46,6 +46,18 @@ jobs:
       - name: Download Webview2 SDK
         run: deps/fetch-mswebview2.sh && ls ninjabuild-windows
 
+      - name: Find ccache.exe
+        run: |
+          ccache_path=$(find / -type f -iname "ccache.exe" 2>/dev/null)
+          if [ -n "$ccache_path" ]; then
+            echo "ccache.exe found at: $ccache_path"
+            ccache_dir=$(dirname "$ccache_path")
+            export PATH=$ccache_dir:$PATH
+            echo "Updated PATH: $PATH"
+          else
+            echo "ccache.exe not found."
+          fi
+
       - name: Configure environment
         run: |
           echo $PATH

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -73,7 +73,7 @@ jobs:
           ls -l $(cygpath -u "$USERPROFILE")/ccache
           ls -l -a $(cygpath -u "$USERPROFILE")
           ls -l -a $(cygpath -u "$USERPROFILE")/.cargo/bin
-          ls -l -a $(cygpath -u "$USERPROFILE")/AppData/Roaming/ccache
+          ls -l -a $(cygpath -u "$USERPROFILE")/AppData
           ls -l -a $(cygpath -u "$USERPROFILE")/AppData/Roaming
           ls -l -a $(cygpath -u "$USERPROFILE")/AppData/Roaming/ccache
           which ccache | which sccache | file $(cygpath -u "$USERPROFILE")/ccache

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -63,7 +63,7 @@ jobs:
           echo $PATH
           echo $MSYS2_PATH
           export PATH=$(cygpath -u "$USERPROFILE")/ccache:$PATH
-          export MSYS2_PATH=$(cygpath -u "$USERPROFILE)/ccache":$MSYS2_PATH
+          export MSYS2_PATH=$(cygpath -u "$USERPROFILE")/ccache:$MSYS2_PATH
           echo $PATH
           echo $MSYS2_PATH
           echo "CC=ccache gcc" >> $GITHUB_ENV

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -48,14 +48,8 @@ jobs:
 
       - name: Configure environment
         run: |
-          echo $PATH
-          export PATH="${{ env.USERPROFILE }}\\.cargo\\bin:$PATH"
-          echo $PATH
-          if [ -n "$MSYSTEM" ]; then
-            export PATH="/c/Users/$(basename ${USERPROFILE})/.cargo/bin:$PATH"
-          else
-            export PATH=$(cygpath -u "${{ env.USERPROFILE }}\\.cargo\\bin"):$PATH
-          fi
+          export PATH=$(cygpath ${{ env.USERPROFILE }}):$PATH
+          export PATH=$(cygpath $USERPROFILE):$PATH
           echo $PATH
           echo "CC=ccache gcc" >> $GITHUB_ENV
           echo "CXX=ccache g++" >> $GITHUB_ENV

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -68,8 +68,6 @@ jobs:
           echo $MSYS2_PATH
           echo "CC=bash -xc ccache gcc" >> $GITHUB_ENV
           echo "CXX=bash -xc ccache g++" >> $GITHUB_ENV
-          ls -l -a /usr/local/bin
-
 
       - name: Set PATH to include ccache
         run: echo "PATH=${env:USERPROFILE}\.cargo\bin;${env:PATH}" >> $GITHUB_ENV

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -52,7 +52,7 @@ jobs:
             ls -l -a $(which ccache)
             ls -l -a /usr/bin/ccache
             ls -l -a /usr/lib/ccache
-            ls -l -a $(basename($(which ccache))
+            ls -l -a $(basename(/usr/bin/ccache)
             echo "CC=ccache gcc" >> $GITHUB_ENV
             echo "CXX=ccache g++" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -70,6 +70,7 @@ jobs:
           echo "CXX=ccache g++" >> $GITHUB_ENV
           ls $(cygpath -u "$USERPROFILE")/ccache | file $(cygpath -u "$USERPROFILE")/ccache
           ls -l $(cygpath -u "$USERPROFILE")
+          ls -l $(cygpath -u "$USERPROFILE")/ccache
           which ccache | which sccache | file $(cygpath -u "$USERPROFILE")/ccache
 
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -48,15 +48,12 @@ jobs:
 
       - name: Configure environment
         run: |
-          export PATH=$(cygpath ${{ env.USERPROFILE }}):$PATH
-          export MSYS2_PATH=$(cygpath ${{ env.USERPROFILE }}):$MSYS2_PATH
-          echo $PATH
-          echo $MSYS2_PATH
-          export PATH=$(cygpath $USERPROFILE):$PATH
-          export MSYS2_PATH=$(cygpath $USERPROFILE):$MSYS2_PATH
           echo $PATH
           echo $MSYS2_PATH
           echo "export PATH=$USERPROFILE/.cargo/bin:$PATH" >> $GITHUB_ENV
+          echo "export MSYS2_PATH=$USERPROFILE/.cargo/bin:$MSYS2_PATH" >> $GITHUB_ENV
+          echo $PATH
+          echo $MSYS2_PATH
           echo "CC=ccache gcc" >> $GITHUB_ENV
           echo "CXX=ccache g++" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -53,7 +53,6 @@ jobs:
             ls -l -a /usr/bin/ccache
             ls -l -a /usr/lib/ccache
             ls -l -a /usr/lib/ccache/bin
-            ls -l -a $(basename(/usr/bin/ccache)
             echo "CC=/usr/lib/ccache/bin/gcc" >> $GITHUB_ENV
             echo "CXX=/usr/lib/ccache/bin/g++" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -68,14 +68,6 @@ jobs:
           echo $MSYS2_PATH
           echo "CC=bash -xc ccache gcc" >> $GITHUB_ENV
           echo "CXX=bash -xc ccache g++" >> $GITHUB_ENV
-          ls $(cygpath -u "$USERPROFILE")/ccache | file $(cygpath -u "$USERPROFILE")/ccache
-          ls -l $(cygpath -u "$USERPROFILE")
-          ls -l $(cygpath -u "$USERPROFILE")/ccache
-          ls -l -a $(cygpath -u "$USERPROFILE")
-          ls -l -a $(cygpath -u "$USERPROFILE")/.cargo/bin
-          ls -l -a $(cygpath -u "$USERPROFILE")/AppData
-          ls -l -a $(cygpath -u "$USERPROFILE")/AppData/Roaming
-          ls -l -a $(cygpath -u "$USERPROFILE")/AppData/Roaming/ccache
           bash -xc ccache
 
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -46,18 +46,6 @@ jobs:
       - name: Download Webview2 SDK
         run: deps/fetch-mswebview2.sh && ls ninjabuild-windows
 
-      - name: Find ccache.exe
-        run: |
-          ccache_path=$(find / -type f -iname "ccache.exe" 2>/dev/null)
-          if [ -n "$ccache_path" ]; then
-            echo "ccache.exe found at: $ccache_path"
-            ccache_dir=$(dirname "$ccache_path")
-            export PATH=$ccache_dir:$PATH
-            echo "Updated PATH: $PATH"
-          else
-            echo "ccache.exe not found."
-          fi
-
       - name: Configure environment
         run: |
           echo $PATH
@@ -78,8 +66,8 @@ jobs:
           export MSYS2_PATH=$(cygpath -u "$USERPROFILE")/ccache:$MSYS2_PATH
           echo $PATH
           echo $MSYS2_PATH
-          echo "CC=ccache gcc" >> $GITHUB_ENV
-          echo "CXX=ccache g++" >> $GITHUB_ENV
+          echo "CC=bash -xc ccache gcc" >> $GITHUB_ENV
+          echo "CXX=bash -xc ccache g++" >> $GITHUB_ENV
           ls $(cygpath -u "$USERPROFILE")/ccache | file $(cygpath -u "$USERPROFILE")/ccache
           ls -l $(cygpath -u "$USERPROFILE")
           ls -l $(cygpath -u "$USERPROFILE")/ccache
@@ -88,7 +76,7 @@ jobs:
           ls -l -a $(cygpath -u "$USERPROFILE")/AppData
           ls -l -a $(cygpath -u "$USERPROFILE")/AppData/Roaming
           ls -l -a $(cygpath -u "$USERPROFILE")/AppData/Roaming/ccache
-          which ccache | which sccache | file $(cygpath -u "$USERPROFILE")/ccache
+          bash -xc ccache
 
 
       - name: Set PATH to include ccache

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up MSYS2 environment
         uses: msys2/setup-msys2@v2
         with:
-          install: git make mingw-w64-x86_64-gcc ninja mingw-w64-x86_64-cmake
+          install: git make mingw-w64-x86_64-gcc ninja mingw-w64-x86_64-cmake ccache
 
       - name: Download Webview2 SDK
         run: deps/fetch-mswebview2.sh && ls ninjabuild-windows
@@ -68,7 +68,7 @@ jobs:
           echo $MSYS2_PATH
           echo "CC=bash -xc ccache gcc" >> $GITHUB_ENV
           echo "CXX=bash -xc ccache g++" >> $GITHUB_ENV
-          bash -xc ccache
+          ls -l -a /usr/local/bin
 
 
       - name: Set PATH to include ccache

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -47,8 +47,13 @@ jobs:
         run: deps/fetch-mswebview2.sh && ls ninjabuild-windows
 
       - name: Configure environment
+        # These directories are way out there, but it's what ccache-action uses ...
         run: |
-          export PATH="/usr/lib/ccache:$PATH"
+          echo $PATH
+          export PATH="${process.env.USERPROFILE}\\.cargo\\bin:$PATH"
+          echo $PATH
+          export PATH="$(cygpath -u ${process.env.USERPROFILE}\\.cargo\\bin):$PATH"
+          echo $PATH
           echo "CC=ccache gcc" >> $GITHUB_ENV
           echo "CXX=ccache g++" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -52,9 +52,10 @@ jobs:
             ls -l -a $(which ccache)
             ls -l -a /usr/bin/ccache
             ls -l -a /usr/lib/ccache
+            ls -l -a /usr/lib/ccache/bin
             ls -l -a $(basename(/usr/bin/ccache)
-            echo "CC=ccache gcc" >> $GITHUB_ENV
-            echo "CXX=ccache g++" >> $GITHUB_ENV
+            echo "CC=/usr/lib/ccache/bin/gcc" >> $GITHUB_ENV
+            echo "CXX=/usr/lib/ccache/bin/g++" >> $GITHUB_ENV
 
       - name: Build luajit
         run: deps/luajit-windowsbuild.sh && ls ninjabuild-windows

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -54,8 +54,13 @@ jobs:
           echo "export MSYS2_PATH=$USERPROFILE/.cargo/bin:$MSYS2_PATH" >> $GITHUB_ENV
           echo $PATH
           echo $MSYS2_PATH
+          echo "export PATH=$(cygpath -u "$USERPROFILE/.cargo/bin"):$PATH" >> $GITHUB_ENV
+          echo "export PATH=$(cygpath -u "$USERPROFILE/.cargo/bin"):$PATH" >> $GITHUB_ENV
+          echo "export MSYS2_PATH=$(cygpath -u "$USERPROFILE"):$PATH" >> $GITHUB_ENV
+          echo "export MSYS2_PATH=$(cygpath -u "$USERPROFILE/.cargo/bin"):$PATH" >> $GITHUB_ENV
           echo "CC=ccache gcc" >> $GITHUB_ENV
           echo "CXX=ccache g++" >> $GITHUB_ENV
+          which ccache | which sccache | ls $(cygpath -u "$USERPROFILE")
 
       - name: Set PATH to include ccache
         run: echo "PATH=${env:USERPROFILE}\.cargo\bin;${env:PATH}" >> $GITHUB_ENV

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -35,16 +35,13 @@ jobs:
           submodules: recursive
           fetch-depth: "0" # Required so that git describe actually works (and we can embed the version tag)
 
-      - name: Setup ccache
+      - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2
 
       - name: Set up MSYS2 environment
         uses: msys2/setup-msys2@v2
         with:
           install: git make mingw-w64-x86_64-gcc ninja mingw-w64-x86_64-cmake
-
-      - name: Find ccache
-        run: which ccache
 
       - name: Download Webview2 SDK
         run: deps/fetch-mswebview2.sh && ls ninjabuild-windows

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -48,26 +48,8 @@ jobs:
 
       - name: Configure environment
         run: |
-          echo $PATH
-          echo $MSYS2_PATH
-          export PATH=$USERPROFILE/.cargo/bin:$PATH
-          export MSYS2_PATH=$USERPROFILE/.cargo/bin:$MSYS2_PATH
-          echo $PATH
-          echo $MSYS2_PATH
-          export PATH=$(cygpath -u "$USERPROFILE/.cargo/bin"):$PATH
-          export MSYS2_PATH=$(cygpath -u "$USERPROFILE/.cargo/bin"):$MSYS2_PATH
-          echo $PATH
-          echo $MSYS2_PATH
-          export PATH=$(cygpath -u "$USERPROFILE"):$PATH
-          export MSYS2_PATH=$(cygpath -u "$USERPROFILE"):$MSYS2_PATH
-          echo $PATH
-          echo $MSYS2_PATH
-          export PATH=$(cygpath -u "$USERPROFILE")/ccache:$PATH
-          export MSYS2_PATH=$(cygpath -u "$USERPROFILE")/ccache:$MSYS2_PATH
-          echo $PATH
-          echo $MSYS2_PATH
-          echo "CC=bash -xc ccache gcc" >> $GITHUB_ENV
-          echo "CXX=bash -xc ccache g++" >> $GITHUB_ENV
+            echo "CC=ccache gcc" >> $GITHUB_ENV
+            echo "CXX=ccache g++" >> $GITHUB_ENV
 
       - name: Set PATH to include ccache
         run: echo "PATH=${env:USERPROFILE}\.cargo\bin;${env:PATH}" >> $GITHUB_ENV

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -50,9 +50,9 @@ jobs:
 
       - name: Configure environment
         run: |
-          export PATH="/usr/lib/ccache/bin:$PATH"
-          echo "CC=/usr/lib/ccache/bin/gcc" >> $GITHUB_ENV
-          echo "CXX=/usr/lib/ccache/bin/g++" >> $GITHUB_ENV
+          export PATH="/usr/lib/ccache:$PATH"
+          echo "CC=/usr/lib/ccache/gcc" >> $GITHUB_ENV
+          echo "CXX=/usr/lib/ccache/g++" >> $GITHUB_ENV
 
       - name: Build luajit
         run: deps/luajit-windowsbuild.sh && ls ninjabuild-windows

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -42,19 +42,17 @@ jobs:
         with:
           install: git make mingw-w64-x86_64-gcc ninja mingw-w64-x86_64-cmake
 
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
 
       - name: Download Webview2 SDK
         run: deps/fetch-mswebview2.sh && ls ninjabuild-windows
 
       - name: Configure environment
         run: |
-          export SCCACHE_WINDOWS_PATH=${SCCACHE_PATH}
-          export SCCACHE_UNIX_PATH=$(cygpath -u "$SCCACHE_WINDOWS_PATH")
-          echo "SCCACHE_UNIX_PATH=$SCCACHE_UNIX_PATH" >> $GITHUB_ENV
-          echo "CC=${SCCACHE_UNIX_PATH} gcc" >> $GITHUB_ENV
-          echo "CXX=${SCCACHE_UNIX_PATH} g++" >> $GITHUB_ENV
+          export PATH="/usr/lib/ccache/bin:$PATH"
+          echo "CC=/usr/lib/ccache/bin/gcc" >> $GITHUB_ENV
+          echo "CXX=/usr/lib/ccache/bin/g++" >> $GITHUB_ENV
 
       - name: Build luajit
         run: deps/luajit-windowsbuild.sh && ls ninjabuild-windows

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -50,15 +50,11 @@ jobs:
         run: |
             which ccache
             ls -l -a $(which ccache)
-            ls -l -a $(which ccache)/..
+            ls -l -a /usr/bin/ccache
+            ls -l -a /usr/lib/ccache
             ls -l -a $(basename($(which ccache))
             echo "CC=ccache gcc" >> $GITHUB_ENV
             echo "CXX=ccache g++" >> $GITHUB_ENV
-
-      - name: Set PATH to include ccache
-        run: echo "PATH=${env:USERPROFILE}\.cargo\bin;${env:PATH}" >> $GITHUB_ENV
-      - name: Set MSYS2_PATH to include ccache
-        run: echo "MSYS2_PATH=${env:USERPROFILE}\.cargo\bin;${env:MSYS2_PATH}" >> $GITHUB_ENV
 
       - name: Build luajit
         run: deps/luajit-windowsbuild.sh && ls ninjabuild-windows

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Configure environment
         run: |
+            which ccache
             echo "CC=ccache gcc" >> $GITHUB_ENV
             echo "CXX=ccache g++" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -49,10 +49,21 @@ jobs:
       - name: Configure environment
         run: |
           export PATH=$(cygpath ${{ env.USERPROFILE }}):$PATH
-          export PATH=$(cygpath $USERPROFILE):$PATH
+          export MSYS2_PATH=$(cygpath ${{ env.USERPROFILE }}):$MSYS2_PATH
           echo $PATH
+          echo $MSYS2_PATH
+          export PATH=$(cygpath $USERPROFILE):$PATH
+          export MSYS2_PATH=$(cygpath $USERPROFILE):$MSYS2_PATH
+          echo $PATH
+          echo $MSYS2_PATH
+          echo "export PATH=$USERPROFILE/.cargo/bin:$PATH" >> $GITHUB_ENV
           echo "CC=ccache gcc" >> $GITHUB_ENV
           echo "CXX=ccache g++" >> $GITHUB_ENV
+
+      - name: Set PATH to include ccache
+        run: echo "PATH=${env:USERPROFILE}\.cargo\bin;${env:PATH}" >> $GITHUB_ENV
+      - name: Set MSYS2_PATH to include ccache
+        run: echo "MSYS2_PATH=${env:USERPROFILE}\.cargo\bin;${env:MSYS2_PATH}" >> $GITHUB_ENV
 
       - name: Build luajit
         run: deps/luajit-windowsbuild.sh && ls ninjabuild-windows

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -71,6 +71,8 @@ jobs:
           ls $(cygpath -u "$USERPROFILE")/ccache | file $(cygpath -u "$USERPROFILE")/ccache
           ls -l $(cygpath -u "$USERPROFILE")
           ls -l $(cygpath -u "$USERPROFILE")/ccache
+          ls -l -a $(cygpath -u "$USERPROFILE")
+          ls -l -a $(cygpath -u "$USERPROFILE")/.cargo/bin
           which ccache | which sccache | file $(cygpath -u "$USERPROFILE")/ccache
 
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -73,6 +73,9 @@ jobs:
           ls -l $(cygpath -u "$USERPROFILE")/ccache
           ls -l -a $(cygpath -u "$USERPROFILE")
           ls -l -a $(cygpath -u "$USERPROFILE")/.cargo/bin
+          ls -l -a $(cygpath -u "$USERPROFILE")/AppData/Roaming/ccache
+          ls -l -a $(cygpath -u "$USERPROFILE")/AppData/Roaming
+          ls -l -a $(cygpath -u "$USERPROFILE")/AppData/Roaming/ccache
           which ccache | which sccache | file $(cygpath -u "$USERPROFILE")/ccache
 
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -23,8 +23,6 @@ jobs:
     if: github.event.pull_request.draft == false
     name: Build for Windows
     runs-on: windows-latest
-    env:
-      SCCACHE_GHA_ENABLED: "true"
 
     defaults:
       run:
@@ -37,13 +35,16 @@ jobs:
           submodules: recursive
           fetch-depth: "0" # Required so that git describe actually works (and we can embed the version tag)
 
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+
+      - name: Find ccache
+        run: which ccache
+
       - name: Set up MSYS2 environment
         uses: msys2/setup-msys2@v2
         with:
           install: git make mingw-w64-x86_64-gcc ninja mingw-w64-x86_64-cmake
-
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
 
       - name: Download Webview2 SDK
         run: deps/fetch-mswebview2.sh && ls ninjabuild-windows
@@ -51,8 +52,8 @@ jobs:
       - name: Configure environment
         run: |
           export PATH="/usr/lib/ccache:$PATH"
-          echo "CC=/usr/lib/ccache/gcc" >> $GITHUB_ENV
-          echo "CXX=/usr/lib/ccache/g++" >> $GITHUB_ENV
+          echo "CC=ccache gcc" >> $GITHUB_ENV
+          echo "CXX=ccache g++" >> $GITHUB_ENV
 
       - name: Build luajit
         run: deps/luajit-windowsbuild.sh && ls ninjabuild-windows

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Build luv and libuv
         run: deps/luv-windowsbuild.sh && ls ninjabuild-windows
 
+      - name: Enable ccache debug
+        run: echo "CCACHE_DEBUG=1" >> $GITHUB_ENV
+
       - name: Build openssl
         run: deps/openssl-windowsbuild.sh && ls ninjabuild-windows
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -38,13 +38,13 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
 
-      - name: Find ccache
-        run: which ccache
-
       - name: Set up MSYS2 environment
         uses: msys2/setup-msys2@v2
         with:
           install: git make mingw-w64-x86_64-gcc ninja mingw-w64-x86_64-cmake
+
+      - name: Find ccache
+        run: which ccache
 
       - name: Download Webview2 SDK
         run: deps/fetch-mswebview2.sh && ls ninjabuild-windows

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -50,16 +50,25 @@ jobs:
         run: |
           echo $PATH
           echo $MSYS2_PATH
-          echo "export PATH=$USERPROFILE/.cargo/bin:$PATH" >> $GITHUB_ENV
-          echo "export MSYS2_PATH=$USERPROFILE/.cargo/bin:$MSYS2_PATH" >> $GITHUB_ENV
+          export PATH=$USERPROFILE/.cargo/bin:$PATH
+          export MSYS2_PATH=$USERPROFILE/.cargo/bin:$MSYS2_PATH
           echo $PATH
           echo $MSYS2_PATH
-          echo "export PATH=$(cygpath -u "$USERPROFILE/.cargo/bin"):$PATH" >> $GITHUB_ENV
-          echo "export PATH=$(cygpath -u "$USERPROFILE/.cargo/bin"):$PATH" >> $GITHUB_ENV
-          echo "export MSYS2_PATH=$(cygpath -u "$USERPROFILE"):$PATH" >> $GITHUB_ENV
-          echo "export MSYS2_PATH=$(cygpath -u "$USERPROFILE/.cargo/bin"):$PATH" >> $GITHUB_ENV
+          export PATH=$(cygpath -u "$USERPROFILE/.cargo/bin"):$PATH
+          export MSYS2_PATH=$(cygpath -u "$USERPROFILE/.cargo/bin"):$MSYS2_PATH
+          echo $PATH
+          echo $MSYS2_PATH
+          export MSYS2_PATH=$(cygpath -u "$USERPROFILE"):$PATH
+          export MSYS2_PATH=$(cygpath -u "$USERPROFILE/.cargo/bin"):$MSYS2_PATH
+          echo $PATH
+          echo $MSYS2_PATH
+          export PATH=$(cygpath -u "$USERPROFILE")/ccache:$PATH
+          export MSYS2_PATH=$(cygpath -u "$USERPROFILE)/ccache":$MSYS2_PATH
+          echo $PATH
+          echo $MSYS2_PATH
           echo "CC=ccache gcc" >> $GITHUB_ENV
           echo "CXX=ccache g++" >> $GITHUB_ENV
+          ls $(cygpath -u "$USERPROFILE")/ccache | file $(cygpath -u "$USERPROFILE")/ccache
           which ccache | which sccache | ls $(cygpath -u "$USERPROFILE")
 
       - name: Set PATH to include ccache

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -58,8 +58,8 @@ jobs:
           export MSYS2_PATH=$(cygpath -u "$USERPROFILE/.cargo/bin"):$MSYS2_PATH
           echo $PATH
           echo $MSYS2_PATH
-          export MSYS2_PATH=$(cygpath -u "$USERPROFILE"):$PATH
-          export MSYS2_PATH=$(cygpath -u "$USERPROFILE/.cargo/bin"):$MSYS2_PATH
+          export PATH=$(cygpath -u "$USERPROFILE"):$PATH
+          export MSYS2_PATH=$(cygpath -u "$USERPROFILE"):$MSYS2_PATH
           echo $PATH
           echo $MSYS2_PATH
           export PATH=$(cygpath -u "$USERPROFILE")/ccache:$PATH
@@ -69,7 +69,9 @@ jobs:
           echo "CC=ccache gcc" >> $GITHUB_ENV
           echo "CXX=ccache g++" >> $GITHUB_ENV
           ls $(cygpath -u "$USERPROFILE")/ccache | file $(cygpath -u "$USERPROFILE")/ccache
-          which ccache | which sccache | ls $(cygpath -u "$USERPROFILE")
+          ls -l $(cygpath -u "$USERPROFILE")
+          which ccache | which sccache | file $(cygpath -u "$USERPROFILE")/ccache
+
 
       - name: Set PATH to include ccache
         run: echo "PATH=${env:USERPROFILE}\.cargo\bin;${env:PATH}" >> $GITHUB_ENV

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Configure environment
         run: |
             which ccache
+            ls -l -a $(which ccache)
+            ls -l -a $(which ccache)/..
+            ls -l -a $(basename($(which ccache))
             echo "CC=ccache gcc" >> $GITHUB_ENV
             echo "CXX=ccache g++" >> $GITHUB_ENV
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -50,9 +50,9 @@ jobs:
         # These directories are way out there, but it's what ccache-action uses ...
         run: |
           echo $PATH
-          export PATH="${process.env.USERPROFILE}\\.cargo\\bin:$PATH"
+          export PATH="${{ env.USERPROFILE }}\\.cargo\\bin:$PATH"
           echo $PATH
-          export PATH="$(cygpath -u ${process.env.USERPROFILE}\\.cargo\\bin):$PATH"
+          export PATH=$(cygpath -u "${{ env.USERPROFILE }}\\.cargo\\bin"):$PATH
           echo $PATH
           echo "CC=ccache gcc" >> $GITHUB_ENV
           echo "CXX=ccache g++" >> $GITHUB_ENV


### PR DESCRIPTION
It seems that sccache isn't hitting any OpenSSL artifacts, defeating the purpose of using it in the first place.

Before I spend time troubleshooting that, let's quickly see if ccache actually works in MSYS2.