### PR TITLE
Fix the displayed json library version in the CLI help text

### DIFF
--- a/Runtime/Bindings/rapidjson.hpp
+++ b/Runtime/Bindings/rapidjson.hpp
@@ -241,6 +241,11 @@ static int json_encode_custom(lua_State* L) {
 	return 0;
 }
 
+int json_get_version_string(lua_State* L) {
+	lua_pushstring(L, RAPIDJSON_VERSION_STRING);
+	return 1;
+}
+
 //  Intendation with four spaces is hardcoded in lua-rapidjson, but tabs are objectively superior (and less wasteful)
 extern "C" {
 int luaopen_rapidjson_modified(lua_State* L) {
@@ -251,6 +256,9 @@ int luaopen_rapidjson_modified(lua_State* L) {
 
 	lua_pushcfunction(L, json_encode_custom);
 	lua_setfield(L, -2, "encode");
+
+	lua_pushcfunction(L, json_get_version_string);
+	lua_setfield(L, -2, "version");
 
 	return success;
 }

--- a/Runtime/Extensions/jsonx.lua
+++ b/Runtime/Extensions/jsonx.lua
@@ -2,11 +2,6 @@ local json = require("json")
 
 local json_decode = json.decode
 local json_encode = json.encode
-local string_match = string.match
-
-function json.version()
-	return string_match(json._VERSION, "v(%d+.%d+.%d+)") -- Strip the leading v
-end
 
 function json.parse(jsonString)
 	return json_decode(jsonString)

--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -120,7 +120,7 @@ function evo.showVersionStrings(commandName, ...)
 
 	local embeddedLibraryVersions = {
 		libuv = uv.version_string(),
-		json = json.version(),
+		rapidjson = json.version(),
 		openssl = sslVersion,
 		stduuid = stduuid.version(),
 		uws = uws.version(),

--- a/Tests/BDD/evo-library.spec.lua
+++ b/Tests/BDD/evo-library.spec.lua
@@ -20,7 +20,7 @@ describe("evo", function()
 			local hasEngineVersion = (engineVersion ~= nil)
 			local hasEmbeddedLibraryVersions = {
 				libuv = (capturedOutput:match("libuv" .. WHITESPACE .. VERSION_PATTERN) ~= nil),
-				json = (capturedOutput:match("json" .. WHITESPACE .. VERSION_PATTERN) ~= nil),
+				rapidjson = (capturedOutput:match("rapidjson" .. WHITESPACE .. VERSION_PATTERN) ~= nil),
 				openssl = (capturedOutput:match("openssl" .. WHITESPACE .. VERSION_PATTERN) ~= nil),
 				stduuid = (capturedOutput:match("stduuid" .. WHITESPACE .. VERSION_PATTERN) ~= nil),
 				uws = (capturedOutput:match("uws" .. WHITESPACE .. VERSION_PATTERN) ~= nil),
@@ -32,7 +32,7 @@ describe("evo", function()
 			assertTrue(hasRuntimeVersion)
 			assertTrue(hasEngineVersion)
 			assertTrue(hasEmbeddedLibraryVersions.libuv)
-			assertTrue(hasEmbeddedLibraryVersions.json)
+			assertTrue(hasEmbeddedLibraryVersions.rapidjson)
 			assertTrue(hasEmbeddedLibraryVersions.openssl)
 			assertTrue(hasEmbeddedLibraryVersions.stduuid)
 			assertTrue(hasEmbeddedLibraryVersions.uws)


### PR DESCRIPTION
It was the version of the bindings, which is inconsistent with how other libraries are displayed (e.g., luv or lua-openssl).