### PR TITLE
Remove the uws header from HTTP responses

### DIFF
--- a/Runtime/API/Networking/WebSocketTestClient.lua
+++ b/Runtime/API/Networking/WebSocketTestClient.lua
@@ -75,7 +75,6 @@ function WebSocketTestClient:TCP_CHUNK_RECEIVED(chunk)
 		.. "Connection: Upgrade\r\n"
 		.. "Sec%-WebSocket%-Accept: ([%w+/]+=*)\r\n"
 		.. "Date: ([%w, %-:]+)\r\n"
-		.. "uWebSockets: (%d+)\r\n\r\n"
 
 	-- Boldly assume it arrives in a single chunk here because we're only testing a local server
 	local isProtocolUpgradeResponse = string.match(chunk, upgradeResponsePattern)

--- a/ninjabuild.lua
+++ b/ninjabuild.lua
@@ -206,6 +206,7 @@ function EvoBuildTarget:GetDefines(cppSourceFilePath)
 	local uwsVersionTag = require(self.BUILD_DIR .. ".uws-version")
 	local uwsVersionString = string.match(uwsVersionTag, "(%d+.%d+.%d+)")
 	defines = defines .. format(' -DUWS_VERSION=\\"%s\\"', uwsVersionString)
+	defines = defines .. " -DUWS_HTTPRESPONSE_NO_WRITEMARK"
 
 	return defines
 end


### PR DESCRIPTION
What good can possibly come of disclosing this information?