### PR TITLE
Introduce a new FFI-based crypto library

### DIFF
--- a/.cppcheck
+++ b/.cppcheck
@@ -5,6 +5,7 @@ passedByValue
 unusedFunction:Runtime/LuaVirtualMachine.cpp
 
 // FFI exports used from Lua, which cppcheck can't see
+unusedStructMember:Runtime/Bindings/crypto_ffi.hpp
 unusedStructMember:Runtime/Bindings/glfw_ffi.hpp
 unusedStructMember:Runtime/Bindings/iconv_ffi.hpp
 unusedStructMember:Runtime/Bindings/interop_ffi.hpp

--- a/Benchmarks/base64-decode.lua
+++ b/Benchmarks/base64-decode.lua
@@ -1,0 +1,80 @@
+local console = require("console")
+local crypto = require("crypto")
+local openssl = require("openssl")
+
+local tinsert = table.insert
+
+local SAMPLE_SIZE = 5000
+
+printf("Generating %d randomized samples of varying lengths", SAMPLE_SIZE)
+console.startTimer("Generate random samples")
+
+local inputs = {
+	luaopenssl = {},
+	openssl = {},
+	argon2 = {},
+}
+
+for i = 1, SAMPLE_SIZE, 1 do
+	tinsert(inputs, openssl.random(4))
+	tinsert(inputs, openssl.random(8))
+	tinsert(inputs, openssl.random(16))
+	tinsert(inputs, openssl.random(32))
+	tinsert(inputs, openssl.random(64))
+	tinsert(inputs, openssl.random(128))
+	tinsert(inputs, openssl.random(256))
+	tinsert(inputs, openssl.random(512))
+	tinsert(inputs, openssl.random(1250))
+	tinsert(inputs, openssl.random(2500))
+	tinsert(inputs, openssl.random(5000))
+	tinsert(inputs, openssl.random(10000))
+	tinsert(inputs, openssl.random(100000))
+end
+
+for i, randomBytes in ipairs(inputs) do
+	inputs.luaopenssl[i] = openssl.base64(randomBytes)
+	inputs.openssl[i] = crypto.toBase64(randomBytes)
+	inputs.argon2[i] = crypto.toCompactBase64(randomBytes)
+end
+
+console.stopTimer("Generate random samples")
+
+math.randomseed(os.clock())
+local availableBenchmarks = {
+	function()
+		console.startTimer("[Base64] Decoding with LuaOpenSSL")
+		for i = 1, SAMPLE_SIZE, 1 do
+			openssl.base64(inputs.luaopenssl[i])
+		end
+		console.stopTimer("[Base64] Decoding with LuaOpenSSL")
+	end,
+
+	function()
+		console.startTimer("[Base64] Decoding with FFI bindings to OpenSSL")
+		for i = 1, SAMPLE_SIZE, 1 do
+			crypto.toBase64(inputs.openssl[i])
+		end
+		console.stopTimer("[Base64] Decoding with FFI bindings to OpenSSL")
+	end,
+
+	function()
+		console.startTimer("[Base64] Decoding with FFI bindings to Argon2")
+		for i = 1, SAMPLE_SIZE, 1 do
+			crypto.toCompactBase64(inputs.argon2[i])
+		end
+		console.stopTimer("[Base64] Decoding with FFI bindings to Argon2")
+	end,
+}
+
+local function shuffle(tbl)
+	for i = #tbl, 2, -1 do
+		local j = math.random(i)
+		tbl[i], tbl[j] = tbl[j], tbl[i]
+	end
+end
+
+shuffle(availableBenchmarks)
+
+for _, benchmark in ipairs(availableBenchmarks) do
+	benchmark()
+end

