### PR TITLE
Update the changelog generation script (and changelog for v0.0.1)

### DIFF
--- a/changelog.lua
+++ b/changelog.lua
@@ -9,11 +9,11 @@ local changelog = {
 			"Embedded LuaJIT FFI bindings for webview, uws, and stduuid",
 			"Embedded Lua bindings for libuv, zlib, and openssl",
 			"Several extensions to the Lua standard libraries",
-			"High-level API namespace for file system access",
+			"High-level API namespaces for file system access and timer management",
 			"Lua library for UUID generation (via stduuid)",
 		},
 		breakingChanges = {
-			"This version of the runtime is completely backwards-incompatible with the previous (C-based) iteration, though many APIs are still the same",
+			"This version of the runtime is generally backwards-incompatible with the previous (C-based) iteration, though many APIs are still the same",
 		},
 	},
 	["v0.0.0"] = {

--- a/create-changelog.lua
+++ b/create-changelog.lua
@@ -1,4 +1,4 @@
-local versionFrom, versionTo = ...
+local versionFrom, versionTo = arg[1], arg[2]
 
 local C_BuildTools = require("BuildTools.NinjaBuildTools")
 


### PR DESCRIPTION
I noticed while generating a new changelog that the argv passing seems broken. I think it worked differently in evo-luvi due to how the scripts were executed (`load` vs `dofile`). Either way, this should now always work since evo uses the same `arg` global as LuaJIT (and PUC Lua), whereas evo-luvi used the same approach as luvi (and luvit, and NodeJS) - i.e., varargs/`process.argv`.