### PR TITLE
Streamline the displayed OpenSSL version format

### DIFF
--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -108,11 +108,13 @@ end
 function evo.showVersionStrings(commandName, ...)
 	local versionText = format("This is Evo.lua %s (powered by %s)", EVO_VERSION, jit.version) .. "\n\n"
 
-	local luaOpensslVersionString, _, opensslVersionString = openssl.version()
+	-- Should use OPENSSL_VERSION_* defines here (not currently exposed via lua-openssl)
+	local _, _, opensslVersionString = openssl.version()
+	local sslVersion = opensslVersionString:match("OpenSSL%s(%d+%.%d+%.%d+)%s.*")
 
 	local embeddedLibraryVersions = {
 		libuv = uv.version_string(),
-		openssl = opensslVersionString .. "(via lua-openssl " .. luaOpensslVersionString .. ")",
+		openssl = sslVersion,
 		stduuid = stduuid.version(),
 		uws = uws.version(),
 		webview = webview.version(),


### PR DESCRIPTION
All other embedded library versions display only the version number, not the version of the bindings. OpenSSL stands out visually here, drawing undue attention to the line and generally breaking the flow of the version command's output. Maybe it's OCD but I'd prefer the output to be consistent.

Unfortunately, there is no way to read the OPENSSL_VERSION_* constants to derive only the version and I don't want to hijack the bindings code from C++. Maybe that can be upstreamed at some point, but for now just extracting it from the final string should suffice (assuming the format doesn't change).