### PR TITLE
Eliminate the isRecursiveMode flag of ReadDirectory by introducing ReadDirectoryTree

### DIFF
--- a/Runtime/API/C_FileSystem.lua
+++ b/Runtime/API/C_FileSystem.lua
@@ -96,8 +96,8 @@ function C_FileSystem.ReadFile(filePath)
 	return fileContents
 end
 
-function C_FileSystem.ReadDirectory(path, isRecursiveMode)
-	local libuvFileSystemRequest, errorMessage = uv.fs_scandir(path)
+local function readDirectory(filePath, isRecursiveMode)
+	local libuvFileSystemRequest, errorMessage = uv.fs_scandir(filePath)
 
 	if not libuvFileSystemRequest then
 		error(errorMessage, 0)
@@ -112,9 +112,10 @@ function C_FileSystem.ReadDirectory(path, isRecursiveMode)
 		end
 
 		local canWalkRecursively = (type == "directory")
-		local absolutePath = path_join(path, name)
+		local absolutePath = path_join(filePath, name)
 		if canWalkRecursively and isRecursiveMode then
-			local files = C_FileSystem.ReadDirectory(absolutePath, isRecursiveMode)
+			local files = isRecursiveMode and C_FileSystem.ReadDirectoryTree(absolutePath)
+				or C_FileSystem.ReadDirectory(absolutePath)
 			for key, value in pairs(files) do
 				directoryContents[key] = value
 			end
@@ -126,6 +127,14 @@ function C_FileSystem.ReadDirectory(path, isRecursiveMode)
 	end
 
 	return directoryContents
+end
+
+function C_FileSystem.ReadDirectory(filePath)
+	return readDirectory(filePath, false)
+end
+
+function C_FileSystem.ReadDirectoryTree(filePath)
+	return readDirectory(filePath, true)
 end
 
 function C_FileSystem.WriteFile(filePath, contents)

--- a/Tests/BDD/filesystem-namespace.spec.lua
+++ b/Tests/BDD/filesystem-namespace.spec.lua
@@ -108,42 +108,38 @@ describe("C_FileSystem", function()
 			end, "ENOENT: no such file or directory: " .. invalidPath)
 		end)
 
-		it(
-			"should return the absolute paths of files in all subdirectories if the isRecursiveMode flag is set to true",
-			function()
-				local contents = C_FileSystem.ReadDirectory(validDirectoryPath, true)
-				assertEquals(contents, {
-					[path.join(validDirectoryPath, "empty.txt")] = true,
-					[path.join(validDirectoryPath, "somefile.txt")] = true,
-					[path.join(validDirectoryPath, "Subdir1", "Subdir2", "hello.txt")] = true,
-					[path.join(validDirectoryPath, "Subdir1", "test.txt")] = true,
-				})
-			end
-		)
+		it("should return the relative paths of files in the root directory", function()
+			local contents = C_FileSystem.ReadDirectory(validDirectoryPath, false)
+			assertEquals(contents, {
+				["empty.txt"] = true,
+				["somefile.txt"] = true,
+				["Subdir1"] = true,
+			})
+		end)
+	end)
 
-		it(
-			"should return the relative paths of files in the root directory if the isRecursiveMode flag is set to false",
-			function()
-				local contents = C_FileSystem.ReadDirectory(validDirectoryPath, false)
-				assertEquals(contents, {
-					["empty.txt"] = true,
-					["somefile.txt"] = true,
-					["Subdir1"] = true,
-				})
-			end
-		)
+	describe("ReadDirectoryTree", function()
+		it("should raise an error if the path given refers to a file on disk", function()
+			assertThrows(function()
+				C_FileSystem.ReadDirectoryTree(validFilePath)
+			end, "ENOTDIR: not a directory: " .. validFilePath)
+		end)
 
-		it(
-			"should return the relative paths of files in the root directory if the isRecursiveMode flag is omitted",
-			function()
-				local contents = C_FileSystem.ReadDirectory(validDirectoryPath)
-				assertEquals(contents, {
-					["empty.txt"] = true,
-					["somefile.txt"] = true,
-					["Subdir1"] = true,
-				})
-			end
-		)
+		it("should raise an error if an invalid path was passed", function()
+			assertThrows(function()
+				C_FileSystem.ReadDirectoryTree(invalidPath)
+			end, "ENOENT: no such file or directory: " .. invalidPath)
+		end)
+
+		it("should return the absolute paths of files in all subdirectories", function()
+			local contents = C_FileSystem.ReadDirectoryTree(validDirectoryPath)
+			assertEquals(contents, {
+				[path.join(validDirectoryPath, "empty.txt")] = true,
+				[path.join(validDirectoryPath, "somefile.txt")] = true,
+				[path.join(validDirectoryPath, "Subdir1", "Subdir2", "hello.txt")] = true,
+				[path.join(validDirectoryPath, "Subdir1", "test.txt")] = true,
+			})
+		end)
 	end)
 
 	describe("ReadFile", function()


### PR DESCRIPTION
Since there's now `MakeDirectory` and `MakeDirectoryTree`, it seems only fitting.