### PR TITLE
Add stbi_flip_vertically_on_write to the stbi FFI bindings

### DIFF
--- a/Runtime/Bindings/stbi.lua
+++ b/Runtime/Bindings/stbi.lua
@@ -45,6 +45,8 @@ stbi.cdefs = [[
 		size_t (*stbi_encode_png)(stbi_image_t* image, uint8_t* buffer, const size_t buffer_size, const int stride);
 		size_t (*stbi_encode_jpg)(stbi_image_t* image, uint8_t* buffer, const size_t buffer_size, int quality);
 		size_t (*stbi_encode_tga)(stbi_image_t* image, uint8_t* buffer, const size_t buffer_size);
+
+		void (*stbi_flip_vertically_on_write)(int flag);
 	};
 
 	// This may be moved to C later if needed, but for now it's Lua only

--- a/Runtime/Bindings/stbi_ffi.cpp
+++ b/Runtime/Bindings/stbi_ffi.cpp
@@ -148,6 +148,8 @@ namespace stbi_ffi {
 		stbi_exports_table.stbi_load_monochrome = stbi_load_monochrome;
 		stbi_exports_table.stbi_load_monochrome_with_alpha = stbi_load_monochrome_with_alpha;
 
+		stbi_exports_table.stbi_flip_vertically_on_write = stbi_flip_vertically_on_write;
+
 		return &stbi_exports_table;
 	}
 

--- a/Runtime/Bindings/stbi_ffi.hpp
+++ b/Runtime/Bindings/stbi_ffi.hpp
@@ -44,6 +44,8 @@ struct static_stbi_exports_table {
 	size_t (*stbi_encode_png)(stbi_image_t* image, uint8_t* buffer, const size_t buffer_size, const int stride);
 	size_t (*stbi_encode_jpg)(stbi_image_t* image, uint8_t* buffer, const size_t buffer_size, int quality);
 	size_t (*stbi_encode_tga)(stbi_image_t* image, uint8_t* buffer, const size_t buffer_size);
+
+	void (*stbi_flip_vertically_on_write)(int flag);
 };
 
 namespace stbi_ffi {


### PR DESCRIPTION
This makes it easier to flip images as there's no need to manually reorder the contents of the pixel array.