### PR TITLE
Improve the phrasing of basic test runner summaries

### DIFF
--- a/Runtime/Libraries/bdd.lua
+++ b/Runtime/Libraries/bdd.lua
@@ -48,7 +48,7 @@ function bdd.startTestRunner(specFiles)
 
 	if bdd.isBasicReportingMode() then
 		local numSpecFiles = tostring(#specFiles)
-		bdd.report("Starting new test runner with a total of " .. bold(numSpecFiles) .. " spec file(s)")
+		bdd.report("Test runner started with a total of " .. bold(numSpecFiles) .. " spec file(s)")
 		bdd.report("")
 	end
 

--- a/Tests/SmokeTests/bdd-library/test-start-runner.lua
+++ b/Tests/SmokeTests/bdd-library/test-start-runner.lua
@@ -112,7 +112,7 @@ local function testBasicEmptyTestCase()
 	assertEquals(numFailingTests, 0)
 
 	local reportString = bdd.getReport()
-	local expectedReportString = "Starting new test runner with a total of "
+	local expectedReportString = "Test runner started with a total of "
 		.. bold("1")
 		.. " spec file(s)"
 		.. "\n\n"
@@ -135,7 +135,7 @@ local function testBasicEmptyTestCases()
 	assertEquals(numFailingTests, 0)
 
 	local reportString = bdd.getReport()
-	local expectedReportString = "Starting new test runner with a total of "
+	local expectedReportString = "Test runner started with a total of "
 		.. bold("2")
 		.. " spec file(s)"
 		.. "\n\n"
@@ -160,7 +160,7 @@ local function testBasicPassingTestCase()
 	assertEquals(numFailingTests, 0)
 
 	local reportString = bdd.getReport()
-	local expectedReportString = "Starting new test runner with a total of "
+	local expectedReportString = "Test runner started with a total of "
 		.. bold("1")
 		.. " spec file(s)"
 		.. "\n\n"
@@ -184,7 +184,7 @@ local function testBasicFailingTestCase()
 	assertEquals(numFailingTests, 1)
 
 	local reportString = bdd.getReport()
-	local expectedReportString = "Starting new test runner with a total of "
+	local expectedReportString = "Test runner started with a total of "
 		.. bold("1")
 		.. " spec file(s)"
 		.. "\n\n"


### PR DESCRIPTION
Since the output is buffered, anything printed during the test itself will be visible before the summary. It seems weird that the summary announces a test run is about to start when it's really already finished.