### PR TITLE
Reorder the parameters of miniz checksum APIs

### DIFF
--- a/Runtime/Bindings/lminiz.cpp
+++ b/Runtime/Bindings/lminiz.cpp
@@ -365,18 +365,18 @@ static int ltdefl(lua_State* L) {
 }
 
 static int lmz_adler32(lua_State* L) {
-	mz_ulong adler = luaL_optinteger(L, 1, 0);
+	mz_ulong adler = luaL_optinteger(L, 2, 0);
 	size_t buf_len = 0;
-	const unsigned char* ptr = reinterpret_cast<const unsigned char*>(luaL_optlstring(L, 2, NULL, &buf_len));
+	const unsigned char* ptr = reinterpret_cast<const unsigned char*>(luaL_optlstring(L, 1, NULL, &buf_len));
 	adler = mz_adler32(adler, ptr, buf_len);
 	lua_pushinteger(L, adler);
 	return 1;
 }
 
 static int lmz_crc32(lua_State* L) {
-	mz_ulong crc32 = luaL_optinteger(L, 1, 0);
+	mz_ulong crc32 = luaL_optinteger(L, 2, 0);
 	size_t buf_len = 0;
-	const unsigned char* ptr = reinterpret_cast<const unsigned char*>(luaL_optlstring(L, 2, NULL, &buf_len));
+	const unsigned char* ptr = reinterpret_cast<const unsigned char*>(luaL_optlstring(L, 1, NULL, &buf_len));
 	crc32 = mz_crc32(crc32, ptr, buf_len);
 	lua_pushinteger(L, crc32);
 	return 1;

--- a/Tests/BDD/miniz-library.spec.lua
+++ b/Tests/BDD/miniz-library.spec.lua
@@ -50,16 +50,16 @@ describe("miniz", function()
 
 	describe("adler32", function()
 		it("should return a checksum for the given input string", function()
-			local checksum = miniz.adler32(1, "Hello world")
+			local checksum = miniz.adler32("Hello world", 1)
 			assertEquals(checksum, 413860925)
 		end)
 
 		it("should generate the same checksum regardless of how it is computed", function()
-			local checksum1 = miniz.adler32(1, "one two")
+			local checksum1 = miniz.adler32("one two", 1)
 			assertEquals(checksum1, 181797565)
 
-			local checksum2 = miniz.adler32(1, "one")
-			checksum2 = miniz.adler32(checksum2, " two")
+			local checksum2 = miniz.adler32("one", 1)
+			checksum2 = miniz.adler32(" two", checksum2)
 
 			assertEquals(checksum1, checksum2)
 		end)
@@ -67,16 +67,16 @@ describe("miniz", function()
 
 	describe("crc32", function()
 		it("should return a checksum for the given input string", function()
-			local checksum = miniz.crc32(0, "Hello world")
+			local checksum = miniz.crc32("Hello world")
 			assertEquals(checksum, 2346098258)
 		end)
 
 		it("should generate the same checksum regardless of how it is computed", function()
-			local checksum1 = miniz.crc32(0, "one two")
+			local checksum1 = miniz.crc32("one two")
 			assertEquals(checksum1, 3439823151)
 
-			local checksum2 = miniz.crc32(0, "one")
-			checksum2 = miniz.crc32(checksum2, " two")
+			local checksum2 = miniz.crc32("one")
+			checksum2 = miniz.crc32(" two", checksum2)
 
 			assertEquals(checksum1, checksum2)
 		end)


### PR DESCRIPTION
The documentation has this inverted, presumably because it was the more intuitive order. I understand that checksums are "objects" internally and so passing it as the first parameter might make sense from a technical perspective, but as a user of the API it's confusing.

The most common use case is "give me the checksum of this string", and optimizing for the common case means moving the IV so that it feels more optional than the actual input - even if, technically speaking, both are optional (as per the code).