### PR TITLE
Add global aliases for commonly-used FFI functions

### DIFF
--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -83,6 +83,13 @@ function evo.registerGlobalAliases()
 
 	_G.printf = evo.printf
 	_G.extend = evo.extend
+
+	_G.cdef = ffi.cdef
+	_G.define = ffi.cdef
+	_G.cast = ffi.cast
+	_G.new = ffi.new
+	_G.sizeof = ffi.sizeof
+	_G.typeof = ffi.typeof
 end
 
 function evo.initializeGlobalNamespaces()

--- a/Tests/BDD/globals.spec.lua
+++ b/Tests/BDD/globals.spec.lua
@@ -1,4 +1,5 @@
 local evo = require("evo")
+local ffi = require("ffi")
 local bdd = require("bdd")
 
 local globalAliases = {
@@ -10,6 +11,12 @@ local globalAliases = {
 	["it"] = bdd.it,
 	["path"] = require("path"),
 	["printf"] = evo.printf,
+	["cast"] = ffi.cast,
+	["cdef"] = ffi.cdef,
+	["define"] = ffi.cdef,
+	["new"] = ffi.new,
+	["sizeof"] = ffi.sizeof,
+	["typeof"] = ffi.typeof,
 }
 
 local globalNamespaces = {


### PR DESCRIPTION
It's just annoying to import the FFI library all the time, and there's not much harm done by having a few extra globals.