### PR TITLE
Apply retroactive fixes to the changelog for v0.0.11

### DIFF
--- a/changelog.lua
+++ b/changelog.lua
@@ -4,9 +4,6 @@ local changelog = {
 			"Integrated FFI bindings to `iconv` that allow converting between different character encodings",
 			"A number of additional console colors are now supported by the `transform` library",
 		},
-		fixes = {
-			"Fixed an issue in the C_ImageProcessing API that could lead to images being decoded as RGB (instead of RGBA))",
-		},
 	},
 	["v0.0.10"] = {
 		newFeatures = {

--- a/changelog.lua
+++ b/changelog.lua
@@ -2,6 +2,8 @@ local changelog = {
 	["v0.0.11"] = {
 		newFeatures = {
 			"Integrated FFI bindings to `iconv` that allow converting between different character encodings",
+		},
+		improvements = {
 			"A number of additional console colors are now supported by the `transform` library",
 		},
 	},


### PR DESCRIPTION
Someone clearly did a whoopsie. The GitHub release is already updated.