### PR TITLE
Correct the default branch name for wgpu-native in scan-submodules.lua

### DIFF
--- a/scan-submodules.lua
+++ b/scan-submodules.lua
@@ -18,6 +18,7 @@ local yellow = transform.yellow
 
 local nonstandardBranches = {
 	["deps/LuaJIT/LuaJIT"] = "v2.1",
+	["deps/gfx-rs/wgpu-native"] = "trunk",
 	["deps/evo-lua/lpeg-compat-52"] = "luajit-compat-52",
 }
 


### PR DESCRIPTION
Looks like I haven't used this script since adding wgpu as a submodule.