### PR TITLE
Rename API parameters for consistency with the docs

### DIFF
--- a/Runtime/API/C_FileSystem.lua
+++ b/Runtime/API/C_FileSystem.lua
@@ -4,12 +4,12 @@ local path_join = path.join
 
 local C_FileSystem = {}
 
-function C_FileSystem.Exists(path)
-	return uv.fs_access(path, "R")
+function C_FileSystem.Exists(fileSystemPath)
+	return uv.fs_access(fileSystemPath, "R")
 end
 
-function C_FileSystem.IsFile(path)
-	local fileAttributes = uv.fs_stat(path)
+function C_FileSystem.IsFile(fileSystemPath)
+	local fileAttributes = uv.fs_stat(fileSystemPath)
 	if not fileAttributes then
 		return false
 	end
@@ -17,8 +17,8 @@ function C_FileSystem.IsFile(path)
 	return fileAttributes.type == "file"
 end
 
-function C_FileSystem.IsDirectory(path)
-	local fileAttributes = uv.fs_stat(path)
+function C_FileSystem.IsDirectory(fileSystemPath)
+	local fileAttributes = uv.fs_stat(fileSystemPath)
 	if not fileAttributes then
 		return false
 	end
@@ -26,28 +26,28 @@ function C_FileSystem.IsDirectory(path)
 	return fileAttributes.type == "directory"
 end
 
-function C_FileSystem.Delete(path)
-	if not C_FileSystem.Exists(path) then
+function C_FileSystem.Delete(fileSystemPath)
+	if not C_FileSystem.Exists(fileSystemPath) then
 		return true
 	end
 
-	if C_FileSystem.IsDirectory(path) then
-		return uv.fs_rmdir(path)
+	if C_FileSystem.IsDirectory(fileSystemPath) then
+		return uv.fs_rmdir(fileSystemPath)
 	end
 
-	return uv.fs_unlink(path)
+	return uv.fs_unlink(fileSystemPath)
 end
 
-function C_FileSystem.MakeDirectory(path)
-	if C_FileSystem.Exists(path) then
+function C_FileSystem.MakeDirectory(directoryPath)
+	if C_FileSystem.Exists(directoryPath) then
 		return false
 	end
 
-	return uv.fs_mkdir(path, 511)
+	return uv.fs_mkdir(directoryPath, 511)
 end
 
-function C_FileSystem.MakeDirectoryTree(path)
-	local parent = path_join(path, "..")
+function C_FileSystem.MakeDirectoryTree(directoryPath)
+	local parent = path_join(directoryPath, "..")
 	if not C_FileSystem.Exists(parent) then
 		local status, error = C_FileSystem.MakeDirectoryTree(parent)
 		if not status then
@@ -55,15 +55,15 @@ function C_FileSystem.MakeDirectoryTree(path)
 		end
 	end
 
-	if C_FileSystem.Exists(path) then
-		if C_FileSystem.IsDirectory(path) then
+	if C_FileSystem.Exists(directoryPath) then
+		if C_FileSystem.IsDirectory(directoryPath) then
 			return true
 		else
 			return false, "Path exists but is not a directory"
 		end
 	end
 
-	local status, error = uv.fs_mkdir(path, 511)
+	local status, error = uv.fs_mkdir(directoryPath, 511)
 	if not status then
 		return false, error
 	end
@@ -71,9 +71,9 @@ function C_FileSystem.MakeDirectoryTree(path)
 	return true
 end
 
-function C_FileSystem.ReadFile(path)
+function C_FileSystem.ReadFile(filePath)
 	local fileDescriptor, fileAttributes, fileContents, errorMessage
-	fileDescriptor, errorMessage = uv.fs_open(path, "r", 438)
+	fileDescriptor, errorMessage = uv.fs_open(filePath, "r", 438)
 
 	if not fileDescriptor then -- Nothing to close
 		error(errorMessage, 0)
@@ -128,8 +128,8 @@ function C_FileSystem.ReadDirectory(path, isRecursiveMode)
 	return directoryContents
 end
 
-function C_FileSystem.WriteFile(path, contents)
-	local fileDescriptor, errorMessage = uv.fs_open(path, "w", 438)
+function C_FileSystem.WriteFile(filePath, contents)
+	local fileDescriptor, errorMessage = uv.fs_open(filePath, "w", 438)
 	if not fileDescriptor then
 		error(errorMessage, 0)
 	end
@@ -140,8 +140,8 @@ function C_FileSystem.WriteFile(path, contents)
 	return true
 end
 
-function C_FileSystem.AppendFile(path, contents)
-	local fileDescriptor, errorMessage = uv.fs_open(path, "a", 438)
+function C_FileSystem.AppendFile(filePath, contents)
+	local fileDescriptor, errorMessage = uv.fs_open(filePath, "a", 438)
 	if not fileDescriptor then
 		error(errorMessage, 0)
 	end

--- a/Runtime/API/C_WebView.lua
+++ b/Runtime/API/C_WebView.lua
@@ -48,12 +48,12 @@ function C_WebView.Destroy()
 	self.pollingUpdateTimer:stop()
 end
 
-function C_WebView.SetWindowTitle(title)
-	webview.bindings.webview_set_title(self.nativeWindow, title)
+function C_WebView.SetWindowTitle(newWindowTitle)
+	webview.bindings.webview_set_title(self.nativeWindow, newWindowTitle)
 end
 
-function C_WebView.SetWindowSize(width, height)
-	webview.bindings.webview_set_size(self.nativeWindow, width, height, 0)
+function C_WebView.SetWindowSize(newWidthInPixels, newHeightInPixels)
+	webview.bindings.webview_set_size(self.nativeWindow, newWidthInPixels, newHeightInPixels, 0)
 end
 
 function C_WebView.NavigateToURL(url)

--- a/Runtime/Extensions/stringx.lua
+++ b/Runtime/Extensions/stringx.lua
@@ -69,19 +69,19 @@ function string.explode(inputString, delimiter)
 	return tokens
 end
 
-function string.filesize(size)
-	if size <= 0 then -- Negative file sizes don't make any sense
+function string.filesize(fileSizeInBytes)
+	if fileSizeInBytes <= 0 then -- Negative file sizes don't make any sense
 		return "0 bytes"
 	end
 
 	local units = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" }
-	local digitGroup = math_floor(math_log10(size) / math_log10(1024))
+	local digitGroup = math_floor(math_log10(fileSizeInBytes) / math_log10(1024))
 
 	if digitGroup == 0 then
-		return size .. " bytes"
+		return fileSizeInBytes .. " bytes"
 	elseif digitGroup == 1 then
-		return format("%d %s", size / math_pow(1024, digitGroup), units[digitGroup + 1])
+		return format("%d %s", fileSizeInBytes / math_pow(1024, digitGroup), units[digitGroup + 1])
 	else
-		return format("%.2f %s", size / math_pow(1024, digitGroup), units[digitGroup + 1])
+		return format("%.2f %s", fileSizeInBytes / math_pow(1024, digitGroup), units[digitGroup + 1])
 	end
 end


### PR DESCRIPTION
I elected to use more specific names in the docs. This just brings the code in line with the names listed there.