### PR TITLE
Eliminate dependencies on MINGW64 runtime DLLs from Windows builds

### DIFF
--- a/.github/scan-dll-deps.sh
+++ b/.github/scan-dll-deps.sh
@@ -1,0 +1,17 @@
+set -e
+
+echo "Scanning for unwanted DLL dependencies ..."
+objdump -p ninjabuild-windows/evo.exe | grep "DLL Name" > ninjabuild-windows/dlls.txt
+
+echo "Found DLL dependencies:"
+cat ninjabuild-windows/dlls.txt
+
+# Check for non-Windows DLLs that prevent standalone apps from running
+for lib in "libgcc" "libwinpthread" "libstdc++"; do
+  if grep -q "$lib" ninjabuild-windows/dlls.txt; then
+    echo "✗ Detected a dynamic dependency on $lib"
+    exit 1
+  fi
+done
+
+echo "✓ No undesirable DLL dependencies detected"

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Build runtime
         run: ls && ./windowsbuild.cmd && ls ninjabuild-windows && cp ninjabuild-windows/evo.exe . && ls
 
+      - name: Scan DLL dependencies
+        run: .github/scan-dll-deps.sh
+
       - name: Run smoke tests
         run: ./evo Tests/smoke-test.lua
 

--- a/ninjabuild.lua
+++ b/ninjabuild.lua
@@ -83,7 +83,7 @@ local EvoBuildTarget = {
 	},
 	sharedLibraries = (
 		isWindows
-			and "-l PSAPI -l USER32 -l ADVAPI32 -l IPHLPAPI -l USERENV -l WS2_32 -l GDI32 -l CRYPT32 -l SHELL32 -l OLE32 -l VERSION -l shlwapi"
+			and "-l PSAPI -l USER32 -l ADVAPI32 -l IPHLPAPI -l USERENV -l WS2_32 -l GDI32 -l CRYPT32 -l SHELL32 -l OLE32 -l VERSION -l shlwapi -static-libgcc -static-libstdc++ -static -lpthread"
 		or "-lm -ldl -pthread"
 			.. (
 				isMacOS and " -framework WebKit -framework CoreFoundation"


### PR DESCRIPTION
They prevent running the executable on systems that don't have MSYS2 installed, and also building standalone ("zip") apps.