### PR TITLE
Ensure a clean shutdown of the uws event loop

### DIFF
--- a/Runtime/Bindings/uws_ffi.cpp
+++ b/Runtime/Bindings/uws_ffi.cpp
@@ -251,8 +251,12 @@ namespace uws_ffi {
 		return &uwebsockets_exports_table;
 	}
 
-	void assignEventLoop(void* existing_native_loop) {
-		uWS::Loop::get(existing_native_loop); // Actually: Assign and then return
+	uWS::Loop* assignEventLoop(void* existing_native_loop) {
+		return uWS::Loop::get(existing_native_loop); // Actually: Assign and then return
+	}
+
+	void unassignEventLoop(uWS::Loop* loop) {
+		loop->free();
 	}
 
 	std::string opCodeToString(uWS::OpCode opCode) {

--- a/Runtime/Bindings/uws_ffi.hpp
+++ b/Runtime/Bindings/uws_ffi.hpp
@@ -78,7 +78,8 @@ typedef struct static_uws_exports_table {
 
 namespace uws_ffi {
 	void* getExportsTable();
-	void assignEventLoop(void* existing_native_loop);
+	uWS::Loop* assignEventLoop(void* existing_native_loop);
+	void unassignEventLoop(uWS::Loop* uwsEventLoop);
 	std::string opCodeToString(uWS::OpCode opCode);
 	std::string compressOptionsToString(uWS::CompressOptions compressOption);
 }

--- a/Runtime/main.cpp
+++ b/Runtime/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* argv[]) {
 
 	// A bit of a hack; Can't use uv_default_loop because luv maintains a separate "default" loop of its own
 	uv_loop_t* loop = luv_loop(luaVM->GetState());
-	uws_ffi::assignEventLoop(loop);
+	auto uwsEventLoop = uws_ffi::assignEventLoop(loop); // TBD: 5 handles created here...
 
 	std::string mainChunk = "local evo = require('evo'); return evo.run()";
 	std::string chunkName = "=(Lua entry point, at " FROM_HERE ")";
@@ -64,5 +64,6 @@ int main(int argc, char* argv[]) {
 
 	uv_run(loop, UV_RUN_DEFAULT);
 
+	uws_ffi::unassignEventLoop(uwsEventLoop);
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
There are a number of handles that uws creates internally. These need to be unhooked from the libuv event loop (and the Lua VM's state) as otherwise the runtime will crash when the Lua state is being closed.

The luv shutdown sequence involves calling all of the now-invalid handles, which results in a SEGFAULT if any of the uws handles is still linked to the event loop (and corresponding Lua state). This is exactly what happens when deleting the `LuaVirtualMachine`.