### PR TITLE
Update the LuaJIT build script to patch bcsave on MSYS2

### DIFF
--- a/deps/luajit-windowsbuild.sh
+++ b/deps/luajit-windowsbuild.sh
@@ -23,3 +23,6 @@ $BUILD_DIR/luajit.exe -e "print(\"Hello from LuaJIT! (This is a test and can be 
 
 # This is needed to save bytecode via luajit -b since the jit module isn't embedded inside the executable
 cp $LUAJIT_SOURCE_DIR/jit/* $BUILD_DIR/jit
+
+# This patch fixes the 'corrupt .drectve' warnings in MSYS2, but breaks MSVC (which isn't supported anyway)
+sed -i 's/\/EXPORT:/-export:/g' $BUILD_DIR/jit/bcsave.lua


### PR DESCRIPTION
Embedding symbols in the wrong format just causes a warning to be emitted before the info is stripped by the linker, but it's pretty annoying as the output clutters the console window.

Changing the format only affects MSVC, which isn't a supported toolchain on Windows (and likely won't be anytime soon), so let's get it over with. It's also trivially easy to revert if push comes to shove.