### PR TITLE
Add a string buffer debug utility via debug.sbuf

### DIFF
--- a/Runtime/Extensions/debugx.lua
+++ b/Runtime/Extensions/debugx.lua
@@ -1,6 +1,9 @@
 local inspect = require("inspect")
+local transform = require("transform")
 
 local print = print
+local format = string.format
+local tinsert = table.insert
 
 local MAX_TABLE_NESTING_LEVEL = 30
 local DEFAULT_OPTIONS = {
@@ -10,12 +13,30 @@ local DEFAULT_OPTIONS = {
 }
 
 local function dump(object, options)
+	if type(object) == "userdata" then
+		local hexBytes = debug.sbuf(object)
+		print(hexBytes)
+		return hexBytes
+	end
+
 	options = options or DEFAULT_OPTIONS
 	local dumpValue = inspect(object, options)
 	if not options.silent then
 		print(dumpValue)
 	end
 	return dumpValue
+end
+
+function debug.sbuf(sbuf)
+	local hexBytes = {}
+	local ptr, len = sbuf:ref()
+	for i = 1, len do
+		tinsert(hexBytes, string.format("%02x", ptr[i - 1])) -- 0-based C index
+	end
+
+	local isEmpty = (#sbuf == 0)
+	local bytes = isEmpty and "" or table.concat(hexBytes, " ")
+	return format("%s %s", transform.bold("userdata<Buffer>:"), bytes)
 end
 
 debug.dump = dump


### PR DESCRIPTION
The usual approach of calling tostring(sbuf) still works, but it isn't the most helpful representation for debugging.