### PR TITLE
Fix a crash in os.exit when the close parameter is set to true

### DIFF
--- a/Runtime/LuaVirtualMachine.cpp
+++ b/Runtime/LuaVirtualMachine.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 
 #include "macros.hpp"
+#include "uws_ffi.hpp"
 
 #include "LuaVirtualMachine.hpp"
 
@@ -20,6 +21,32 @@ int onLuaError(lua_State* m_luaState) {
 	return EXIT_FAILURE; // It's an error, after all
 }
 
+void unregister_uws_handles(lua_State* m_luaState) {
+	lua_getglobal(m_luaState, "UWS_EVENT_LOOP");
+	void* userdataPointer = lua_touserdata(m_luaState, -1);
+
+	if(userdataPointer != nullptr) {
+		auto uwsEventLoop = static_cast<uWS::Loop*>(userdataPointer);
+		uws_ffi::unassignEventLoop(uwsEventLoop);
+
+		lua_pushnil(m_luaState);
+		lua_setglobal(m_luaState, "UWS_EVENT_LOOP");
+	}
+	lua_pop(m_luaState, 1);
+}
+
+int modified_os_exit(lua_State* m_luaState) {
+	// Should probably check for close=true here, but it seems uws can deal with it just fine
+	unregister_uws_handles(m_luaState);
+
+	// Have to move the original function before the arguments before calling it
+	lua_getfield(m_luaState, LUA_REGISTRYINDEX, "default_os_exit");
+	lua_insert(m_luaState, 1);
+	lua_call(m_luaState, lua_gettop(m_luaState) - 1, LUA_MULTRET);
+
+	return lua_gettop(m_luaState);
+}
+
 LuaVirtualMachine::LuaVirtualMachine() {
 	m_relativeStackOffset = 0;
 
@@ -36,6 +63,15 @@ LuaVirtualMachine::LuaVirtualMachine() {
 	// This global table simply exports the static APIs embedded within the runtime for the FFI to call into
 	lua_newtable(m_luaState);
 	lua_setglobal(m_luaState, "STATIC_FFI_EXPORTS");
+
+	// Not pretty, but os.exit doesn't unassign the uws loop (which crashes the runtime if close=true)
+	lua_getglobal(m_luaState, "os");
+	lua_getfield(m_luaState, -1, "exit");
+	lua_setfield(m_luaState, LUA_REGISTRYINDEX, "default_os_exit");
+
+	lua_pushcfunction(m_luaState, modified_os_exit);
+	lua_setfield(m_luaState, -2, "exit");
+	lua_pop(m_luaState, 1);
 
 	this->CheckStack();
 }
@@ -133,6 +169,11 @@ void LuaVirtualMachine::CreateGlobalNamespace(std::string name) {
 
 void LuaVirtualMachine::AssignGlobalVariable(std::string key, std::string value) {
 	lua_pushstring(m_luaState, value.c_str());
+	lua_setglobal(m_luaState, key.c_str());
+}
+
+void LuaVirtualMachine::AssignGlobalVariable(std::string key, void* lightUserdataPointer) {
+	lua_pushlightuserdata(m_luaState, lightUserdataPointer);
 	lua_setglobal(m_luaState, key.c_str());
 }
 

--- a/Runtime/LuaVirtualMachine.hpp
+++ b/Runtime/LuaVirtualMachine.hpp
@@ -20,6 +20,7 @@ public:
 	void BindStaticLibraryExports(std::string fieldName, void* staticExportsTable);
 	void CreateGlobalNamespace(std::string name);
 	void AssignGlobalVariable(std::string key, std::string value);
+	void AssignGlobalVariable(std::string key, void* lightUserdataPointer);
 	bool CheckStack();
 	lua_State* GetState();
 

--- a/Runtime/main.cpp
+++ b/Runtime/main.cpp
@@ -52,6 +52,7 @@ int main(int argc, char* argv[]) {
 	// A bit of a hack; Can't use uv_default_loop because luv maintains a separate "default" loop of its own
 	uv_loop_t* loop = luv_loop(luaVM->GetState());
 	auto uwsEventLoop = uws_ffi::assignEventLoop(loop);
+	luaVM->AssignGlobalVariable("UWS_EVENT_LOOP", static_cast<void*>(uwsEventLoop));
 
 	std::string mainChunk = "local evo = require('evo'); return evo.run()";
 	std::string chunkName = "=(Lua entry point, at " FROM_HERE ")";

--- a/Tests/integration-test.lua
+++ b/Tests/integration-test.lua
@@ -23,4 +23,4 @@ local testFiles = {
 }
 
 local numFailedTests = C_Runtime.RunBasicTests(testFiles)
-os.exit(numFailedTests)
+os.exit(numFailedTests, true)

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -32,4 +32,4 @@ local specFiles = {
 
 local numFailedSections = C_Runtime.RunDetailedTests(#arg > 0 and arg or specFiles)
 
-os.exit(numFailedSections)
+os.exit(numFailedSections, true)


### PR DESCRIPTION
Need to manually unassign the uws loop here as otherwise there'll be a SEGFAULT when LuaJIT shuts down the Lua state and luv calls the active handles (which should have been removed by this time).

Not sure if it's a good idea to merge this yet, as there have been some crashes still (that may or may not be related). TBD...