### PR TITLE
Simplify the version command output

### DIFF
--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -88,7 +88,7 @@ end
 
 function evo.setUpCommandLineInterface()
 	C_CommandLine.RegisterCommand("help", evo.displayHelpText, "Display usage instructions (this text)")
-	C_CommandLine.RegisterCommand("version", evo.showVersionStrings, "Show versioning information")
+	C_CommandLine.RegisterCommand("version", evo.displayRuntimeVersion, "Show versioning information only")
 	C_CommandLine.RegisterCommand("eval", evo.evaluateChunk, "Evaluate the next token as a Lua chunk")
 	C_CommandLine.SetDefaultHandler(evo.onInvalidCommand)
 end
@@ -105,6 +105,10 @@ Commands:
 	)
 	print(helpText)
 	evo.showVersionStrings()
+end
+
+function evo.displayRuntimeVersion(commandName, ...)
+	print(EVO_VERSION)
 end
 
 function evo.showVersionStrings(commandName, ...)


### PR DESCRIPTION
There's no point in duplicating the verbose version info here. This way, at least it can be used in CI runs or for other shell scripts.