### PR TITLE
Add support for WebGPU surfaces to the GLFW bindings

### DIFF
--- a/BuildTools/NinjaBuildTools.lua
+++ b/BuildTools/NinjaBuildTools.lua
@@ -1,6 +1,7 @@
 local ffi = require("ffi")
 
 local isWindows = (ffi.os == "Windows")
+local isMacOS = (ffi.os == "OSX")
 
 local C_BuildTools = {
 	OBJECT_FILE_EXTENSION = (isWindows and "obj" or "o"),
@@ -11,7 +12,8 @@ local C_BuildTools = {
 	GCC_COMPILATION_SETTINGS = {
 		displayName = "GNU Compiler Collection",
 		CPP_COMPILER = "g++",
-		COMPILER_FLAGS = "-O2 -DNDEBUG -g -std=c++20 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -fvisibility=hidden -fno-strict-aliasing -fdiagnostics-color -Wfatal-errors",
+		COMPILER_FLAGS = "-O2 -DNDEBUG -g -std=c++20 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -fvisibility=hidden -fno-strict-aliasing -fdiagnostics-color -Wfatal-errors"
+			.. (isMacOS and " -ObjC++" or ""), -- Forced Objc++ should be removed once glfw3webgpu is merged into the GLFW core library... until then, it's a necessary evil
 		CPP_LINKER = "g++",
 		-- Must export the entry point of bytecode objects so that LuaJIT can load them via require()
 		LINKER_FLAGS = isWindows and "-Wl,--export-all-symbols" or "-rdynamic",

--- a/Runtime/Bindings/glfw.lua
+++ b/Runtime/Bindings/glfw.lua
@@ -17,9 +17,15 @@ glfw.cdefs = [[
 	typedef struct GLFWmonitor GLFWmonitor;
 	typedef void* deferred_event_queue_t;
 
+	// These are passed to WebGPU, but the internals aren't exposed
+	typedef void* WGPUSurface;
+	typedef void* WGPUInstance;
+
 	struct static_glfw_exports_table {
 		const char* (*glfw_version)(void);
 		int (*glfw_find_constant)(const char* name);
+
+		WGPUSurface (*glfw_get_wgpu_surface)(WGPUInstance instance, GLFWwindow* window);
 
 		int (*glfw_init)(void);
 		void (*glfw_terminate)(void);

--- a/Runtime/Bindings/glfw.lua
+++ b/Runtime/Bindings/glfw.lua
@@ -28,6 +28,7 @@ glfw.cdefs = [[
 		GLFWwindow* (*glfw_create_window)(int width, int height, const char* title, GLFWmonitor* monitor, GLFWwindow* share);
 		void (*glfw_destroy_window)(GLFWwindow* window);
 		int (*glfw_window_should_close)(GLFWwindow* window);
+		void (*glfw_window_hint)(int hint, int value);
 
 		void (*glfw_register_events)(GLFWwindow* window, deferred_event_queue_t queue);
 

--- a/Runtime/Bindings/glfw_ffi.cpp
+++ b/Runtime/Bindings/glfw_ffi.cpp
@@ -235,6 +235,7 @@ namespace glfw_ffi {
 		glfw_exports_table.glfw_create_window = glfwCreateWindow;
 		glfw_exports_table.glfw_destroy_window = glfwDestroyWindow;
 		glfw_exports_table.glfw_window_should_close = glfwWindowShouldClose;
+		glfw_exports_table.glfw_window_hint = glfwWindowHint;
 
 		glfw_exports_table.glfw_register_events = glfw_register_events;
 

--- a/Runtime/Bindings/glfw_ffi.cpp
+++ b/Runtime/Bindings/glfw_ffi.cpp
@@ -1,6 +1,9 @@
 #include "glfw_ffi.hpp"
 #include "interop_ffi.hpp"
 
+#include <glfw3webgpu.h>
+#include <glfw3webgpu.c>
+
 #include <string>
 
 const char* glfw_version() {
@@ -227,6 +230,8 @@ namespace glfw_ffi {
 
 		glfw_exports_table.glfw_version = glfw_version;
 		glfw_exports_table.glfw_find_constant = glfw_find_constant;
+
+		glfw_exports_table.glfw_get_wgpu_surface = glfwGetWGPUSurface;
 
 		glfw_exports_table.glfw_init = glfwInit;
 		glfw_exports_table.glfw_terminate = glfwTerminate;

--- a/Runtime/Bindings/glfw_ffi.hpp
+++ b/Runtime/Bindings/glfw_ffi.hpp
@@ -2,6 +2,7 @@
 
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
+#include <webgpu.h>
 
 #include "glfw_constants.hpp"
 #include "interop_ffi.hpp"
@@ -28,6 +29,8 @@ void glfw_set_character_input_callback(GLFWwindow* window, std::queue<deferred_e
 struct static_glfw_exports_table {
 	const char* (*glfw_version)(void);
 	int (*glfw_find_constant)(const char* name);
+
+	WGPUSurface (*glfw_get_wgpu_surface)(WGPUInstance instance, GLFWwindow* window);
 
 	int (*glfw_init)(void);
 	void (*glfw_terminate)(void);

--- a/Runtime/Bindings/glfw_ffi.hpp
+++ b/Runtime/Bindings/glfw_ffi.hpp
@@ -36,6 +36,7 @@ struct static_glfw_exports_table {
 	GLFWwindow* (*glfw_create_window)(int width, int height, const char* title, GLFWmonitor* monitor, GLFWwindow* share);
 	void (*glfw_destroy_window)(GLFWwindow* window);
 	int (*glfw_window_should_close)(GLFWwindow* window);
+	void (*glfw_window_hint)(int hint, int value);
 
 	void (*glfw_register_events)(GLFWwindow* window, deferred_event_queue_t queue);
 

--- a/Tests/BDD/glfw-library.spec.lua
+++ b/Tests/BDD/glfw-library.spec.lua
@@ -12,6 +12,7 @@ describe("glfw", function()
 				"glfw_create_window",
 				"glfw_destroy_window",
 				"glfw_window_should_close",
+				"glfw_window_hint",
 				"glfw_register_events",
 				"glfw_get_primary_monitor",
 				"glfw_get_monitors",

--- a/Tests/BDD/glfw-library.spec.lua
+++ b/Tests/BDD/glfw-library.spec.lua
@@ -6,6 +6,7 @@ describe("glfw", function()
 			local exportedApiSurface = {
 				"glfw_version",
 				"glfw_find_constant",
+				"glfw_get_wgpu_surface",
 				"glfw_init",
 				"glfw_terminate",
 				"glfw_poll_events",

--- a/Tests/Integration/glfw-webgpu-surface.lua
+++ b/Tests/Integration/glfw-webgpu-surface.lua
@@ -1,0 +1,95 @@
+local ffi = require("ffi")
+local glfw = require("glfw")
+local webgpu = require("webgpu")
+
+local instanceDescriptor = ffi.new("WGPUInstanceDescriptor")
+local instance = webgpu.bindings.wgpu_create_instance(instanceDescriptor)
+if not instance then
+	error("Could not initialize WebGPU!")
+end
+
+if not glfw.bindings.glfw_init() then
+	error("Could not initialize GLFW")
+end
+
+local GLFW_CLIENT_API = glfw.bindings.glfw_find_constant("GLFW_CLIENT_API")
+local GLFW_NO_API = glfw.bindings.glfw_find_constant("GLFW_NO_API")
+glfw.bindings.glfw_window_hint(GLFW_CLIENT_API, GLFW_NO_API)
+
+local window = glfw.bindings.glfw_create_window(640, 480, "WebGPU Surface Test", nil, nil)
+assert(window, "Failed to create window")
+
+print("Requesting adapter...")
+local surface = glfw.bindings.glfw_get_wgpu_surface(instance, window)
+assert(surface, "Failed to create WebGPU surface")
+
+local adapterOpts = ffi.new("WGPURequestAdapterOptions")
+adapterOpts.compatibleSurface = surface
+
+local requestedAdapter
+local function onAdapterRequested(status, adapter, message, pUserData)
+	print("onAdapterRequested", status, adapter, message, pUserData)
+	assert(status == ffi.C.WGPURequestAdapterStatus_Success, "Failed to request adapter")
+	requestedAdapter = adapter
+end
+webgpu.bindings.wgpu_instance_request_adapter(instance, adapterOpts, onAdapterRequested, nil)
+print("Got adapter: ", requestedAdapter)
+
+local function inspectAdapter(adapter)
+	local featureCount = webgpu.bindings.wgpu_adapter_enumerate_features(adapter, nil)
+	local features = ffi.new("WGPUFeatureName[?]", featureCount)
+	webgpu.bindings.wgpu_adapter_enumerate_features(adapter, features)
+
+	print("Adapter features:")
+	for index = 0, tonumber(featureCount) - 1 do
+		local feature = features[index]
+		print(index + 1, feature)
+	end
+
+	local limits = ffi.new("WGPUSupportedLimits")
+	local success = webgpu.bindings.wgpu_adapter_get_limits(adapter, limits)
+	assert(success, "Failed to get adapter limits")
+
+	print("Adapter limits:")
+	print("\tmaxTextureDimension1D: ", limits.limits.maxTextureDimension1D)
+	print("\tmaxTextureDimension2D: ", limits.limits.maxTextureDimension2D)
+	print("\tmaxTextureDimension3D: ", limits.limits.maxTextureDimension3D)
+	print("\tmaxTextureArrayLayers: ", limits.limits.maxTextureArrayLayers)
+	print("\tmaxBindGroups: ", limits.limits.maxBindGroups)
+	print("\tmaxDynamicUniformBuffersPerPipelineLayout: ", limits.limits.maxDynamicUniformBuffersPerPipelineLayout)
+	print("\tmaxDynamicStorageBuffersPerPipelineLayout: ", limits.limits.maxDynamicStorageBuffersPerPipelineLayout)
+	print("\tmaxSampledTexturesPerShaderStage: ", limits.limits.maxSampledTexturesPerShaderStage)
+	print("\tmaxSamplersPerShaderStage: ", limits.limits.maxSamplersPerShaderStage)
+	print("\tmaxStorageBuffersPerShaderStage: ", limits.limits.maxStorageBuffersPerShaderStage)
+	print("\tmaxStorageTexturesPerShaderStage: ", limits.limits.maxStorageTexturesPerShaderStage)
+	print("\tmaxUniformBuffersPerShaderStage: ", limits.limits.maxUniformBuffersPerShaderStage)
+	print("\tmaxUniformBufferBindingSize: ", limits.limits.maxUniformBufferBindingSize)
+	print("\tmaxStorageBufferBindingSize: ", limits.limits.maxStorageBufferBindingSize)
+	print("\tminUniformBufferOffsetAlignment: ", limits.limits.minUniformBufferOffsetAlignment)
+	print("\tminStorageBufferOffsetAlignment: ", limits.limits.minStorageBufferOffsetAlignment)
+	print("\tmaxVertexBuffers: ", limits.limits.maxVertexBuffers)
+	print("\tmaxVertexAttributes: ", limits.limits.maxVertexAttributes)
+	print("\tmaxVertexBufferArrayStride: ", limits.limits.maxVertexBufferArrayStride)
+	print("\tmaxInterStageShaderComponents: ", limits.limits.maxInterStageShaderComponents)
+	print("\tmaxComputeWorkgroupStorageSize: ", limits.limits.maxComputeWorkgroupStorageSize)
+	print("\tmaxComputeInvocationsPerWorkgroup: ", limits.limits.maxComputeInvocationsPerWorkgroup)
+	print("\tmaxComputeWorkgroupSizeX: ", limits.limits.maxComputeWorkgroupSizeX)
+	print("\tmaxComputeWorkgroupSizeY: ", limits.limits.maxComputeWorkgroupSizeY)
+	print("\tmaxComputeWorkgroupSizeZ: ", limits.limits.maxComputeWorkgroupSizeZ)
+	print("\tmaxComputeWorkgroupsPerDimension: ", limits.limits.maxComputeWorkgroupsPerDimension)
+
+	local properties = ffi.new("WGPUAdapterProperties")
+	webgpu.bindings.wgpu_adapter_get_properties(adapter, properties)
+
+	print("Adapter properties:")
+	print("\tvendorID: ", properties.vendorID)
+	print("\tdeviceID: ", properties.deviceID)
+	print("\tname: ", ffi.string(properties.name))
+	if properties.driverDescription then
+		print("\tdriverDescription: ", ffi.string(properties.driverDescription))
+	end
+	print("\tadapterType: ", properties.adapterType)
+	print("\tbackendType: ", properties.backendType)
+end
+
+inspectAdapter(requestedAdapter)

--- a/Tests/Integration/glfw-webgpu-surface.lua
+++ b/Tests/Integration/glfw-webgpu-surface.lua
@@ -2,6 +2,15 @@ local ffi = require("ffi")
 local glfw = require("glfw")
 local webgpu = require("webgpu")
 
+local isWindows = (ffi.os == "Windows")
+if not isWindows then
+	local transform = require("transform")
+	-- GitHub's Unix runners can't request adapters (might not have a "real" GPU or at least it isn't exposed)
+	-- On OSX, the issue is, presumably, that WebView and GLFW both try to manage the shared app delegate
+	print(transform.yellow("Skipping WebGPU/GLFW surface test (currently only works on Windows runners)"))
+	return
+end
+
 local instanceDescriptor = ffi.new("WGPUInstanceDescriptor")
 local instance = webgpu.bindings.wgpu_create_instance(instanceDescriptor)
 if not instance then

--- a/Tests/integration-test.lua
+++ b/Tests/integration-test.lua
@@ -4,6 +4,7 @@ local testFiles = {
 	"Tests/Integration/websocket-echo-server.lua",
 	"Tests/Integration/websocket-event-queue.lua",
 	"Tests/Integration/websocket-messaging.lua",
+	"Tests/Integration/glfw-webgpu-surface.lua",
 	"Tests/Integration/glfw-window-events.lua",
 	"Tests/Integration/http-routing.lua",
 	"Tests/Integration/http-event-queue.lua",

--- a/deps/eliemichel/glfw3webgpu/glfw3webgpu.c
+++ b/deps/eliemichel/glfw3webgpu/glfw3webgpu.c
@@ -1,0 +1,158 @@
+/**
+ * This is an extension of GLFW for WebGPU, abstracting away the details of
+ * OS-specific operations.
+ * 
+ * This file is part of the "Learn WebGPU for C++" book.
+ *   https://eliemichel.github.io/LearnWebGPU
+ * 
+ * Most of this code comes from the wgpu-native triangle example:
+ *   https://github.com/gfx-rs/wgpu-native/blob/master/examples/triangle/main.c
+ * 
+ * MIT License
+ * Copyright (c) 2022-2023 Elie Michel and the wgpu-native authors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "glfw3webgpu.h"
+
+#include <webgpu/webgpu.h>
+
+#define WGPU_TARGET_MACOS 1
+#define WGPU_TARGET_LINUX_X11 2
+#define WGPU_TARGET_WINDOWS 3
+#define WGPU_TARGET_LINUX_WAYLAND 4
+
+#if defined(_WIN32)
+#define WGPU_TARGET WGPU_TARGET_WINDOWS
+#elif defined(__APPLE__)
+#define WGPU_TARGET WGPU_TARGET_MACOS
+#else
+#define WGPU_TARGET WGPU_TARGET_LINUX_X11
+#endif
+
+#if WGPU_TARGET == WGPU_TARGET_MACOS
+#include <Foundation/Foundation.h>
+#include <QuartzCore/CAMetalLayer.h>
+#endif
+
+#include <GLFW/glfw3.h>
+#if WGPU_TARGET == WGPU_TARGET_MACOS
+#define GLFW_EXPOSE_NATIVE_COCOA
+#elif WGPU_TARGET == WGPU_TARGET_LINUX_X11
+#define GLFW_EXPOSE_NATIVE_X11
+#elif WGPU_TARGET == WGPU_TARGET_LINUX_WAYLAND
+#define GLFW_EXPOSE_NATIVE_WAYLAND
+#elif WGPU_TARGET == WGPU_TARGET_WINDOWS
+#define GLFW_EXPOSE_NATIVE_WIN32
+#endif
+#include <GLFW/glfw3native.h>
+
+WGPUSurface glfwGetWGPUSurface(WGPUInstance instance, GLFWwindow* window) {
+#if WGPU_TARGET == WGPU_TARGET_MACOS
+    {
+        id metal_layer = NULL;
+        NSWindow* ns_window = glfwGetCocoaWindow(window);
+        [ns_window.contentView setWantsLayer : YES] ;
+        metal_layer = [CAMetalLayer layer];
+        [ns_window.contentView setLayer : metal_layer] ;
+        return wgpuInstanceCreateSurface(
+            instance,
+            &(WGPUSurfaceDescriptor){
+            .label = NULL,
+                .nextInChain =
+                (const WGPUChainedStruct*)&(
+                    WGPUSurfaceDescriptorFromMetalLayer) {
+                .chain =
+                    (WGPUChainedStruct){
+                        .next = NULL,
+                        .sType = WGPUSType_SurfaceDescriptorFromMetalLayer,
+                },
+                .layer = metal_layer,
+            },
+        });
+    }
+#elif WGPU_TARGET == WGPU_TARGET_LINUX_X11
+    {
+        Display* x11_display = glfwGetX11Display();
+        Window x11_window = glfwGetX11Window(window);
+        return wgpuInstanceCreateSurface(
+            instance,
+            &(WGPUSurfaceDescriptor){
+            .label = NULL,
+                .nextInChain =
+                (const WGPUChainedStruct*)&(
+                    WGPUSurfaceDescriptorFromXlibWindow) {
+                .chain =
+                    (WGPUChainedStruct){
+                        .next = NULL,
+                        .sType = WGPUSType_SurfaceDescriptorFromXlibWindow,
+                },
+                .display = x11_display,
+                .window = x11_window,
+            },
+        });
+    }
+#elif WGPU_TARGET == WGPU_TARGET_LINUX_WAYLAND
+    {
+        struct wl_display* wayland_display = glfwGetWaylandDisplay();
+        struct wl_surface* wayland_surface = glfwGetWaylandWindow(window);
+        return wgpuInstanceCreateSurface(
+            instance,
+            &(WGPUSurfaceDescriptor){
+            .label = NULL,
+                .nextInChain =
+                (const WGPUChainedStruct*)&(
+                    WGPUSurfaceDescriptorFromWaylandSurface) {
+                .chain =
+                    (WGPUChainedStruct){
+                        .next = NULL,
+                        .sType =
+                            WGPUSType_SurfaceDescriptorFromWaylandSurface,
+},
+.display = wayland_display,
+.surface = wayland_surface,
+                },
+        });
+  }
+#elif WGPU_TARGET == WGPU_TARGET_WINDOWS
+    {
+        HWND hwnd = glfwGetWin32Window(window);
+        HINSTANCE hinstance = GetModuleHandle(NULL);
+        return wgpuInstanceCreateSurface(
+            instance,
+            &(WGPUSurfaceDescriptor){
+            .label = NULL,
+                .nextInChain =
+                (const WGPUChainedStruct*)&(
+                    WGPUSurfaceDescriptorFromWindowsHWND) {
+                .chain =
+                    (WGPUChainedStruct){
+                        .next = NULL,
+                        .sType = WGPUSType_SurfaceDescriptorFromWindowsHWND,
+            },
+            .hinstance = hinstance,
+            .hwnd = hwnd,
+        },
+    });
+  }
+#else
+#error "Unsupported WGPU_TARGET"
+#endif
+}

--- a/deps/eliemichel/glfw3webgpu/glfw3webgpu.c
+++ b/deps/eliemichel/glfw3webgpu/glfw3webgpu.c
@@ -32,7 +32,7 @@
 
 #include "glfw3webgpu.h"
 
-#include <webgpu/webgpu.h>
+#include <webgpu.h>
 
 #define WGPU_TARGET_MACOS 1
 #define WGPU_TARGET_LINUX_X11 2

--- a/deps/eliemichel/glfw3webgpu/glfw3webgpu.h
+++ b/deps/eliemichel/glfw3webgpu/glfw3webgpu.h
@@ -1,0 +1,49 @@
+/**
+ * This is an extension of GLFW for WebGPU, abstracting away the details of
+ * OS-specific operations.
+ * 
+ * This file is part of the "Learn WebGPU for C++" book.
+ *   https://eliemichel.github.io/LearnWebGPU
+ * 
+ * MIT License
+ * Copyright (c) 2022-2023 Elie Michel and the wgpu-native authors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _glfw3_webgpu_h_
+#define _glfw3_webgpu_h_
+
+#include <webgpu/webgpu.h>
+#include <GLFW/glfw3.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Get a WGPUSurface from a GLFW window.
+ */
+WGPUSurface glfwGetWGPUSurface(WGPUInstance instance, GLFWwindow* window);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _glfw3_webgpu_h_

--- a/deps/eliemichel/glfw3webgpu/glfw3webgpu.h
+++ b/deps/eliemichel/glfw3webgpu/glfw3webgpu.h
@@ -30,7 +30,7 @@
 #ifndef _glfw3_webgpu_h_
 #define _glfw3_webgpu_h_
 
-#include <webgpu/webgpu.h>
+#include <webgpu.h>
 #include <GLFW/glfw3.h>
 
 #ifdef __cplusplus

--- a/ninjabuild.lua
+++ b/ninjabuild.lua
@@ -73,6 +73,7 @@ local EvoBuildTarget = {
 		"Runtime",
 		"Runtime/Bindings",
 		"deps",
+		"deps/eliemichel/glfw3webgpu",
 		"deps/glfw/glfw/include",
 		"deps/LuaJIT/LuaJIT/src",
 		"deps/luvit/luv/src",


### PR DESCRIPTION
This requires an unofficial extension currently, which is hopefully a stopgap measure.