--- a/Benchmarks/base64-encode.lua
+++ b/Benchmarks/base64-encode.lua
@@ -1,0 +1,70 @@
+local console = require("console")
+local crypto = require("crypto")
+local openssl = require("openssl")
+
+local tinsert = table.insert
+
+local SAMPLE_SIZE = 10000
+
+printf("Generating %d randomized samples of varying lengths", SAMPLE_SIZE)
+console.startTimer("Generate random samples")
+
+local inputs = {}
+
+for i = 1, SAMPLE_SIZE, 1 do
+	tinsert(inputs, openssl.random(4))
+	tinsert(inputs, openssl.random(8))
+	tinsert(inputs, openssl.random(16))
+	tinsert(inputs, openssl.random(32))
+	tinsert(inputs, openssl.random(64))
+	tinsert(inputs, openssl.random(128))
+	tinsert(inputs, openssl.random(256))
+	tinsert(inputs, openssl.random(512))
+	tinsert(inputs, openssl.random(1250))
+	tinsert(inputs, openssl.random(2500))
+	tinsert(inputs, openssl.random(5000))
+	tinsert(inputs, openssl.random(10000))
+	tinsert(inputs, openssl.random(100000))
+end
+
+console.stopTimer("Generate random samples")
+
+math.randomseed(os.clock())
+local availableBenchmarks = {
+	function()
+		console.startTimer("[Base64] Encoding with LuaOpenSSL")
+		for i = 1, SAMPLE_SIZE, 1 do
+			openssl.base64(inputs[i])
+		end
+		console.stopTimer("[Base64] Encoding with LuaOpenSSL")
+	end,
+
+	function()
+		console.startTimer("[Base64] Encoding with FFI bindings to OpenSSL")
+		for i = 1, SAMPLE_SIZE, 1 do
+			crypto.toBase64(inputs[i])
+		end
+		console.stopTimer("[Base64] Encoding with FFI bindings to OpenSSL")
+	end,
+
+	function()
+		console.startTimer("[Base64] Encoding with FFI bindings to Argon2")
+		for i = 1, SAMPLE_SIZE, 1 do
+			crypto.toCompactBase64(inputs[i])
+		end
+		console.stopTimer("[Base64] Encoding with FFI bindings to Argon2")
+	end,
+}
+
+local function shuffle(tbl)
+	for i = #tbl, 2, -1 do
+		local j = math.random(i)
+		tbl[i], tbl[j] = tbl[j], tbl[i]
+	end
+end
+
+shuffle(availableBenchmarks)
+
+for _, benchmark in ipairs(availableBenchmarks) do
+	benchmark()
+end

