### PR TITLE
Implement aliases for registered CLI commands via the CommandLine API

### DIFF
--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -116,6 +116,12 @@ function evo.setUpCommandLineInterface()
 	C_CommandLine.RegisterCommand("version", evo.displayRuntimeVersion, "Show versioning information only")
 	C_CommandLine.RegisterCommand("eval", evo.evaluateChunk, "Evaluate the next token as a Lua chunk")
 	C_CommandLine.RegisterCommand("build", evo.buildZipApp, "Create a self-contained executable")
+
+	C_CommandLine.SetAlias("help", "-h")
+	C_CommandLine.SetAlias("version", "-v")
+	C_CommandLine.SetAlias("eval", "-e")
+	C_CommandLine.SetAlias("build", "-b")
+
 	C_CommandLine.SetDefaultHandler(evo.onInvalidCommand)
 end
 

--- a/Tests/BDD/evo-library.spec.lua
+++ b/Tests/BDD/evo-library.spec.lua
@@ -75,15 +75,18 @@ describe("evo", function()
 			evo.displayHelpText()
 			local capturedOutput = console.release()
 
-			local evalCommandInfo = capturedOutput:match("eval" .. "%s+" .. "Evaluate the next token as a Lua chunk")
-			local helpCommandInfo = capturedOutput:match("help" .. "%s+" .. "Display usage instructions %(this text%)")
-			local versionCommandInfo = capturedOutput:match("version" .. "%s+" .. "Show versioning information")
-			local buildCommandInfo = capturedOutput:match("build" .. "%s+" .. "Create a self%-contained executable")
+			local evalCommandInfo =
+				capturedOutput:match("%-e, eval" .. "%s+" .. "Evaluate the next token as a Lua chunk")
+			local helpCommandInfo =
+				capturedOutput:match("%-h, help" .. "%s+" .. "Display usage instructions %(this text%)")
+			local versionCommandInfo = capturedOutput:match("%-v, version" .. "%s+" .. "Show versioning information")
+			local buildCommandInfo =
+				capturedOutput:match("%-b, build" .. "%s+" .. "Create a self%-contained executable")
 
-			assertEquals(evalCommandInfo, "eval\t\tEvaluate the next token as a Lua chunk")
-			assertEquals(helpCommandInfo, "help\t\tDisplay usage instructions (this text)")
-			assertEquals(versionCommandInfo, "version\t\tShow versioning information")
-			assertEquals(buildCommandInfo, "build\t\tCreate a self-contained executable")
+			assertEquals(evalCommandInfo, "-e, eval\t\tEvaluate the next token as a Lua chunk")
+			assertEquals(helpCommandInfo, "-h, help\t\tDisplay usage instructions (this text)")
+			assertEquals(versionCommandInfo, "-v, version\t\tShow versioning information")
+			assertEquals(buildCommandInfo, "-b, build\t\tCreate a self-contained executable")
 		end)
 	end)
 

--- a/Tests/BDD/evo-library.spec.lua
+++ b/Tests/BDD/evo-library.spec.lua
@@ -53,6 +53,12 @@ describe("evo", function()
 	end)
 
 	describe("displayHelpText", function()
+		before(function()
+			-- Handlers may have been removed by the C_CommandLine tests
+			C_CommandLine.UnregisterAllCommands()
+			evo.setUpCommandLineInterface()
+		end)
+
 		it("should display the usage instructions", function()
 			console.capture()
 			evo.displayHelpText()


### PR DESCRIPTION
The primary benefit here is that the runtime now accepts chunks via `-e`, which enables live debugging in VS Code,