### PR TITLE
Update the CodeQL workflow to only run when scheduled

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,11 +1,6 @@
 name: Semantic Analysis
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
   schedule:
     - cron: '00 00 * * 6'
 


### PR DESCRIPTION
  It seems I misunderstood how the action works: Instead of failing when alerts are found, it instead (silently....) "reports" them in the security tab. It also detects a lot of "non-issues" in dependencies such as LuaJIT, OpenSSL, or libuv.
  
  Since this effectively renders running it on every PR useless and the workflow takes significant time (as it has to rebuild the entire runtime), there's zero point in wasting resources here. It should just run once per week in the background instead.