### PR TITLE
Add -Wfatal-errors to the build configuration

### DIFF
--- a/BuildTools/NinjaBuildTools.lua
+++ b/BuildTools/NinjaBuildTools.lua
@@ -11,7 +11,7 @@ local C_BuildTools = {
 	GCC_COMPILATION_SETTINGS = {
 		displayName = "GNU Compiler Collection",
 		CPP_COMPILER = "g++",
-		COMPILER_FLAGS = "-O2 -DNDEBUG -g -std=c++20 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -fvisibility=hidden -fno-strict-aliasing -fdiagnostics-color",
+		COMPILER_FLAGS = "-O2 -DNDEBUG -g -std=c++20 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -fvisibility=hidden -fno-strict-aliasing -fdiagnostics-color -Wfatal-errors",
 		CPP_LINKER = "g++",
 		-- Must export the entry point of bytecode objects so that LuaJIT can load them via require()
 		LINKER_FLAGS = isWindows and "-Wl,--export-all-symbols" or "-rdynamic",


### PR DESCRIPTION
It doesn't seem very useful to spam the console with errors.