### PR TITLE
Add more window APIs to the GLFW bindings

### DIFF
--- a/Runtime/Bindings/glfw.lua
+++ b/Runtime/Bindings/glfw.lua
@@ -46,6 +46,11 @@ glfw.cdefs = [[
 		void (*glfw_set_window_pos)(GLFWwindow* window, int xpos, int ypos);
 		void (*glfw_get_framebuffer_size)(GLFWwindow* window, int* width, int* height);
 		void (*glfw_get_window_size)(GLFWwindow* window, int* width, int* height);
+		void (*glfw_maximize_window)(GLFWwindow* window);
+		void (*glfw_restore_window)(GLFWwindow* window);
+		void (*glfw_hide_window)(GLFWwindow* window);
+		void (*glfw_show_window)(GLFWwindow* window);
+		int (*glfw_get_window_attrib)(GLFWwindow* window, int attrib);
 
 		void (*glfw_register_events)(GLFWwindow* window, deferred_event_queue_t queue);
 

--- a/Runtime/Bindings/glfw_ffi.cpp
+++ b/Runtime/Bindings/glfw_ffi.cpp
@@ -244,6 +244,11 @@ namespace glfw_ffi {
 		glfw_exports_table.glfw_set_window_pos = glfwSetWindowPos;
 		glfw_exports_table.glfw_get_framebuffer_size = glfwGetFramebufferSize;
 		glfw_exports_table.glfw_get_window_size = glfwGetWindowSize;
+		glfw_exports_table.glfw_maximize_window = glfwMaximizeWindow;
+		glfw_exports_table.glfw_restore_window = glfwRestoreWindow;
+		glfw_exports_table.glfw_hide_window = glfwHideWindow;
+		glfw_exports_table.glfw_show_window = glfwShowWindow;
+		glfw_exports_table.glfw_get_window_attrib = glfwGetWindowAttrib;
 
 		glfw_exports_table.glfw_register_events = glfw_register_events;
 

--- a/Runtime/Bindings/glfw_ffi.hpp
+++ b/Runtime/Bindings/glfw_ffi.hpp
@@ -43,6 +43,11 @@ struct static_glfw_exports_table {
 	void (*glfw_set_window_pos)(GLFWwindow* window, int xpos, int ypos);
 	void (*glfw_get_framebuffer_size)(GLFWwindow* window, int* width, int* height);
 	void (*glfw_get_window_size)(GLFWwindow* window, int* width, int* height);
+	void (*glfw_maximize_window)(GLFWwindow* window);
+	void (*glfw_restore_window)(GLFWwindow* window);
+	void (*glfw_hide_window)(GLFWwindow* window);
+	void (*glfw_show_window)(GLFWwindow* window);
+	int (*glfw_get_window_attrib)(GLFWwindow* window, int attrib);
 
 	void (*glfw_register_events)(GLFWwindow* window, deferred_event_queue_t queue);
 

--- a/Tests/Integration/glfw-window-size.lua
+++ b/Tests/Integration/glfw-window-size.lua
@@ -36,3 +36,23 @@ printf(
 	contentWidthInPixels[0],
 	contentHeightInPixels[0]
 )
+
+-- Should probably create more elaborate scenarios for window management here?
+-- Deferred for now since the bindings need a do-over, anyway (reorganize later)
+local uv = require("uv")
+
+glfw.bindings.glfw_maximize_window(window)
+uv.sleep(1000)
+
+local GLFW_MAXIMIZED = glfw.bindings.glfw_find_constant("GLFW_MAXIMIZED")
+local maximized = glfw.bindings.glfw_get_window_attrib(window, GLFW_MAXIMIZED)
+assert(maximized == 0, "Window should not be maximized (window hints disallow it)")
+
+glfw.bindings.glfw_restore_window(window)
+uv.sleep(1000)
+
+glfw.bindings.glfw_hide_window(window)
+uv.sleep(1000)
+
+glfw.bindings.glfw_show_window(window)
+uv.sleep(1000)


### PR DESCRIPTION
The tests could certainly be more extensive, but I'm not sure what use cases should be covered here. For now, making sure the API is available will suffice, but after the planned streamlining of the FFI bindings this will need to be improved.