### PR TITLE
Add a function to swap pixel formats to the stbi FFI bindings

### DIFF
--- a/Runtime/Bindings/stbi.lua
+++ b/Runtime/Bindings/stbi.lua
@@ -50,6 +50,8 @@ stbi.cdefs = [[
 		size_t (*stbi_get_required_png_size)(stbi_image_t* image, const int stride);
 		size_t (*stbi_get_required_jpg_size)(stbi_image_t* image, const int quality);
 		size_t (*stbi_get_required_tga_size)(stbi_image_t* image);
+
+		void (*stbi_abgr_to_rgba)(stbi_image_t* image);
 	};
 
 	// This may be moved to C later if needed, but for now it's Lua only

--- a/Runtime/Bindings/stbi_ffi.cpp
+++ b/Runtime/Bindings/stbi_ffi.cpp
@@ -7,6 +7,8 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
 
+#include <utility>
+
 const char* stbi_version() {
 	// There's no versioned releases or semver here, so this is as good as it gets
 	return TOSTRING(STBI_VERSION) ".0.0";
@@ -181,6 +183,23 @@ size_t stbi_get_required_tga_size(stbi_image_t* image) {
 	return byte_counter;
 }
 
+const size_t ABGR_RED_INDEX = 3;
+const size_t ABGR_GREEN_INDEX = 2;
+const size_t ABGR_BLUE_INDEX = 1;
+const size_t ABGR_ALPHA_INDEX = 0;
+
+void stbi_abgr_to_rgba(stbi_image_t* image) {
+	if(!image) return;
+	if(!image->data) return;
+
+	const size_t num_pixels = image->width * image->height;
+	for(size_t i = 0; i < num_pixels; i++) {
+		uint8_t* pixel = image->data + i * 4;
+		std::swap(pixel[ABGR_ALPHA_INDEX], pixel[ABGR_RED_INDEX]);
+		std::swap(pixel[ABGR_BLUE_INDEX], pixel[ABGR_GREEN_INDEX]);
+	}
+}
+
 namespace stbi_ffi {
 
 	void* getExportsTable() {
@@ -208,6 +227,8 @@ namespace stbi_ffi {
 		stbi_exports_table.stbi_get_required_png_size = stbi_get_required_png_size;
 		stbi_exports_table.stbi_get_required_jpg_size = stbi_get_required_jpg_size;
 		stbi_exports_table.stbi_get_required_tga_size = stbi_get_required_tga_size;
+
+		stbi_exports_table.stbi_abgr_to_rgba = stbi_abgr_to_rgba;
 
 		return &stbi_exports_table;
 	}

--- a/Runtime/Bindings/stbi_ffi.hpp
+++ b/Runtime/Bindings/stbi_ffi.hpp
@@ -51,6 +51,8 @@ struct static_stbi_exports_table {
 	size_t (*stbi_get_required_png_size)(stbi_image_t* image, const int stride);
 	size_t (*stbi_get_required_jpg_size)(stbi_image_t* image, const int quality);
 	size_t (*stbi_get_required_tga_size)(stbi_image_t* image);
+
+	void (*stbi_abgr_to_rgba)(stbi_image_t* image);
 };
 
 namespace stbi_ffi {

--- a/Tests/BDD/stbi-library.spec.lua
+++ b/Tests/BDD/stbi-library.spec.lua
@@ -3,6 +3,14 @@ local stbi = require("stbi")
 
 local FIXTURES_DIR = path.join("Tests", "Fixtures")
 
+local EXAMPLE_FILE_CONTENTS = C_FileSystem.ReadFile(path.join(FIXTURES_DIR, "8bpp-image-without-alpha.bmp"))
+local EXAMPLE_IMAGE_BUFFER = buffer.new(#EXAMPLE_FILE_CONTENTS):put(EXAMPLE_FILE_CONTENTS)
+local EXAMPLE_IMAGE = ffi.new("stbi_image_t")
+EXAMPLE_IMAGE.width = 2
+EXAMPLE_IMAGE.height = 3
+EXAMPLE_IMAGE.data = EXAMPLE_IMAGE_BUFFER
+EXAMPLE_IMAGE.channels = 4
+
 describe("stbi", function()
 	describe("bindings", function()
 		it("should export the entirety of the stbi API", function()
@@ -772,21 +780,13 @@ describe("stbi", function()
 			end)
 		end)
 
-		local fileContents = C_FileSystem.ReadFile(path.join(FIXTURES_DIR, "8bpp-image-without-alpha.bmp"))
-		local imageBuffer = buffer.new(#fileContents):put(fileContents)
-		local image = ffi.new("stbi_image_t")
-		image.width = 2
-		image.height = 3
-		image.data = imageBuffer
-		image.channels = 4
-
 		describe("stbi_get_required_bmp_size", function()
 			it("should return the required BMP size for the given image", function()
-				local requiredBufferSize = tonumber(stbi.bindings.stbi_get_required_bmp_size(image))
+				local requiredBufferSize = tonumber(stbi.bindings.stbi_get_required_bmp_size(EXAMPLE_IMAGE))
 
 				local outputBuffer = buffer.new()
 				local ptr, len = outputBuffer:reserve(requiredBufferSize)
-				local numBytesWritten = stbi.bindings.stbi_encode_bmp(image, ptr, len)
+				local numBytesWritten = stbi.bindings.stbi_encode_bmp(EXAMPLE_IMAGE, ptr, len)
 				outputBuffer:commit(numBytesWritten)
 
 				assertEquals(tonumber(requiredBufferSize), #outputBuffer)
@@ -795,11 +795,11 @@ describe("stbi", function()
 
 		describe("stbi_get_required_png_size", function()
 			it("should return the required PNG size for the given image", function()
-				local requiredBufferSize = stbi.bindings.stbi_get_required_png_size(image, 0)
+				local requiredBufferSize = stbi.bindings.stbi_get_required_png_size(EXAMPLE_IMAGE, 0)
 
 				local outputBuffer = buffer.new()
 				local ptr, len = outputBuffer:reserve(requiredBufferSize)
-				local numBytesWritten = stbi.bindings.stbi_encode_png(image, ptr, len, 0)
+				local numBytesWritten = stbi.bindings.stbi_encode_png(EXAMPLE_IMAGE, ptr, len, 0)
 				outputBuffer:commit(numBytesWritten)
 
 				assertEquals(tonumber(requiredBufferSize), #outputBuffer)
@@ -808,11 +808,11 @@ describe("stbi", function()
 
 		describe("stbi_get_required_jpg_size", function()
 			it("should return the required JPG size for the given image", function()
-				local requiredBufferSize = stbi.bindings.stbi_get_required_jpg_size(image, 100)
+				local requiredBufferSize = stbi.bindings.stbi_get_required_jpg_size(EXAMPLE_IMAGE, 100)
 
 				local outputBuffer = buffer.new()
 				local ptr, len = outputBuffer:reserve(requiredBufferSize)
-				local numBytesWritten = stbi.bindings.stbi_encode_jpg(image, ptr, len, 100)
+				local numBytesWritten = stbi.bindings.stbi_encode_jpg(EXAMPLE_IMAGE, ptr, len, 100)
 				outputBuffer:commit(numBytesWritten)
 
 				assertEquals(tonumber(requiredBufferSize), #outputBuffer)
@@ -821,11 +821,11 @@ describe("stbi", function()
 
 		describe("stbi_get_required_tga_size", function()
 			it("should return the required TGA size for the given image", function()
-				local requiredBufferSize = stbi.bindings.stbi_get_required_tga_size(image)
+				local requiredBufferSize = stbi.bindings.stbi_get_required_tga_size(EXAMPLE_IMAGE)
 
 				local outputBuffer = buffer.new()
 				local ptr, len = outputBuffer:reserve(requiredBufferSize)
-				local numBytesWritten = stbi.bindings.stbi_encode_tga(image, ptr, len)
+				local numBytesWritten = stbi.bindings.stbi_encode_tga(EXAMPLE_IMAGE, ptr, len)
 				outputBuffer:commit(numBytesWritten)
 
 				assertEquals(tonumber(requiredBufferSize), #outputBuffer)

--- a/Tests/BDD/stbi-library.spec.lua
+++ b/Tests/BDD/stbi-library.spec.lua
@@ -831,6 +831,39 @@ describe("stbi", function()
 				assertEquals(tonumber(requiredBufferSize), #outputBuffer)
 			end)
 		end)
+
+		describe("stbi_abgr_to_rgba", function()
+			it("should swap the pixel format of a given image from ABGR to RGBA", function()
+				local imageBytes = "\1\2\3\4\5\6\7\8"
+				local image = ffi.new("stbi_image_t")
+				image.width = 2
+				image.height = 1
+				image.data = buffer.new(#imageBytes):put(imageBytes)
+				image.channels = 4
+
+				stbi.bindings.stbi_abgr_to_rgba(image)
+
+				assertEquals(image.data[0], 4)
+				assertEquals(image.data[1], 3)
+				assertEquals(image.data[2], 2)
+				assertEquals(image.data[3], 1)
+				assertEquals(image.data[4], 8)
+				assertEquals(image.data[5], 7)
+				assertEquals(image.data[6], 6)
+				assertEquals(image.data[7], 5)
+
+				stbi.bindings.stbi_abgr_to_rgba(image)
+
+				assertEquals(image.data[0], 1)
+				assertEquals(image.data[1], 2)
+				assertEquals(image.data[2], 3)
+				assertEquals(image.data[3], 4)
+				assertEquals(image.data[4], 5)
+				assertEquals(image.data[5], 6)
+				assertEquals(image.data[6], 7)
+				assertEquals(image.data[7], 8)
+			end)
+		end)
 	end)
 
 	describe("replace_pixel_color_rgba", function()


### PR DESCRIPTION
Doing this in Lua (with cdata and the FFI) is significantly slower, and I need a fast way to do this for an image processing task.