### PR TITLE
Add a new pixel recoloring method to the stbi library API

### DIFF
--- a/Runtime/Bindings/stbi.lua
+++ b/Runtime/Bindings/stbi.lua
@@ -46,6 +46,14 @@ stbi.cdefs = [[
 		size_t (*stbi_encode_jpg)(stbi_image_t* image, uint8_t* buffer, const size_t buffer_size, int quality);
 		size_t (*stbi_encode_tga)(stbi_image_t* image, uint8_t* buffer, const size_t buffer_size);
 	};
+
+	// This may be moved to C later if needed, but for now it's Lua only
+	typedef struct {
+		uint8_t red;
+		uint8_t green;
+		uint8_t blue;
+		uint8_t alpha;
+	} stbi_color_t;
 ]]
 
 function stbi.initialize()
@@ -73,6 +81,24 @@ function stbi.max_bitmap_size(width, height, channels)
 
 	-- JPEG-encoded sections add significant overhead if the image is small, so let's account for that
 	return math_max(estimatedWorstCaseBitmapFileSize, JPEG_OVERHEAD_BUFFER_SIZE)
+end
+
+function stbi.replace_pixel_color_rgba(image, sourceColor, replacementColor)
+	local pixelCount = image.width * image.height
+	local pixelBuffer = ffi.cast("stbi_color_t*", image.data)
+
+	for i = 0, pixelCount - 1 do
+		local pixel = pixelBuffer[i]
+
+		if
+			pixel.red == sourceColor.red
+			and pixel.green == sourceColor.green
+			and pixel.blue == sourceColor.blue
+			and pixel.alpha == sourceColor.alpha
+		then
+			pixelBuffer[i] = replacementColor
+		end
+	end
 end
 
 return stbi

--- a/Tests/BDD/stbi-library.spec.lua
+++ b/Tests/BDD/stbi-library.spec.lua
@@ -729,6 +729,50 @@ describe("stbi", function()
 		end)
 	end)
 
+	describe("replace_pixel_color_rgba", function()
+		it("should replace all pixels of the given color", function()
+			local image = ffi.new("stbi_image_t")
+			local originaBitmapContents = C_FileSystem.ReadFile(path.join(FIXTURES_DIR, "8bpp-image-without-alpha.bmp"))
+			stbi.bindings.stbi_load_rgba(originaBitmapContents, #originaBitmapContents, image)
+
+			local sourceColor = ffi.new("stbi_color_t", { 0, 0, 255, 255 })
+			local replacementColor = ffi.new("stbi_color_t", { 255, 0, 0, 255 })
+			stbi.replace_pixel_color_rgba(image, sourceColor, replacementColor)
+
+			local expectedPixels = {
+				255,
+				0,
+				0,
+				255,
+				255,
+				0,
+				0,
+				255,
+				255,
+				0,
+				0,
+				255,
+				255,
+				0,
+				0,
+				255,
+				255,
+				0,
+				0,
+				255,
+				255,
+				0,
+				0,
+				255,
+			}
+
+			local BYTES_PER_PIXEL = 4 -- RGBA
+			for i = 0, image.width * image.height * BYTES_PER_PIXEL - 1 do
+				assertEquals(image.data[i], expectedPixels[i + 1])
+			end
+		end)
+	end)
+
 	describe("version", function()
 		it("should be a semantic version string", function()
 			local versionString = stbi.version()


### PR DESCRIPTION
Only RGBA for now since that's the most useful format (to me, anyway) and images can be loaded as RGBA if another input format needs to be processed. Somewhat experimental, so that's also why I don't want to bother adding more methods for the other formats just yet.