### PR TITLE
Fix an error in the submodule status checker script

### DIFF
--- a/scan-submodules.lua
+++ b/scan-submodules.lua
@@ -99,7 +99,7 @@ function SubmoduleUpdateChecker:GetUpdatedSubmoduleStatus()
 
 	for _, line in ipairs(lines) do
 		local checkedOutCommitHash, submodulePath, checkedOutVersionTag =
-			string_match(line, "%s([0-9a-z]+).*(deps/%S+).*%((.*)%)")
+			string_match(line, "%s?[%+%-U]?([0-9a-z]+).*(deps/%S+).*%((.*)%)")
 
 		local branch = nonstandardBranches[submodulePath] or "master"
 		printf("Fetching changes from %s for submodule %s ...", bold("origin/" .. branch), bold(submodulePath))


### PR DESCRIPTION
When new changes are present (as well as in some other cases), the output of git submodule status includes a prefix before the commit hash (and place of the usual whitespace).

This change ensures that the script can deal with the situation.