### PR TITLE
Implement password hashing and verification using the Argon2 KDF

### DIFF
--- a/Runtime/Bindings/crypto_ffi.cpp
+++ b/Runtime/Bindings/crypto_ffi.cpp
@@ -1,7 +1,13 @@
 #include "crypto_ffi.hpp"
 #include "crypto_argon2.hpp"
 
+#include <openssl/core_names.h>
+#include <openssl/crypto.h>
+#include <openssl/err.h>
 #include <openssl/evp.h>
+#include <openssl/kdf.h>
+#include <openssl/params.h>
+#include <openssl/thread.h>
 
 #include <cstddef>
 #include <iostream>
@@ -44,6 +50,59 @@ size_t openssl_from_base64(unsigned char* dst, size_t dst_len, const unsigned ch
 	return out_len;
 }
 
+// Must match the number of parameters passed via kdf_parameters_t (plus end tag)
+constexpr size_t NUM_SUPPORTED_KDF_PARAMS = 7 + 1;
+
+void openssl_kdf_derive(kdf_input_t inputs, kdf_parameters_t parameters, kdf_result_t* result) {
+	result->success = false;
+
+	EVP_KDF* kdf = nullptr;
+	EVP_KDF_CTX* kctx = nullptr;
+	OSSL_PARAM params[NUM_SUPPORTED_KDF_PARAMS], *p = params;
+
+	if(OSSL_set_max_threads(nullptr, parameters.threads) != 1) {
+		std::cerr << "Failed to set_max_threads" << std::endl;
+		goto fail;
+	}
+
+	p = params;
+	*p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD, const_cast<char*>(inputs.password), inputs.pw_length);
+	*p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT, const_cast<char*>(inputs.salt), inputs.salt_length);
+	*p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_ARGON2_VERSION, &parameters.version);
+	*p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_ITER, &parameters.iterations);
+	*p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_THREADS, &parameters.threads);
+	*p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_ARGON2_LANES, &parameters.lanes);
+	*p++ = OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_ARGON2_MEMCOST, &parameters.kilobytes);
+	*p++ = OSSL_PARAM_construct_end();
+
+	if((kdf = EVP_KDF_fetch(nullptr, parameters.kdf, nullptr)) == nullptr) {
+		std::cerr << "Failed to fetch KDF " << parameters.kdf << std::endl;
+		goto fail;
+	}
+
+	if((kctx = EVP_KDF_CTX_new(kdf)) == nullptr) {
+		std::cerr << "Failed to create hashing context" << std::endl;
+		goto fail;
+	}
+
+	if(EVP_KDF_derive(kctx, &result->hash[0], parameters.size, params) != 1) {
+		std::cerr << "Failed to derive key" << std::endl;
+		goto fail;
+	}
+
+	result->success = true;
+	return;
+
+fail:
+	unsigned long error_code = ERR_get_error();
+	ERR_error_string(error_code, result->message);
+	std::cerr << "OpenSSL Error: " << result->message << std::endl;
+
+	EVP_KDF_free(kdf);
+	EVP_KDF_CTX_free(kctx);
+	OSSL_set_max_threads(nullptr, 0);
+}
+
 namespace crypto_ffi {
 
 	void* getExportsTable() {
@@ -56,6 +115,8 @@ namespace crypto_ffi {
 		exports_table.openssl_from_base64 = &openssl_from_base64;
 		exports_table.argon2_to_base64 = &argon2_to_base64;
 		exports_table.argon2_from_base64 = &argon2_from_base64;
+		exports_table.openssl_kdf_derive = &openssl_kdf_derive;
+		exports_table.openssl_crypto_memcmp = &CRYPTO_memcmp;
 
 		return &exports_table;
 	}

--- a/Runtime/Bindings/crypto_ffi.hpp
+++ b/Runtime/Bindings/crypto_ffi.hpp
@@ -1,6 +1,30 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
+
+typedef struct kdf_parameters_t {
+	const char* kdf;
+	uint32_t version;
+	uint32_t kilobytes;
+	uint32_t threads;
+	uint32_t lanes;
+	size_t size;
+	uint32_t iterations;
+} kdf_parameters_t;
+
+typedef struct kdf_input_t {
+	const char* password;
+	size_t pw_length;
+	const char* salt;
+	size_t salt_length;
+} kdf_input_t;
+
+typedef struct kdf_result_t {
+	bool success;
+	unsigned char* hash;
+	char* message;
+} kdf_result_t;
 
 struct static_crypto_exports_table {
 	// OpenSSL (libcrypto) metadata
@@ -12,15 +36,12 @@ struct static_crypto_exports_table {
 	size_t (*openssl_from_base64)(unsigned char* dst, size_t dst_len, const unsigned char* src, size_t src_len);
 	size_t (*argon2_to_base64)(unsigned char* dst, size_t dst_len, const unsigned char* src, size_t src_len);
 	size_t (*argon2_from_base64)(unsigned char* dst, size_t dst_len, const char* src);
+	void (*openssl_kdf_derive)(kdf_input_t inputs, kdf_parameters_t parameters, kdf_result_t* result);
+
+	int (*openssl_crypto_memcmp)(const void* a, const void* b, size_t len);
 };
 
 namespace crypto_ffi {
-
-	typedef enum {
-		KDF_ARGON2ID,
-		KDF_ARGON2D,
-		KDF_ARGON2I,
-	} KEY_DERIVATION_FUNCTIONS;
 
 	void* getExportsTable();
 	const char* getVersionText();

--- a/Tests/BDD/crypto-library.spec.lua
+++ b/Tests/BDD/crypto-library.spec.lua
@@ -1,20 +1,23 @@
 local crypto = require("crypto")
-local ffi = require("ffi")
 local openssl = require("openssl")
 
 local tinsert = table.insert
 
 describe("crypto", function()
-	it("should export all shared Argon2 constants", function()
-		assertEquals(crypto.KDF_ARGON2D, ffi.C.KDF_ARGON2D)
-		assertEquals(crypto.KDF_ARGON2I, ffi.C.KDF_ARGON2I)
-		assertEquals(crypto.KDF_ARGON2ID, ffi.C.KDF_ARGON2ID)
+	it("should export all shared Argon2 KDF constants", function()
+		assertEquals(crypto.KDF_ARGON2D, "ARGON2D")
+		assertEquals(crypto.KDF_ARGON2I, "ARGON2I")
+		assertEquals(crypto.KDF_ARGON2ID, "ARGON2ID")
 
-		assertEquals(crypto.DEFAULT_ARGON2_VERSION, 0x13)
+		-- Based on https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
+		assertEquals(crypto.DEFAULT_KDF_PARAMETERS.kdf, crypto.KDF_ARGON2ID)
+		assertEquals(crypto.DEFAULT_KDF_PARAMETERS.version, 0x13)
+		assertEquals(crypto.DEFAULT_KDF_PARAMETERS.kilobytes, 47104)
+		assertEquals(crypto.DEFAULT_KDF_PARAMETERS.threads, 1)
+		assertEquals(crypto.DEFAULT_KDF_PARAMETERS.lanes, 1)
 
-		assertEquals(crypto.kdfs[crypto.KDF_ARGON2D], "argon2d")
-		assertEquals(crypto.kdfs[crypto.KDF_ARGON2I], "argon2i")
-		assertEquals(crypto.kdfs[crypto.KDF_ARGON2ID], "argon2id")
+		assertEquals(crypto.DEFAULT_KDF_PARAMETERS.size, 32)
+		assertEquals(crypto.DEFAULT_KDF_PARAMETERS.iterations, 3)
 	end)
 
 	describe("version", function()
@@ -45,94 +48,87 @@ describe("crypto", function()
 				assertTrue(crypto.getMaxSizeOfBase64(string.rep("A", 6666)) >= #crypto.toBase64(string.rep("A", 6666)))
 			end
 		)
+	end)
 
-		describe("getSizeOfCompactBase64", function()
-			-- The Argon2 format is shorter, so if it returns enough space for EVP then Argon2 will also fit
-			it(
-				"should return a number that is large enough to contain the Base64 representation in OpenSSL EVP format",
-				function()
-					assertTrue(crypto.getSizeOfCompactBase64("A") >= #crypto.toCompactBase64("A"))
-					assertTrue(crypto.getSizeOfCompactBase64("Hello") >= #crypto.toCompactBase64("Hello"))
-					assertTrue(
-						crypto.getSizeOfCompactBase64(string.rep("A", 48))
-							>= #crypto.toCompactBase64(string.rep("A", 48))
-					)
-					assertTrue(
-						crypto.getSizeOfCompactBase64(string.rep("A", 49))
-							>= #crypto.toCompactBase64(string.rep("A", 49))
-					)
-					assertTrue(
-						crypto.getSizeOfCompactBase64(string.rep("A", 64))
-							>= #crypto.toCompactBase64(string.rep("A", 64))
-					)
-					assertTrue(
-						crypto.getSizeOfCompactBase64(string.rep("A", 65))
-							>= #crypto.toCompactBase64(string.rep("A", 65))
-					)
-					assertTrue(
-						crypto.getSizeOfCompactBase64(string.rep("A", 66))
-							>= #crypto.toCompactBase64(string.rep("A", 66))
-					)
-					assertTrue(
-						crypto.getSizeOfCompactBase64(string.rep("A", 666))
-							>= #crypto.toCompactBase64(string.rep("A", 666))
-					)
-					assertTrue(
-						crypto.getSizeOfCompactBase64(string.rep("A", 6666))
-							>= #crypto.toCompactBase64(string.rep("A", 6666))
-					)
+	describe("getSizeOfCompactBase64", function()
+		it(
+			"should return a number that is large enough to contain the Base64 representation in OpenSSL EVP format",
+			function()
+				assertTrue(crypto.getSizeOfCompactBase64("A") >= #crypto.toCompactBase64("A"))
+				assertTrue(crypto.getSizeOfCompactBase64("Hello") >= #crypto.toCompactBase64("Hello"))
+				assertTrue(
+					crypto.getSizeOfCompactBase64(string.rep("A", 48)) >= #crypto.toCompactBase64(string.rep("A", 48))
+				)
+				assertTrue(
+					crypto.getSizeOfCompactBase64(string.rep("A", 49)) >= #crypto.toCompactBase64(string.rep("A", 49))
+				)
+				assertTrue(
+					crypto.getSizeOfCompactBase64(string.rep("A", 64)) >= #crypto.toCompactBase64(string.rep("A", 64))
+				)
+				assertTrue(
+					crypto.getSizeOfCompactBase64(string.rep("A", 65)) >= #crypto.toCompactBase64(string.rep("A", 65))
+				)
+				assertTrue(
+					crypto.getSizeOfCompactBase64(string.rep("A", 66)) >= #crypto.toCompactBase64(string.rep("A", 66))
+				)
+				assertTrue(
+					crypto.getSizeOfCompactBase64(string.rep("A", 666)) >= #crypto.toCompactBase64(string.rep("A", 666))
+				)
+				assertTrue(
+					crypto.getSizeOfCompactBase64(string.rep("A", 6666))
+						>= #crypto.toCompactBase64(string.rep("A", 6666))
+				)
+			end
+		)
+
+		it("should return the space required to store the Base64 representation in OpenSSL EVP format", function()
+			local inputs = {}
+			tinsert(inputs, openssl.random(4))
+			tinsert(inputs, openssl.random(8))
+			tinsert(inputs, openssl.random(16))
+			tinsert(inputs, openssl.random(32))
+			tinsert(inputs, openssl.random(64))
+			tinsert(inputs, openssl.random(128))
+			tinsert(inputs, openssl.random(256))
+			tinsert(inputs, openssl.random(512))
+			tinsert(inputs, openssl.random(1250))
+			tinsert(inputs, openssl.random(2500))
+			tinsert(inputs, openssl.random(5000))
+			tinsert(inputs, openssl.random(10000))
+			tinsert(inputs, openssl.random(100000))
+
+			for index, input in ipairs(inputs) do
+				local expectedMaxSize = #crypto.toBase64(input)
+				if crypto.getMaxSizeOfBase64(input) < expectedMaxSize then
+					error("Output buffer would overflow", 0)
 				end
-			)
-
-			it("should return the space required to store the Base64 representation in OpenSSL EVP format", function()
-				local inputs = {}
-				tinsert(inputs, openssl.random(4))
-				tinsert(inputs, openssl.random(8))
-				tinsert(inputs, openssl.random(16))
-				tinsert(inputs, openssl.random(32))
-				tinsert(inputs, openssl.random(64))
-				tinsert(inputs, openssl.random(128))
-				tinsert(inputs, openssl.random(256))
-				tinsert(inputs, openssl.random(512))
-				tinsert(inputs, openssl.random(1250))
-				tinsert(inputs, openssl.random(2500))
-				tinsert(inputs, openssl.random(5000))
-				tinsert(inputs, openssl.random(10000))
-				tinsert(inputs, openssl.random(100000))
-
-				for index, input in ipairs(inputs) do
-					local expectedMaxSize = #crypto.toBase64(input)
-					if crypto.getMaxSizeOfBase64(input) < expectedMaxSize then
-						error("Output buffer would overflow", 0)
-					end
-				end
-			end)
+			end
 		end)
+	end)
 
-		describe("getSizeOfCompactBase64", function()
-			it("should return the space required to store the Base64 representation in Argon2 MCF format", function()
-				local inputs = {}
-				tinsert(inputs, openssl.random(4))
-				tinsert(inputs, openssl.random(8))
-				tinsert(inputs, openssl.random(16))
-				tinsert(inputs, openssl.random(32))
-				tinsert(inputs, openssl.random(64))
-				tinsert(inputs, openssl.random(128))
-				tinsert(inputs, openssl.random(256))
-				tinsert(inputs, openssl.random(512))
-				tinsert(inputs, openssl.random(1250))
-				tinsert(inputs, openssl.random(2500))
-				tinsert(inputs, openssl.random(5000))
-				tinsert(inputs, openssl.random(10000))
-				tinsert(inputs, openssl.random(100000))
+	describe("getSizeOfCompactBase64", function()
+		it("should return the space required to store the Base64 representation in Argon2 MCF format", function()
+			local inputs = {}
+			tinsert(inputs, openssl.random(4))
+			tinsert(inputs, openssl.random(8))
+			tinsert(inputs, openssl.random(16))
+			tinsert(inputs, openssl.random(32))
+			tinsert(inputs, openssl.random(64))
+			tinsert(inputs, openssl.random(128))
+			tinsert(inputs, openssl.random(256))
+			tinsert(inputs, openssl.random(512))
+			tinsert(inputs, openssl.random(1250))
+			tinsert(inputs, openssl.random(2500))
+			tinsert(inputs, openssl.random(5000))
+			tinsert(inputs, openssl.random(10000))
+			tinsert(inputs, openssl.random(100000))
 
-				for index, input in ipairs(inputs) do
-					local expectedMaxSize = #crypto.toCompactBase64(input)
-					if crypto.getSizeOfCompactBase64(input) < expectedMaxSize then
-						error("Output buffer would overflow", 0)
-					end
+			for index, input in ipairs(inputs) do
+				local expectedMaxSize = #crypto.toCompactBase64(input)
+				if crypto.getSizeOfCompactBase64(input) < expectedMaxSize then
+					error("Output buffer would overflow", 0)
 				end
-			end)
+			end
 		end)
 	end)
 
@@ -212,5 +208,95 @@ describe("crypto", function()
 				assertEquals(crypto.mcf(hash, salt, params), expectedMCF)
 			end
 		)
+
+		it("should use the default KDF parameters if none were passed", function()
+			local hash = openssl.hex(
+				"38b341ed50ce995b20baba760bf8f9e9fc650c37bb321359f95da57b6535861151aff373a5f005c8f7b0cf6a91a139113367b1ffd8c789f2c78ec211fc93eab1",
+				false
+			)
+			local salt = "saltsalt"
+			local expectedMCF =
+				"$argon2id$v=19$m=47104,t=1,p=1$c2FsdHNhbHQ$OLNB7VDOmVsgurp2C/j56fxlDDe7MhNZ+V2le2U1hhFRr/NzpfAFyPewz2qRoTkRM2ex/9jHifLHjsIR/JPqsQ"
+			assertEquals(crypto.mcf(hash, salt), expectedMCF)
+		end)
+	end)
+
+	describe("hash", function()
+		it("should return a failure with the OpenSSL error message if the provided salt is too short", function()
+			-- Minimum length is 8, so this will always fail to derive a key
+			local result, errorMessage = crypto.hash("password", "salt")
+			assertEquals(result, nil)
+			assertEquals(errorMessage, "OpenSSL error:1C800070:Provider routines::invalid salt length")
+		end)
+
+		it("should return the derived key if valid Argon2I parameters were passed", function()
+			local parameters = {
+				kdf = crypto.KDF_ARGON2I,
+			}
+			local expectedResult = "82615d6e6ce041b231a94b86054106c87996097f7db2e534802694b25f3fffd6"
+			assertEquals(openssl.hex(crypto.hash("password", "saltsalt", parameters)), expectedResult)
+		end)
+
+		it("should return the derived key if valid Argon2D parameters were passed", function()
+			local parameters = {
+				kdf = crypto.KDF_ARGON2D,
+			}
+			local expectedResult = "34b5ed95db7e4dd2c7140abb2b53834c8ce6bb303f7ad862c6ba5a5ace37146f"
+			assertEquals(openssl.hex(crypto.hash("password", "saltsalt", parameters)), expectedResult)
+		end)
+
+		it("should return the derived key if valid Argon2ID parameters were passed", function()
+			local parameters = {
+				kdf = crypto.KDF_ARGON2ID,
+			}
+			local expectedResult = "f2886c40de48b303c6441cb62e1bf8a0423d74bf7bd34027cc87f560c76054f1"
+			assertEquals(openssl.hex(crypto.hash("password", "saltsalt", parameters)), expectedResult)
+		end)
+
+		it("should be able to derive variable-length keys longer than the usual password lengths", function()
+			local expectedResult =
+				"8ee0698f0fec907169324128a6b43e9266226d020ef313e5bfd49d425bca8c7db87fc13e810aef32c8fb4696c39151e57ce083704df03db9aab8356873246c105a757e6dd8eb37f0df0629c2fde5f30ef1196cf49f80bcf9e81b39279e34898c676c4c96e1bb52133fe0349a7de557e920933fd53364687d0561fa66591f60852b5ffcc8f2429f7f257d3095063c898c30e536fc53fcef6ddd4c55feb72f3519025a2b82e75111f5917f57646baf1e22942f640edd716312d466acf81781ab85c2b3f5d56358c4b4b8cf18100ba14b76092ad727fb7e5fadb16ae0b85acc9401782e3f11558c5d6eb8ae6390fe0fbab30e41c764756db104c67ae3d17ad64b30"
+
+			local parameters = {
+				size = 256,
+			}
+			assertEquals(openssl.hex(crypto.hash("password", "saltsalt", parameters)), expectedResult)
+		end)
+
+		it("should use the default KDF parameters if none were passed", function()
+			local parameters = crypto.DEFAULT_KDF_PARAMETERS
+			local actual = openssl.hex(crypto.hash("password", "saltsalt"))
+			local expected = openssl.hex(crypto.hash("password", "saltsalt", parameters))
+			assertEquals(actual, expected)
+		end)
+	end)
+
+	describe("verify", function()
+		it(
+			"should return false if the given hash cannot be derived from the plaintext password, salt, and kdf parameters",
+			function()
+				local parameters = {
+					kdf = crypto.KDF_ARGON2I,
+				}
+				local hash = "82615d6e6ce041b231a94b86054106c87996097f7db2e534802694b25f3fffd?"
+				assertFalse(crypto.verify("password", "saltsalt", openssl.hex(hash, false), parameters))
+			end
+		)
+
+		it(
+			"should return true if the given hash can be derived from the plaintext password, salt, and kdf parameters",
+			function()
+				local parameters = {
+					kdf = crypto.KDF_ARGON2I,
+				}
+				local hash = "82615d6e6ce041b231a94b86054106c87996097f7db2e534802694b25f3fffd6"
+				assertTrue(crypto.verify("password", "saltsalt", openssl.hex(hash, false), parameters))
+			end
+		)
+
+		it("should use the default KDF parameters if none were passed", function()
+			local hash = "f2886c40de48b303c6441cb62e1bf8a0423d74bf7bd34027cc87f560c76054f1"
+			assertTrue(crypto.verify("password", "saltsalt", openssl.hex(hash, false), nil))
+		end)
 	end)
 end)


### PR DESCRIPTION
Doesn't support passing the MCF yet, which is likely a useful improvement that could be added in the future. Same for `hex2bin`.