### PR TITLE
Slightly modify the format for CLI shorthands

### DIFF
--- a/Runtime/API/C_CommandLine.lua
+++ b/Runtime/API/C_CommandLine.lua
@@ -74,8 +74,8 @@ function C_CommandLine.GetUsageInfo()
 	for index, commandName in ipairs(sortedCommandNames) do
 		local commandInfo = commands[commandName]
 		local alias = C_CommandLine.aliases[commandName]
-		local aliasText = alias and (alias .. ", ") or ""
-		usageInfoText = usageInfoText .. "\t" .. aliasText .. commandName .. "\t\t" .. commandInfo.description .. "\n"
+		local commandText = alias and (alias .. "\t" .. commandName .. "") or commandName
+		usageInfoText = usageInfoText .. "\t" .. commandText .. "\t\t" .. commandInfo.description .. "\n"
 	end
 
 	return usageInfoText

--- a/Tests/BDD/commandline-namespace.spec.lua
+++ b/Tests/BDD/commandline-namespace.spec.lua
@@ -248,7 +248,7 @@ describe("C_CommandLine", function()
 
 				assertEquals(
 					C_CommandLine.GetUsageInfo(),
-					"\t-b, bar\t\tDoes something\n" .. "\tfoo\t\tDoes something else\n"
+					"\t-b\tbar\t\tDoes something\n" .. "\tfoo\t\tDoes something else\n"
 				)
 
 				-- Cleanup

--- a/Tests/BDD/evo-library.spec.lua
+++ b/Tests/BDD/evo-library.spec.lua
@@ -76,17 +76,18 @@ describe("evo", function()
 			local capturedOutput = console.release()
 
 			local evalCommandInfo =
-				capturedOutput:match("%-e, eval" .. "%s+" .. "Evaluate the next token as a Lua chunk")
+				capturedOutput:match("%-e" .. "%s+" .. "eval" .. "%s+" .. "Evaluate the next token as a Lua chunk")
 			local helpCommandInfo =
-				capturedOutput:match("%-h, help" .. "%s+" .. "Display usage instructions %(this text%)")
-			local versionCommandInfo = capturedOutput:match("%-v, version" .. "%s+" .. "Show versioning information")
+				capturedOutput:match("%-h" .. "%s+" .. "help" .. "%s+" .. "Display usage instructions %(this text%)")
+			local versionCommandInfo =
+				capturedOutput:match("%-v" .. "%s+" .. "version" .. "%s+" .. "Show versioning information")
 			local buildCommandInfo =
-				capturedOutput:match("%-b, build" .. "%s+" .. "Create a self%-contained executable")
+				capturedOutput:match("%-b" .. "%s+" .. "build" .. "%s+" .. "Create a self%-contained executable")
 
-			assertEquals(evalCommandInfo, "-e, eval\t\tEvaluate the next token as a Lua chunk")
-			assertEquals(helpCommandInfo, "-h, help\t\tDisplay usage instructions (this text)")
-			assertEquals(versionCommandInfo, "-v, version\t\tShow versioning information")
-			assertEquals(buildCommandInfo, "-b, build\t\tCreate a self-contained executable")
+			assertEquals(evalCommandInfo, "-e\teval\t\tEvaluate the next token as a Lua chunk")
+			assertEquals(helpCommandInfo, "-h\thelp\t\tDisplay usage instructions (this text)")
+			assertEquals(versionCommandInfo, "-v\tversion\t\tShow versioning information")
+			assertEquals(buildCommandInfo, "-b\tbuild\t\tCreate a self-contained executable")
 		end)
 	end)
 


### PR DESCRIPTION
Not sure if it's better, but it looks a little cleaner this way.