--- a/BuildTools/NinjaBuildTools.lua
+++ b/BuildTools/NinjaBuildTools.lua
@@ -12,7 +12,7 @@ local C_BuildTools = {
 	GCC_COMPILATION_SETTINGS = {
 		displayName = "GNU Compiler Collection",
 		CPP_COMPILER = "g++",
-		COMPILER_FLAGS = "-O2 -DNDEBUG -g -std=c++20 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -fvisibility=hidden -fno-strict-aliasing -fdiagnostics-color -Wfatal-errors"
+		COMPILER_FLAGS = "-O3 -DNDEBUG -g -std=c++20 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -fvisibility=hidden -fno-strict-aliasing -fdiagnostics-color -Wfatal-errors"
 			.. (isMacOS and " -ObjC++" or ""), -- Forced Objc++ should be removed once glfw3webgpu is merged into the GLFW core library... until then, it's a necessary evil
 		CPP_LINKER = "g++",
 		-- Must export the entry point of bytecode objects so that LuaJIT can load them via require()

--- a/Runtime/Bindings/crypto.lua
+++ b/Runtime/Bindings/crypto.lua
@@ -1,0 +1,143 @@
+local buffer = require("string.buffer")
+local ffi = require("ffi")
+
+local math_ceil = math.ceil
+local tostring = tostring
+local math_floor = math.floor
+
+local crypto = {}
+
+crypto.cdefs = [[
+	typedef enum {
+		KDF_ARGON2ID,
+		KDF_ARGON2D,
+		KDF_ARGON2I,
+	} KEY_DERIVATION_FUNCTIONS;
+
+	struct static_crypto_exports_table {
+		// OpenSSL (libcrypto) metadata
+		const char* (*version_text)(void);
+		long int (*version_number)(void);
+
+		// Argon2 MCF utilities
+		size_t (*openssl_to_base64)(char *dst, size_t dst_len, const char *src, size_t src_len);
+		size_t (*openssl_from_base64)(unsigned char* dst, size_t dst_len, const unsigned char* src, size_t src_len);
+		size_t (*argon2_to_base64)(unsigned char* dst, size_t dst_len, const unsigned char* src, size_t src_len);
+		size_t (*argon2_from_base64)(char *dst, size_t dst_len, const char *src);
+	};
+]]
+
+local preallocatedConversionBuffer = buffer.new(128)
+
+function crypto.initialize()
+	ffi.cdef(crypto.cdefs)
+
+	crypto.KDF_ARGON2D = ffi.C.KDF_ARGON2D
+	crypto.KDF_ARGON2I = ffi.C.KDF_ARGON2I
+	crypto.KDF_ARGON2ID = ffi.C.KDF_ARGON2ID
+
+	crypto.kdfs = {
+		[ffi.C.KDF_ARGON2D] = "argon2d",
+		[ffi.C.KDF_ARGON2I] = "argon2i",
+		[ffi.C.KDF_ARGON2ID] = "argon2id",
+	}
+
+	crypto.DEFAULT_ARGON2_VERSION = 0x13
+end
+
+function crypto.version()
+	local versionText = ffi.string(crypto.bindings.version_text())
+	local sslVersion = versionText:match("OpenSSL%s(%d+%.%d+%.%d+).*")
+
+	return sslVersion, tonumber(crypto.bindings.version_number())
+end
+
+function crypto.mcf(hash, salt, parameters)
+	local mcf = string.format(
+		"$%s$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		crypto.kdfs[parameters.kdf],
+		parameters.version,
+		parameters.kilobytes,
+		parameters.threads,
+		parameters.lanes,
+		crypto.toCompactBase64(salt),
+		crypto.toCompactBase64(hash)
+	)
+
+	return mcf
+end
+
+function crypto.getMaxSizeOfBase64(input)
+	-- See https://www.openssl.org/docs/man3.1/man3/EVP_DecodeUpdate.html
+	local OPENSSL_EVP_BLOCK_SIZE_IN_BYTES = 48
+	local OPENSSL_EVP_STORAGE_SIZE_PER_BLOCK = 65 + 1 -- Output + Newline
+	local numUnprocessedBytesInEncoder = 0 -- We always flush (streaming isn't supported)
+	local numBlocks = math_floor((#input + numUnprocessedBytesInEncoder) / OPENSSL_EVP_BLOCK_SIZE_IN_BYTES)
+	local requiredSize = (numBlocks + 1) * OPENSSL_EVP_STORAGE_SIZE_PER_BLOCK -- Flushing the last block adds one extra
+
+	return requiredSize
+end
+
+function crypto.getSizeOfCompactBase64(input)
+	-- Space requred to store one extra character in the B64 alphabet
+	local BASE64_CHUNK_SIZE_IN_BITS = 6
+	-- How many bytes a single 3-byte chunk will end up as when encoded
+	local BASE64_BLOCK_SIZE_IN_BYTES = 4
+	-- The number of complete 3-byte chunks in the input
+	local blockCount = math_floor(#input / 3)
+	-- How many bytes remain after the full blocks are encoded
+	local numLeftoverBytes = (#input % 3)
+	local numLeftoverBits = numLeftoverBytes * 8 -- 8 bits = 1 byte
+	-- How many extra Base64 characters are needed to represent the leftover bits
+	local numLeftoverChars = math_ceil(numLeftoverBits / BASE64_CHUNK_SIZE_IN_BITS)
+
+	local requiredSpace = blockCount * BASE64_BLOCK_SIZE_IN_BYTES + numLeftoverChars
+
+	return requiredSpace
+end
+
+function crypto.toCompactBase64(input)
+	local requiredSpace = crypto.getSizeOfCompactBase64(input)
+
+	preallocatedConversionBuffer:reset()
+	local ptr, len = preallocatedConversionBuffer:reserve(requiredSpace)
+	local numBytesWritten = crypto.bindings.argon2_to_base64(ptr, len, input, #input)
+	preallocatedConversionBuffer:commit(numBytesWritten)
+
+	return tostring(preallocatedConversionBuffer)
+end
+
+function crypto.toBase64(input)
+	local requiredSpace = crypto.getMaxSizeOfBase64(input)
+
+	preallocatedConversionBuffer:reset()
+	local ptr, len = preallocatedConversionBuffer:reserve(requiredSpace)
+	local numBytesWritten = crypto.bindings.openssl_to_base64(ptr, len, input, #input)
+	preallocatedConversionBuffer:commit(numBytesWritten)
+
+	return tostring(preallocatedConversionBuffer)
+end
+
+function crypto.fromCompactBase64(encodedHash)
+	local requiredSpace = math_ceil(#encodedHash * 3 / 4) -- Worst case (no padding bytes)
+
+	preallocatedConversionBuffer:reset()
+	local ptr, len = preallocatedConversionBuffer:reserve(requiredSpace)
+	local numBytesWritten = crypto.bindings.argon2_from_base64(ptr, len, encodedHash)
+	preallocatedConversionBuffer:commit(numBytesWritten)
+
+	return tostring(preallocatedConversionBuffer)
+end
+
+function crypto.fromBase64(encodedHash)
+	local requiredSpace = math_ceil(#encodedHash * 3 / 4) -- Worst case (no padding bytes)
+
+	preallocatedConversionBuffer:reset()
+	local ptr, len = preallocatedConversionBuffer:reserve(requiredSpace)
+	local numBytesWritten = crypto.bindings.openssl_from_base64(ptr, len, encodedHash, #encodedHash)
+	preallocatedConversionBuffer:commit(numBytesWritten)
+
+	return tostring(preallocatedConversionBuffer)
+end
+
+return crypto

--- a/Runtime/Bindings/crypto_argon2.cpp
+++ b/Runtime/Bindings/crypto_argon2.cpp
@@ -1,0 +1,126 @@
+// This code was mostly taken from the PHC-Argon2 reference implemention (with some basic optimizations added)
+// Source: https://github.com/P-H-C/phc-winner-argon2/blob/master/src/encoding.c
+// See the original licensing terms below:
+/*
+ * Argon2 reference source code package - reference C implementations
+ *
+ * Copyright 2015
+ * Daniel Dinu, Dmitry Khovratovich, Jean-Philippe Aumasson, and Samuel Neves
+ *
+ * You may use this work under the terms of a Creative Commons CC0 1.0
+ * License/Waiver or the Apache Public License 2.0, at your option. The terms of
+ * these licenses can be found at:
+ *
+ * - CC0 1.0 Universal : https://creativecommons.org/publicdomain/zero/1.0
+ * - Apache 2.0        : https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * You should have received a copy of both of these licenses along with this
+ * software. If not, they may be obtained at the above URLs.
+ */
+
+#include "crypto_argon2.hpp"
+
+#include <cstddef>
+
+const char base64_chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+							"abcdefghijklmnopqrstuvwxyz"
+							"0123456789+/";
+
+inline char b64_byte_to_char(unsigned x) {
+	return base64_chars[x];
+}
+
+inline unsigned b64_char_to_byte(int c) {
+	unsigned x;
+
+	x = (GE(c, 'A') & LE(c, 'Z') & (c - 'A')) | (GE(c, 'a') & LE(c, 'z') & (c - ('a' - 26))) | (GE(c, '0') & LE(c, '9') & (c - ('0' - 52))) | (EQ(c, '+') & 62) | (EQ(c, '/') & 63);
+	return x | (EQ(x, 0) & (EQ(c, 'A') ^ 0xFF));
+}
+
+size_t argon2_to_base64(unsigned char* dst, size_t dst_len, const unsigned char* src, size_t src_len) {
+	size_t olen;
+	const unsigned char* buf;
+	unsigned acc, acc_len;
+
+	olen = (src_len / 3) << 2;
+	switch(src_len % 3) {
+	case 2:
+		olen++;
+	/* fall through */
+	case 1:
+		olen += 2;
+		break;
+	}
+	if(dst_len <= olen) {
+		return static_cast<size_t>(-1);
+	}
+
+	acc = 0;
+	acc_len = 0;
+	buf = src;
+
+	// Loop unrolling: Process 3 bytes at a time
+	while(src_len >= 3) {
+		acc = (acc << 24) + (buf[0] << 16) + (buf[1] << 8) + buf[2];
+		buf += 3;
+		src_len -= 3;
+		acc_len = 24;
+
+		while(acc_len >= 6) {
+			acc_len -= 6;
+			*dst++ = b64_byte_to_char((acc >> acc_len) & 0x3F);
+		}
+	}
+
+	// Handle remaining bytes
+	while(src_len-- > 0) {
+		acc = (acc << 8) + (*buf++);
+		acc_len += 8;
+		while(acc_len >= 6) {
+			acc_len -= 6;
+			*dst++ = b64_byte_to_char((acc >> acc_len) & 0x3F);
+		}
+	}
+
+	if(acc_len > 0) {
+		*dst++ = b64_byte_to_char((acc << (6 - acc_len)) & 0x3F);
+	}
+	*dst++ = 0;
+	return olen;
+}
+
+size_t argon2_from_base64(unsigned char* dst, size_t dst_len, const char* src) {
+	size_t len;
+	unsigned char* buf;
+	unsigned acc, acc_len;
+
+	buf = dst;
+	len = 0;
+	acc = 0;
+	acc_len = 0;
+	for(;;) {
+		unsigned d;
+
+		d = b64_char_to_byte(*src);
+		if(d > 63) { // Invalid character
+			break;
+		}
+		src++;
+		acc = (acc << 6) + d;
+		acc_len += 6;
+		if(acc_len >= 8) {
+			acc_len -= 8;
+			if(len >= dst_len) {
+				return static_cast<size_t>(-1); // Error: buffer overflow
+			}
+			*buf++ = (acc >> acc_len) & 0xFF;
+			len++;
+		}
+	}
+
+	// Check for invalid input
+	if(acc_len > 4 || (acc & ((static_cast<unsigned>(1) << acc_len) - 1)) != 0) {
+		return static_cast<size_t>(-1);
+	}
+	return len;
+}

--- a/Runtime/Bindings/crypto_argon2.hpp
+++ b/Runtime/Bindings/crypto_argon2.hpp
@@ -1,0 +1,32 @@
+// This code was mostly taken from the PHC-Argon2 reference implemention (with some basic optimizations added)
+// Source: https://github.com/P-H-C/phc-winner-argon2/blob/master/src/encoding.c
+// See the original licensing terms below:
+/*
+ * Argon2 reference source code package - reference C implementations
+ *
+ * Copyright 2015
+ * Daniel Dinu, Dmitry Khovratovich, Jean-Philippe Aumasson, and Samuel Neves
+ *
+ * You may use this work under the terms of a Creative Commons CC0 1.0
+ * License/Waiver or the Apache Public License 2.0, at your option. The terms of
+ * these licenses can be found at:
+ *
+ * - CC0 1.0 Universal : https://creativecommons.org/publicdomain/zero/1.0
+ * - Apache 2.0        : https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * You should have received a copy of both of these licenses along with this
+ * software. If not, they may be obtained at the above URLs.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+#define EQ(x, y) ((((0U - ((unsigned)(x) ^ (unsigned)(y))) >> 8) & 0xFF) ^ 0xFF)
+#define GT(x, y) ((((unsigned)(y) - (unsigned)(x)) >> 8) & 0xFF)
+#define GE(x, y) (GT(y, x) ^ 0xFF)
+#define LT(x, y) GT(y, x)
+#define LE(x, y) GE(y, x)
+
+size_t argon2_to_base64(unsigned char* dst, size_t dst_len, const unsigned char* src, size_t src_len);
+size_t argon2_from_base64(unsigned char* dst, size_t dst_len, const char* src);

--- a/Runtime/Bindings/crypto_ffi.cpp
+++ b/Runtime/Bindings/crypto_ffi.cpp
@@ -1,0 +1,72 @@
+#include "crypto_ffi.hpp"
+#include "crypto_argon2.hpp"
+
+#include <openssl/evp.h>
+
+#include <cstddef>
+#include <iostream>
+
+size_t openssl_to_base64(unsigned char* dst, size_t dst_len, const unsigned char* src, size_t src_len) {
+	EVP_ENCODE_CTX* ctx = EVP_ENCODE_CTX_new();
+	if(!ctx) return 0;
+
+	int out_len = 0, tmp_len = 0;
+
+	EVP_EncodeInit(ctx);
+	EVP_EncodeUpdate(ctx, dst, &out_len, src, src_len);
+	EVP_EncodeFinal(ctx, static_cast<unsigned char*>(dst + out_len), &tmp_len);
+
+	out_len += tmp_len;
+	EVP_ENCODE_CTX_free(ctx);
+
+	return out_len;
+}
+
+size_t openssl_from_base64(unsigned char* dst, size_t dst_len, const unsigned char* src, size_t src_len) {
+	EVP_ENCODE_CTX* ctx = EVP_ENCODE_CTX_new();
+	if(!ctx) return 0;
+
+	int out_len = 0, tmp_len = 0;
+
+	EVP_DecodeInit(ctx);
+	if(EVP_DecodeUpdate(ctx, dst, &out_len, src, src_len) == -1) {
+		EVP_ENCODE_CTX_free(ctx);
+		return 0;
+	}
+	if(EVP_DecodeFinal(ctx, static_cast<unsigned char*>(dst + out_len), &tmp_len) == -1) {
+		EVP_ENCODE_CTX_free(ctx);
+		return 0;
+	}
+
+	out_len += tmp_len;
+	EVP_ENCODE_CTX_free(ctx);
+
+	return out_len;
+}
+
+namespace crypto_ffi {
+
+	void* getExportsTable() {
+		static struct static_crypto_exports_table exports_table;
+
+		exports_table.version_text = &getVersionText;
+		exports_table.version_number = &getVersionNumber;
+
+		exports_table.openssl_to_base64 = &openssl_to_base64;
+		exports_table.openssl_from_base64 = &openssl_from_base64;
+		exports_table.argon2_to_base64 = &argon2_to_base64;
+		exports_table.argon2_from_base64 = &argon2_from_base64;
+
+		return &exports_table;
+	}
+
+	const char* getVersionText() {
+		std::cout << OPENSSL_VERSION_TEXT << std::endl;
+		return OPENSSL_VERSION_TEXT;
+	}
+
+	long int getVersionNumber() {
+		std::cout << OPENSSL_VERSION_NUMBER << std::endl;
+		return OPENSSL_VERSION_NUMBER;
+	}
+}

--- a/Runtime/Bindings/crypto_ffi.hpp
+++ b/Runtime/Bindings/crypto_ffi.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstddef>
+
+struct static_crypto_exports_table {
+	// OpenSSL (libcrypto) metadata
+	const char* (*version_text)(void);
+	long int (*version_number)(void);
+
+	// Argon2 MCF utilities
+	size_t (*openssl_to_base64)(unsigned char* dst, size_t dst_len, const unsigned char* src, size_t src_len);
+	size_t (*openssl_from_base64)(unsigned char* dst, size_t dst_len, const unsigned char* src, size_t src_len);
+	size_t (*argon2_to_base64)(unsigned char* dst, size_t dst_len, const unsigned char* src, size_t src_len);
+	size_t (*argon2_from_base64)(unsigned char* dst, size_t dst_len, const char* src);
+};
+
+namespace crypto_ffi {
+
+	typedef enum {
+		KDF_ARGON2ID,
+		KDF_ARGON2D,
+		KDF_ARGON2I,
+	} KEY_DERIVATION_FUNCTIONS;
+
+	void* getExportsTable();
+	const char* getVersionText();
+	long int getVersionNumber();
+
+}

--- a/Runtime/main.cpp
+++ b/Runtime/main.cpp
@@ -9,6 +9,7 @@ extern "C" {
 #include "rapidjson.hpp"
 
 #include "macros.hpp"
+#include "crypto_ffi.hpp"
 #include "glfw_ffi.hpp"
 #include "iconv_ffi.hpp"
 #include "interop_ffi.hpp"
@@ -35,6 +36,7 @@ int main(int argc, char* argv[]) {
 	luaVM->PreloadPackage("zlib", luaopen_zlib);
 
 	// The embedded libraries are statically linked in, so we require some glue code to access them via FFI
+	luaVM->BindStaticLibraryExports("crypto", crypto_ffi::getExportsTable());
 	luaVM->BindStaticLibraryExports("glfw", glfw_ffi::getExportsTable());
 	luaVM->BindStaticLibraryExports("iconv", iconv_ffi::getExportsTable());
 	luaVM->BindStaticLibraryExports("interop", interop_ffi::getExportsTable());

--- a/Tests/BDD/crypto-library.spec.lua
+++ b/Tests/BDD/crypto-library.spec.lua
@@ -1,0 +1,216 @@
+local crypto = require("crypto")
+local ffi = require("ffi")
+local openssl = require("openssl")
+
+local tinsert = table.insert
+
+describe("crypto", function()
+	it("should export all shared Argon2 constants", function()
+		assertEquals(crypto.KDF_ARGON2D, ffi.C.KDF_ARGON2D)
+		assertEquals(crypto.KDF_ARGON2I, ffi.C.KDF_ARGON2I)
+		assertEquals(crypto.KDF_ARGON2ID, ffi.C.KDF_ARGON2ID)
+
+		assertEquals(crypto.DEFAULT_ARGON2_VERSION, 0x13)
+
+		assertEquals(crypto.kdfs[crypto.KDF_ARGON2D], "argon2d")
+		assertEquals(crypto.kdfs[crypto.KDF_ARGON2I], "argon2i")
+		assertEquals(crypto.kdfs[crypto.KDF_ARGON2ID], "argon2id")
+	end)
+
+	describe("version", function()
+		it("should return the embedded OpenSSL version in semver format", function()
+			local embeddedLibraryVersion, versionNumber = crypto.version()
+			assertTrue(type(versionNumber) == "number")
+			local firstMatchedCharacterIndex, lastMatchedCharacterIndex =
+				string.find(embeddedLibraryVersion, "%d+.%d+.%d+")
+
+			assertEquals(firstMatchedCharacterIndex, 1)
+			assertEquals(lastMatchedCharacterIndex, string.len(embeddedLibraryVersion))
+			assertEquals(type(string.match(embeddedLibraryVersion, "%d+.%d+.%d+")), "string")
+		end)
+	end)
+
+	describe("getMaxSizeOfBase64", function()
+		it(
+			"should return a number that is large enough to contain the Base64 representation in OpenSSL EVP format",
+			function()
+				assertTrue(crypto.getMaxSizeOfBase64("A") >= #crypto.toBase64("A"))
+				assertTrue(crypto.getMaxSizeOfBase64("Hello") >= #crypto.toBase64("Hello"))
+				assertTrue(crypto.getMaxSizeOfBase64(string.rep("A", 48)) >= #crypto.toBase64(string.rep("A", 48)))
+				assertTrue(crypto.getMaxSizeOfBase64(string.rep("A", 49)) >= #crypto.toBase64(string.rep("A", 49)))
+				assertTrue(crypto.getMaxSizeOfBase64(string.rep("A", 64)) >= #crypto.toBase64(string.rep("A", 64)))
+				assertTrue(crypto.getMaxSizeOfBase64(string.rep("A", 65)) >= #crypto.toBase64(string.rep("A", 65)))
+				assertTrue(crypto.getMaxSizeOfBase64(string.rep("A", 66)) >= #crypto.toBase64(string.rep("A", 66)))
+				assertTrue(crypto.getMaxSizeOfBase64(string.rep("A", 666)) >= #crypto.toBase64(string.rep("A", 666)))
+				assertTrue(crypto.getMaxSizeOfBase64(string.rep("A", 6666)) >= #crypto.toBase64(string.rep("A", 6666)))
+			end
+		)
+
+		describe("getSizeOfCompactBase64", function()
+			-- The Argon2 format is shorter, so if it returns enough space for EVP then Argon2 will also fit
+			it(
+				"should return a number that is large enough to contain the Base64 representation in OpenSSL EVP format",
+				function()
+					assertTrue(crypto.getSizeOfCompactBase64("A") >= #crypto.toCompactBase64("A"))
+					assertTrue(crypto.getSizeOfCompactBase64("Hello") >= #crypto.toCompactBase64("Hello"))
+					assertTrue(
+						crypto.getSizeOfCompactBase64(string.rep("A", 48))
+							>= #crypto.toCompactBase64(string.rep("A", 48))
+					)
+					assertTrue(
+						crypto.getSizeOfCompactBase64(string.rep("A", 49))
+							>= #crypto.toCompactBase64(string.rep("A", 49))
+					)
+					assertTrue(
+						crypto.getSizeOfCompactBase64(string.rep("A", 64))
+							>= #crypto.toCompactBase64(string.rep("A", 64))
+					)
+					assertTrue(
+						crypto.getSizeOfCompactBase64(string.rep("A", 65))
+							>= #crypto.toCompactBase64(string.rep("A", 65))
+					)
+					assertTrue(
+						crypto.getSizeOfCompactBase64(string.rep("A", 66))
+							>= #crypto.toCompactBase64(string.rep("A", 66))
+					)
+					assertTrue(
+						crypto.getSizeOfCompactBase64(string.rep("A", 666))
+							>= #crypto.toCompactBase64(string.rep("A", 666))
+					)
+					assertTrue(
+						crypto.getSizeOfCompactBase64(string.rep("A", 6666))
+							>= #crypto.toCompactBase64(string.rep("A", 6666))
+					)
+				end
+			)
+
+			it("should return the space required to store the Base64 representation in OpenSSL EVP format", function()
+				local inputs = {}
+				tinsert(inputs, openssl.random(4))
+				tinsert(inputs, openssl.random(8))
+				tinsert(inputs, openssl.random(16))
+				tinsert(inputs, openssl.random(32))
+				tinsert(inputs, openssl.random(64))
+				tinsert(inputs, openssl.random(128))
+				tinsert(inputs, openssl.random(256))
+				tinsert(inputs, openssl.random(512))
+				tinsert(inputs, openssl.random(1250))
+				tinsert(inputs, openssl.random(2500))
+				tinsert(inputs, openssl.random(5000))
+				tinsert(inputs, openssl.random(10000))
+				tinsert(inputs, openssl.random(100000))
+
+				for index, input in ipairs(inputs) do
+					local expectedMaxSize = #crypto.toBase64(input)
+					if crypto.getMaxSizeOfBase64(input) < expectedMaxSize then
+						error("Output buffer would overflow", 0)
+					end
+				end
+			end)
+		end)
+
+		describe("getSizeOfCompactBase64", function()
+			it("should return the space required to store the Base64 representation in Argon2 MCF format", function()
+				local inputs = {}
+				tinsert(inputs, openssl.random(4))
+				tinsert(inputs, openssl.random(8))
+				tinsert(inputs, openssl.random(16))
+				tinsert(inputs, openssl.random(32))
+				tinsert(inputs, openssl.random(64))
+				tinsert(inputs, openssl.random(128))
+				tinsert(inputs, openssl.random(256))
+				tinsert(inputs, openssl.random(512))
+				tinsert(inputs, openssl.random(1250))
+				tinsert(inputs, openssl.random(2500))
+				tinsert(inputs, openssl.random(5000))
+				tinsert(inputs, openssl.random(10000))
+				tinsert(inputs, openssl.random(100000))
+
+				for index, input in ipairs(inputs) do
+					local expectedMaxSize = #crypto.toCompactBase64(input)
+					if crypto.getSizeOfCompactBase64(input) < expectedMaxSize then
+						error("Output buffer would overflow", 0)
+					end
+				end
+			end)
+		end)
+	end)
+
+	describe("toBase64", function()
+		it("should return the Base64 encoded input string in OpenSSL EVP format", function()
+			local input = openssl.hex(
+				"38b341ed50ce995b20baba760bf8f9e9fc650c37bb321359f95da57b6535861151aff373a5f005c8f7b0cf6a91a139113367b1ffd8c789f2c78ec211fc93eab1",
+				false
+			)
+			local expectedOutput =
+				"OLNB7VDOmVsgurp2C/j56fxlDDe7MhNZ+V2le2U1hhFRr/NzpfAFyPewz2qRoTkR\nM2ex/9jHifLHjsIR/JPqsQ==\n"
+			assertEquals(crypto.toBase64(input), expectedOutput)
+		end)
+	end)
+
+	describe("toCompactBase64", function()
+		it("should return the Base64 encoded input string in Argon2 MCF format", function()
+			local input = openssl.hex(
+				"38b341ed50ce995b20baba760bf8f9e9fc650c37bb321359f95da57b6535861151aff373a5f005c8f7b0cf6a91a139113367b1ffd8c789f2c78ec211fc93eab1",
+				false
+			)
+			local expectedOutput =
+				"OLNB7VDOmVsgurp2C/j56fxlDDe7MhNZ+V2le2U1hhFRr/NzpfAFyPewz2qRoTkRM2ex/9jHifLHjsIR/JPqsQ"
+			assertEquals(crypto.toCompactBase64(input), expectedOutput)
+		end)
+	end)
+
+	describe("fromBase64", function()
+		it("should return the original input if a Base64-encoded string in OpenSSL EVP form was passed", function()
+			local encodedInput =
+				"OLNB7VDOmVsgurp2C/j56fxlDDe7MhNZ+V2le2U1hhFRr/NzpfAFyPewz2qRoTkR\nM2ex/9jHifLHjsIR/JPqsQ==\n"
+			local expectedOutput = openssl.hex(
+				"38b341ed50ce995b20baba760bf8f9e9fc650c37bb321359f95da57b6535861151aff373a5f005c8f7b0cf6a91a139113367b1ffd8c789f2c78ec211fc93eab1",
+				false
+			)
+			assertEquals(#crypto.fromBase64(encodedInput), #expectedOutput)
+			assertEquals(crypto.fromBase64(encodedInput), expectedOutput)
+			assertEquals(openssl.hex(crypto.fromBase64(encodedInput), false), openssl.hex(expectedOutput, false))
+		end)
+	end)
+
+	describe("fromCompactBase64", function()
+		it("should return the original input if a Base64-encoded string in Argon2 MCF form was passed", function()
+			local encodedInput =
+				"OLNB7VDOmVsgurp2C/j56fxlDDe7MhNZ+V2le2U1hhFRr/NzpfAFyPewz2qRoTkRM2ex/9jHifLHjsIR/JPqsQ"
+			local expectedOutput = openssl.hex(
+				"38b341ed50ce995b20baba760bf8f9e9fc650c37bb321359f95da57b6535861151aff373a5f005c8f7b0cf6a91a139113367b1ffd8c789f2c78ec211fc93eab1",
+				false
+			)
+			assertEquals(#crypto.fromCompactBase64(encodedInput), #expectedOutput)
+			assertEquals(crypto.fromCompactBase64(encodedInput), expectedOutput)
+			assertEquals(openssl.hex(crypto.fromCompactBase64(encodedInput), false), openssl.hex(expectedOutput, false))
+		end)
+	end)
+
+	describe("mcf", function()
+		it(
+			"should return the modular crypt formatted representation of the hash for a given set of Argon2 parameters",
+			function()
+				local hash = openssl.hex(
+					"38b341ed50ce995b20baba760bf8f9e9fc650c37bb321359f95da57b6535861151aff373a5f005c8f7b0cf6a91a139113367b1ffd8c789f2c78ec211fc93eab1",
+					false
+				)
+				local salt = "saltsalt"
+				local params = {
+					kdf = crypto.KDF_ARGON2D,
+					version = 0x13,
+					iterations = 3,
+					threads = 3,
+					lanes = 1,
+					kilobytes = 47104,
+					-- length is implicitly defind by the hash itself
+				}
+
+				local expectedMCF =
+					"$argon2d$v=19$m=47104,t=3,p=1$c2FsdHNhbHQ$OLNB7VDOmVsgurp2C/j56fxlDDe7MhNZ+V2le2U1hhFRr/NzpfAFyPewz2qRoTkRM2ex/9jHifLHjsIR/JPqsQ"
+				assertEquals(crypto.mcf(hash, salt, params), expectedMCF)
+			end
+		)
+	end)
+end)

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -2,6 +2,7 @@
 local specFiles = {
 	"Tests/BDD/globals.spec.lua",
 	"Tests/BDD/console-library.spec.lua",
+	"Tests/BDD/crypto-library.spec.lua",
 	"Tests/BDD/evo-library.spec.lua",
 	"Tests/BDD/glfw-library.spec.lua",
 	"Tests/BDD/iconv-library.spec.lua",

--- a/ninjabuild.lua
+++ b/ninjabuild.lua
@@ -37,6 +37,7 @@ local EvoBuildTarget = {
 		"Runtime/API/Networking/HttpServer.lua",
 		"Runtime/API/Networking/WebSocketTestClient.lua",
 		"Runtime/API/Networking/WebSocketServer.lua",
+		"Runtime/Bindings/crypto.lua",
 		"Runtime/Bindings/glfw.lua",
 		"Runtime/Bindings/iconv.lua",
 		"Runtime/Bindings/interop.lua",
@@ -61,6 +62,8 @@ local EvoBuildTarget = {
 	},
 	cppSources = {
 		"Runtime/main.cpp",
+		"Runtime/Bindings/crypto_argon2.cpp",
+		"Runtime/Bindings/crypto_ffi.cpp",
 		"Runtime/Bindings/glfw_ffi.cpp",
 		"Runtime/Bindings/iconv_ffi.cpp",
 		"Runtime/Bindings/interop_ffi.cpp",


### PR DESCRIPTION
This complements the existing lua-openssl bindings with an optimized implementation of Base64 (required for Argon2 MCF generation). Benchmarks show that encoding is about 3 times faster and decoding about 5 times when it uses the FFI (as opposed to the existing C API bindings), which I consider significant enough to warrant the inclusion in this module.

Needless to say, the surface area of any cryptographic code should be kept minimal, which is why there's only glue code binding to OpenSSL APIs, and a slightly modified version of the PHC Argon2 Base64 implementation.

Key derivation and verification via Argon2 is NYI, coming soon.