### PR TITLE
Allow passing individual files to the unit test script

### DIFF
--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -23,6 +23,6 @@ local specFiles = {
 	"Tests/BDD/timer-namespace.spec.lua",
 }
 
-local numFailedSections = C_Runtime.RunDetailedTests(specFiles)
+local numFailedSections = C_Runtime.RunDetailedTests(#arg > 0 and arg or specFiles)
 
 os.exit(numFailedSections)


### PR DESCRIPTION
This just makes local development a bit easier, for essentially zero cost.

A similar approach could be used for the other test scripts, but since there aren't as many I haven't bothered changing them yet.