### PR TITLE
Re-enable tracking of new submodule commits

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,72 +1,72 @@
 [submodule "deps/LuaJIT/LuaJIT"]
 	path = deps/LuaJIT/LuaJIT
 	url = https://github.com/LuaJIT/LuaJIT
-	ignore = all
+	ignore = dirty
 [submodule "deps/madler/zlib"]
 	path = deps/madler/zlib
 	url = https://github.com/madler/zlib
-	ignore = all
+	ignore = dirty
 [submodule "deps/PCRE2Project/pcre2"]
 	path = deps/PCRE2Project/pcre2
 	url = https://github.com/PCRE2Project/pcre2
-	ignore = all
+	ignore = dirty
 [submodule "deps/openssl/openssl"]
 	path = deps/openssl/openssl
 	url = https://github.com/openssl/openssl
-	ignore = all
+	ignore = dirty
 [submodule "deps/evo-lua/lpeg-compat-52"]
 	path = deps/evo-lua/lpeg-compat-52
 	url = https://github.com/evo-lua/lpeg-compat-52
-	ignore = all
+	ignore = dirty
 [submodule "deps/richgel999/miniz"]
 	path = deps/richgel999/miniz
 	url = https://github.com/richgel999/miniz
-	ignore = all
+	ignore = dirty
 [submodule "deps/luvit/luv"]
 	path = deps/luvit/luv
 	url = https://github.com/luvit/luv
-	ignore = all
+	ignore = dirty
 [submodule "deps/kikito/inspect.lua"]
 	path = deps/kikito/inspect.lua
 	url = https://github.com/kikito/inspect.lua.git
-	ignore = all
+	ignore = dirty
 [submodule "deps/webview/webview"]
 	path = deps/webview/webview
 	url = https://github.com/webview/webview
-	ignore = all
+	ignore = dirty
 [submodule "deps/uNetworking/uWebSockets"]
 	path = deps/uNetworking/uWebSockets
 	url = https://github.com/uNetworking/uWebSockets.git
-	ignore = all
+	ignore = dirty
 [submodule "deps/zhaog/lua-openssl"]
 	path = deps/zhaog/lua-openssl
 	url = https://github.com/zhaozg/lua-openssl
-	ignore = all
+	ignore = dirty
 [submodule "deps/mariusbancila/stduuid"]
 	path = deps/mariusbancila/stduuid
 	url = https://github.com/mariusbancila/stduuid
-	ignore = all
+	ignore = dirty
 [submodule "deps/brimworks/lua-zlib"]
 	path = deps/brimworks/lua-zlib
 	url = https://github.com/brimworks/lua-zlib
-	ignore = all
+	ignore = dirty
 [submodule "deps/xpol/lua-rapidjson"]
 	path = deps/xpol/lua-rapidjson
 	url = https://github.com/xpol/lua-rapidjson.git
-	ignore = all
+	ignore = dirty
 [submodule "deps/nothings/stb"]
 	path = deps/nothings/stb
 	url = https://github.com/nothings/stb.git
-	ignore = all
+	ignore = dirty
 [submodule "deps/rrthomas/lrexlib"]
 	path = deps/rrthomas/lrexlib
 	url = https://github.com/rrthomas/lrexlib
-	ignore = all
+	ignore = dirty
 [submodule "deps/glfw/glfw"]
 	path = deps/glfw/glfw
 	url = https://github.com/glfw/glfw/
-	ignore = all
+	ignore = dirty
 [submodule "deps/gfx-rs/wgpu-native"]
 	path = deps/gfx-rs/wgpu-native
 	url = https://github.com/gfx-rs/wgpu-native.git
-	ignore = all
+	ignore = dirty


### PR DESCRIPTION
Well, I guess selecting the nuclear option was overkill. Now, new commits aren't detected at all (which, in hindsight, is kind of obvious). The only time there'll be new commits is if a submodule is being updated, so that's not something to ignore.