### PR TITLE
Improve error handling in the iconv FFI bindings

### DIFF
--- a/Runtime/Bindings/iconv_ffi.cpp
+++ b/Runtime/Bindings/iconv_ffi.cpp
@@ -12,14 +12,20 @@ size_t iconv_convert(char* input, const char* input_encoding, const char* output
 
 	iconv_t conversion_descriptor = iconv_open(output_encoding, input_encoding);
 	if(conversion_descriptor == (iconv_t)-1) {
-		std::cout << "iconv_open failed: " << errno << std::endl;
-		throw std::runtime_error("iconv_open failed");
+		std::cout << "WARNING: iconv_open failed with error code " << errno << " (" << strerror(errno) << ")" << std::endl;
+		std::cout << "Input: " << input << std::endl;
+		std::cout << "Input Encoding: " << input_encoding << std::endl;
+		std::cout << "Output Encoding: " << output_encoding << std::endl;
+		return 0;
 	}
 
 	size_t num_output_bytes_left = output_size;
 	if(iconv(conversion_descriptor, &input, &num_input_bytes_left, &output, &num_output_bytes_left) == (size_t)-1) {
-		std::cout << "iconv failed: " << errno << std::endl;
-		throw std::runtime_error("iconv failed");
+		std::cout << "WARNING: iconv_open failed with error code " << errno << " (" << strerror(errno) << ")" << std::endl;
+		std::cout << "Input: " << input << std::endl;
+		std::cout << "Input Encoding: " << input_encoding << std::endl;
+		std::cout << "Output Encoding: " << output_encoding << std::endl;
+		return 0;
 	}
 	iconv_close(conversion_descriptor);
 	*output = '\0'; // Null-terminate the output buffer

--- a/Tests/BDD/iconv-library.spec.lua
+++ b/Tests/BDD/iconv-library.spec.lua
@@ -44,5 +44,29 @@ describe("iconv", function()
 			assertEquals(output, "")
 			assertEquals(numBytesWritten, 0)
 		end)
+
+		it("should fail gracefully if given the wrong input encoding", function()
+			local input = "유저인터페이스"
+			local output, numBytesWritten = iconv.convert(input, "CP949", "UTF-8")
+
+			assertEquals(output, "")
+			assertEquals(numBytesWritten, 0)
+		end)
+
+		it("should fail gracefully if given an invalid input encoding", function()
+			local input = "유저인터페이스"
+			local output, numBytesWritten = iconv.convert(input, "INVALID_ENCODING", "UTF-8")
+
+			assertEquals(output, "")
+			assertEquals(numBytesWritten, 0)
+		end)
+
+		it("should fail gracefully if given an invalid output encoding", function()
+			local input = "유저인터페이스"
+			local output, numBytesWritten = iconv.convert(input, "UTF-8", "INVALID_ENCODING")
+
+			assertEquals(output, "")
+			assertEquals(numBytesWritten, 0)
+		end)
 	end)
 end)


### PR DESCRIPTION
Exceptions don't provide any useful feedback in case of failure, and even crash the runtime when it's really not needed.

Not sure if this is the best way of handling conversion errors still, but it's a slight improvement at least.