### PR TITLE
Update zlib to the latest HEAD

### DIFF
--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -163,6 +163,10 @@ function evo.getVersionText()
 	local major, minor = string.match(regex.version(), "^(%d+)%.(%d+)")
 	local semanticPcre2VersionString = major .. "." .. minor .. "." .. 0
 
+	-- zlib versions don't include a patch version if it's a clean major/minor release
+	local zlibVersionMajor, zlibVersionMinor, zlibVersionPatch = zlib.version()
+	local semanticZlibVersionString = format("%d.%d.%d", zlibVersionMajor, zlibVersionMinor, zlibVersionPatch or 0)
+
 	local embeddedLibraryVersions = {
 		glfw = glfw.version(),
 		libuv = uv.version_string(),
@@ -175,7 +179,7 @@ function evo.getVersionText()
 		uws = uws.version(),
 		wgpu = webgpu.version(),
 		webview = webview.version(),
-		zlib = format("%d.%d.%d", zlib.version()),
+		zlib = semanticZlibVersionString,
 		-- Since the ordering of pairs isn't well-defined, enforce alphabetic order for the CLI output
 		"glfw",
 		"libuv",

--- a/Tests/BDD/zlib-library.spec.lua
+++ b/Tests/BDD/zlib-library.spec.lua
@@ -6,7 +6,9 @@ describe("zlib", function()
 			local major, minor, patch = zlib.version()
 			assertEquals(type(major), "number")
 			assertEquals(type(minor), "number")
-			assertEquals(type(patch), "number")
+			if patch then -- May be nil if it's a clean major/minor release
+				assertEquals(type(patch), "number")
+			end
 		end)
 	end)
 


### PR DESCRIPTION
Build failure is due to `zlib.version()` returning `nil` as the patch version. Unfortunate, but a workaround will have to do.