### PR TITLE
Add linkage of ntdll.lib on Windows to the Ninja build script

### DIFF
--- a/ninjabuild.lua
+++ b/ninjabuild.lua
@@ -124,6 +124,7 @@ local EvoBuildTarget = {
 			"uuid",
 			"bcrypt",
 			"d3dcompiler",
+			"ntdll",
 		},
 		OSX = {
 			"m",


### PR DESCRIPTION
Not sure why this is needed all of a sudden, might be a Windows 11 thing?