### PR TITLE
Add a more reliable way to compute image sizes

### DIFF
--- a/Runtime/Bindings/stbi.lua
+++ b/Runtime/Bindings/stbi.lua
@@ -1,7 +1,5 @@
 local ffi = require("ffi")
 
-local math_max = math.max
-
 local stbi = {
 	COLOR_DEPTHS = {
 		[0] = "NO_CONVERSION",
@@ -69,25 +67,6 @@ end
 
 function stbi.version()
 	return ffi.string(stbi.bindings.stbi_version())
-end
-
-local BMP_HEADER_SIZE = 54
-local JPEG_OVERHEAD_BUFFER_SIZE = 1024
--- Somewhat sketchy, but should be large enough for all formats
-function stbi.max_bitmap_size(width, height, channels)
-	local headerSizeInBytes = BMP_HEADER_SIZE
-	local pixelSizeInBytes = channels
-	local rowSizeInBytes = width * pixelSizeInBytes
-
-	-- Rows are aligned to 4 bytes in BMP format
-	local padding = (4 - (rowSizeInBytes % 4)) % 4
-	rowSizeInBytes = rowSizeInBytes + padding
-
-	-- This should cover most regular-sized images in all of the supported formats
-	local estimatedWorstCaseBitmapFileSize = (headerSizeInBytes + height * rowSizeInBytes)
-
-	-- JPEG-encoded sections add significant overhead if the image is small, so let's account for that
-	return math_max(estimatedWorstCaseBitmapFileSize, JPEG_OVERHEAD_BUFFER_SIZE)
 end
 
 function stbi.replace_pixel_color_rgba(image, sourceColor, replacementColor)

--- a/Runtime/Bindings/stbi.lua
+++ b/Runtime/Bindings/stbi.lua
@@ -47,6 +47,11 @@ stbi.cdefs = [[
 		size_t (*stbi_encode_tga)(stbi_image_t* image, uint8_t* buffer, const size_t buffer_size);
 
 		void (*stbi_flip_vertically_on_write)(int flag);
+
+		size_t (*stbi_get_required_bmp_size)(stbi_image_t* image);
+		size_t (*stbi_get_required_png_size)(stbi_image_t* image, const int stride);
+		size_t (*stbi_get_required_jpg_size)(stbi_image_t* image, const int quality);
+		size_t (*stbi_get_required_tga_size)(stbi_image_t* image);
 	};
 
 	// This may be moved to C later if needed, but for now it's Lua only

--- a/Runtime/Bindings/stbi_ffi.cpp
+++ b/Runtime/Bindings/stbi_ffi.cpp
@@ -127,6 +127,60 @@ size_t stbi_encode_tga(stbi_image_t* image, uint8_t* buffer, const size_t buffer
 	return result.num_bytes_used;
 }
 
+// There's no more reliable way to get the required buffer size AFAICT
+static void count_bytes(void* context, void* data, int size) {
+	size_t* byte_counter = static_cast<size_t*>(context);
+	*byte_counter += size;
+}
+
+size_t stbi_get_required_bmp_size(stbi_image_t* image) {
+	if(!image) return 0;
+	if(!image->data) return 0;
+
+	size_t byte_counter = 0;
+
+	int success = stbi_write_bmp_to_func(count_bytes, &byte_counter, image->width, image->height, image->channels, image->data);
+	if(!success) return 0;
+
+	return byte_counter;
+}
+
+size_t stbi_get_required_png_size(stbi_image_t* image, const int stride) {
+	if(!image) return 0;
+	if(!image->data) return 0;
+
+	size_t byte_counter = 0;
+
+	int success = stbi_write_png_to_func(count_bytes, &byte_counter, image->width, image->height, image->channels, image->data, stride);
+	if(!success) return 0;
+
+	return byte_counter;
+}
+
+size_t stbi_get_required_jpg_size(stbi_image_t* image, int quality) {
+	if(!image) return 0;
+	if(!image->data) return 0;
+
+	size_t byte_counter = 0;
+
+	int success = stbi_write_jpg_to_func(count_bytes, &byte_counter, image->width, image->height, image->channels, image->data, quality);
+	if(!success) return 0;
+
+	return byte_counter;
+}
+
+size_t stbi_get_required_tga_size(stbi_image_t* image) {
+	if(!image) return 0;
+	if(!image->data) return 0;
+
+	size_t byte_counter = 0;
+
+	int success = stbi_write_tga_to_func(count_bytes, &byte_counter, image->width, image->height, image->channels, image->data);
+	if(!success) return 0;
+
+	return byte_counter;
+}
+
 namespace stbi_ffi {
 
 	void* getExportsTable() {
@@ -149,6 +203,11 @@ namespace stbi_ffi {
 		stbi_exports_table.stbi_load_monochrome_with_alpha = stbi_load_monochrome_with_alpha;
 
 		stbi_exports_table.stbi_flip_vertically_on_write = stbi_flip_vertically_on_write;
+
+		stbi_exports_table.stbi_get_required_bmp_size = stbi_get_required_bmp_size;
+		stbi_exports_table.stbi_get_required_png_size = stbi_get_required_png_size;
+		stbi_exports_table.stbi_get_required_jpg_size = stbi_get_required_jpg_size;
+		stbi_exports_table.stbi_get_required_tga_size = stbi_get_required_tga_size;
 
 		return &stbi_exports_table;
 	}

--- a/Runtime/Bindings/stbi_ffi.hpp
+++ b/Runtime/Bindings/stbi_ffi.hpp
@@ -46,6 +46,11 @@ struct static_stbi_exports_table {
 	size_t (*stbi_encode_tga)(stbi_image_t* image, uint8_t* buffer, const size_t buffer_size);
 
 	void (*stbi_flip_vertically_on_write)(int flag);
+
+	size_t (*stbi_get_required_bmp_size)(stbi_image_t* image);
+	size_t (*stbi_get_required_png_size)(stbi_image_t* image, const int stride);
+	size_t (*stbi_get_required_jpg_size)(stbi_image_t* image, const int quality);
+	size_t (*stbi_get_required_tga_size)(stbi_image_t* image);
 };
 
 namespace stbi_ffi {

--- a/Tests/BDD/stbi-library.spec.lua
+++ b/Tests/BDD/stbi-library.spec.lua
@@ -133,7 +133,7 @@ describe("stbi", function()
 
 				stbi.bindings.stbi_flip_vertically_on_write(true)
 
-				local maxFileSize = stbi.max_bitmap_size(image.width, image.height, image.channels)
+				local maxFileSize = tonumber(stbi.bindings.stbi_get_required_bmp_size(image))
 				local startPointer, length = result:reserve(maxFileSize)
 				local numBytesWritten = stbi.bindings.stbi_encode_bmp(image, startPointer, length)
 				result:commit(numBytesWritten)
@@ -183,7 +183,7 @@ describe("stbi", function()
 
 				local decodedPixelData = ffi.string(image.data, image.width * image.height * image.channels)
 
-				local maxFileSize = stbi.max_bitmap_size(image.width, image.height, image.channels)
+				local maxFileSize = tonumber(stbi.bindings.stbi_get_required_bmp_size(image))
 				local startPointer, length = result:reserve(maxFileSize)
 				local numBytesWritten = stbi.bindings.stbi_encode_bmp(image, startPointer, length)
 
@@ -273,7 +273,7 @@ describe("stbi", function()
 
 				local decodedPixelData = ffi.string(image.data, image.width * image.height * image.channels)
 
-				local maxFileSize = stbi.max_bitmap_size(image.width, image.height, image.channels)
+				local maxFileSize = tonumber(stbi.bindings.stbi_get_required_tga_size(image))
 				local startPointer, length = result:reserve(maxFileSize)
 				local numBytesWritten = stbi.bindings.stbi_encode_tga(image, startPointer, length)
 
@@ -363,7 +363,8 @@ describe("stbi", function()
 
 				local decodedPixelData = ffi.string(image.data, image.width * image.height * image.channels)
 
-				local maxFileSize = stbi.max_bitmap_size(image.width, image.height, image.channels)
+				local maxFileSize = tonumber(stbi.bindings.stbi_get_required_jpg_size(image, 100))
+
 				local startPointer, length = result:reserve(maxFileSize)
 				local numBytesWritten = stbi.bindings.stbi_encode_jpg(image, startPointer, length, 100)
 
@@ -457,7 +458,7 @@ describe("stbi", function()
 
 				local decodedPixelData = ffi.string(image.data, image.width * image.height * image.channels)
 
-				local maxFileSize = stbi.max_bitmap_size(image.width, image.height, image.channels)
+				local maxFileSize = tonumber(stbi.bindings.stbi_get_required_bmp_size(image))
 				local startPointer, length = result:reserve(maxFileSize)
 				local numBytesWritten = stbi.bindings.stbi_encode_png(image, startPointer, length, 0)
 
@@ -781,7 +782,7 @@ describe("stbi", function()
 
 		describe("stbi_get_required_bmp_size", function()
 			it("should return the required BMP size for the given image", function()
-				local requiredBufferSize = stbi.bindings.stbi_get_required_bmp_size(image)
+				local requiredBufferSize = tonumber(stbi.bindings.stbi_get_required_bmp_size(image))
 
 				local outputBuffer = buffer.new()
 				local ptr, len = outputBuffer:reserve(requiredBufferSize)
@@ -807,11 +808,11 @@ describe("stbi", function()
 
 		describe("stbi_get_required_jpg_size", function()
 			it("should return the required JPG size for the given image", function()
-				local requiredBufferSize = stbi.bindings.stbi_get_required_jpg_size(image, 10)
+				local requiredBufferSize = stbi.bindings.stbi_get_required_jpg_size(image, 100)
 
 				local outputBuffer = buffer.new()
 				local ptr, len = outputBuffer:reserve(requiredBufferSize)
-				local numBytesWritten = stbi.bindings.stbi_encode_jpg(image, ptr, len, 10)
+				local numBytesWritten = stbi.bindings.stbi_encode_jpg(image, ptr, len, 100)
 				outputBuffer:commit(numBytesWritten)
 
 				assertEquals(tonumber(requiredBufferSize), #outputBuffer)
@@ -829,18 +830,6 @@ describe("stbi", function()
 
 				assertEquals(tonumber(requiredBufferSize), #outputBuffer)
 			end)
-		end)
-	end)
-
-	describe("max_bitmap_size", function()
-		it("should return the maximum bitmap size for a simple BMP file", function()
-			local maxBitmapSize = stbi.max_bitmap_size(256, 256, 3)
-			assertEquals(maxBitmapSize, 196662)
-		end)
-
-		it("should reserve enough space for JPG section overhead if the image is small", function()
-			local maxBitmapSize = stbi.max_bitmap_size(2, 3, 3)
-			assertEquals(maxBitmapSize, 1024)
 		end)
 	end)
 

--- a/Tests/BDD/stbi-library.spec.lua
+++ b/Tests/BDD/stbi-library.spec.lua
@@ -20,6 +20,10 @@ describe("stbi", function()
 				"stbi_encode_jpg",
 				"stbi_encode_tga",
 				"stbi_flip_vertically_on_write",
+				"stbi_get_required_bmp_size",
+				"stbi_get_required_png_size",
+				"stbi_get_required_jpg_size",
+				"stbi_get_required_tga_size",
 			}
 
 			for _, functionName in ipairs(exportedApiSurface) do
@@ -764,6 +768,66 @@ describe("stbi", function()
 			it("should return false if the buffer size given was negative", function()
 				local result = stbi.bindings.stbi_load_monochrome_with_alpha(fileContents, -1, nil)
 				assertFalse(result)
+			end)
+		end)
+
+		local fileContents = C_FileSystem.ReadFile(path.join(FIXTURES_DIR, "8bpp-image-without-alpha.bmp"))
+		local imageBuffer = buffer.new(#fileContents):put(fileContents)
+		local image = ffi.new("stbi_image_t")
+		image.width = 2
+		image.height = 3
+		image.data = imageBuffer
+		image.channels = 4
+
+		describe("stbi_get_required_bmp_size", function()
+			it("should return the required BMP size for the given image", function()
+				local requiredBufferSize = stbi.bindings.stbi_get_required_bmp_size(image)
+
+				local outputBuffer = buffer.new()
+				local ptr, len = outputBuffer:reserve(requiredBufferSize)
+				local numBytesWritten = stbi.bindings.stbi_encode_bmp(image, ptr, len)
+				outputBuffer:commit(numBytesWritten)
+
+				assertEquals(tonumber(requiredBufferSize), #outputBuffer)
+			end)
+		end)
+
+		describe("stbi_get_required_png_size", function()
+			it("should return the required PNG size for the given image", function()
+				local requiredBufferSize = stbi.bindings.stbi_get_required_png_size(image, 0)
+
+				local outputBuffer = buffer.new()
+				local ptr, len = outputBuffer:reserve(requiredBufferSize)
+				local numBytesWritten = stbi.bindings.stbi_encode_png(image, ptr, len, 0)
+				outputBuffer:commit(numBytesWritten)
+
+				assertEquals(tonumber(requiredBufferSize), #outputBuffer)
+			end)
+		end)
+
+		describe("stbi_get_required_jpg_size", function()
+			it("should return the required JPG size for the given image", function()
+				local requiredBufferSize = stbi.bindings.stbi_get_required_jpg_size(image, 10)
+
+				local outputBuffer = buffer.new()
+				local ptr, len = outputBuffer:reserve(requiredBufferSize)
+				local numBytesWritten = stbi.bindings.stbi_encode_jpg(image, ptr, len, 10)
+				outputBuffer:commit(numBytesWritten)
+
+				assertEquals(tonumber(requiredBufferSize), #outputBuffer)
+			end)
+		end)
+
+		describe("stbi_get_required_tga_size", function()
+			it("should return the required TGA size for the given image", function()
+				local requiredBufferSize = stbi.bindings.stbi_get_required_tga_size(image)
+
+				local outputBuffer = buffer.new()
+				local ptr, len = outputBuffer:reserve(requiredBufferSize)
+				local numBytesWritten = stbi.bindings.stbi_encode_tga(image, ptr, len)
+				outputBuffer:commit(numBytesWritten)
+
+				assertEquals(tonumber(requiredBufferSize), #outputBuffer)
 			end)
 		end)
 	end)


### PR DESCRIPTION
The original approach was always hacky, and indeed it breaks down for certain types of images. I found that when encoding an 8-bit palette BMP as RGBA with a lot of duplicated colors, the duplicated pixels will cause the resulting BMP file to exceed the computed maximum size.