### PR TITLE
Fix a minor inconsistency in the CLI help text

### DIFF
--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -122,7 +122,7 @@ end
 function evo.displayHelpText(commandName, ...)
 	local helpText = format(
 		[[
-Usage: evo [ script.lua | command ... ]
+Usage: evo [ script.lua | command ] ...
 
 Commands:
 
@@ -136,7 +136,7 @@ end
 function evo.getHelpText()
 	local helpText = format(
 		[[
-Usage: evo [ script.lua | command ... ]
+Usage: evo [ script.lua | command ] ...
 
 Commands:
 

--- a/Tests/BDD/evo-library.spec.lua
+++ b/Tests/BDD/evo-library.spec.lua
@@ -58,10 +58,10 @@ describe("evo", function()
 			evo.displayHelpText()
 			local capturedOutput = console.release()
 
-			local USAGE_PATTERN = "Usage: evo %[ script%.lua %| command %.%.%. %]"
+			local USAGE_PATTERN = "Usage: evo %[ script%.lua %| command %] %.%.%."
 
 			local usageInfoText = capturedOutput:match(USAGE_PATTERN)
-			assertEquals(usageInfoText, "Usage: evo [ script.lua | command ... ]")
+			assertEquals(usageInfoText, "Usage: evo [ script.lua | command ] ...")
 		end)
 
 		it("should display the list of available commands", function()


### PR DESCRIPTION
The varargs ... indicates that additional arguments will be passed to the command handler. However, this is also true when invoking the default handler (script loader) - at least from the user's perspective, since CLI args are passed via the `arg` global.