### PR TITLE
Add proper input validation to iconv.convert (should fix the sporadic crashes)

### DIFF
--- a/Runtime/Bindings/iconv.lua
+++ b/Runtime/Bindings/iconv.lua
@@ -18,6 +18,12 @@ end
 local UTF_BYTES_PER_CODEPOINT = 4
 
 function iconv.convert(input, inputEncoding, outputEncoding)
+
+	if #input == 0 then
+		-- Prevents LuaJIT from trying to collect a NULL buffer (= crash)
+		return "", 0
+	end
+
 	local inputBuffer = ffi.new("char[?]", #input, input) -- Wasteful, but iconv modifies the input buffer
 	local maxOutputBufferSize = #input * UTF_BYTES_PER_CODEPOINT -- Worst case scenario (also wasteful)
 	local outputBuffer = buffer.new(maxOutputBufferSize)

--- a/Runtime/Bindings/iconv.lua
+++ b/Runtime/Bindings/iconv.lua
@@ -1,4 +1,7 @@
 local ffi = require("ffi")
+local validation = require("validation")
+
+local validateString = validation.validateString
 
 local tonumber = tonumber
 local tostring = tostring
@@ -18,6 +21,9 @@ end
 local UTF_BYTES_PER_CODEPOINT = 4
 
 function iconv.convert(input, inputEncoding, outputEncoding)
+	validateString(input, "input")
+	validateString(inputEncoding, "inputEncoding")
+	validateString(outputEncoding, "outputEncoding")
 
 	if #input == 0 then
 		-- Prevents LuaJIT from trying to collect a NULL buffer (= crash)

--- a/Tests/BDD/iconv-library.spec.lua
+++ b/Tests/BDD/iconv-library.spec.lua
@@ -86,5 +86,32 @@ describe("iconv", function()
 			assertEquals(output, "")
 			assertEquals(numBytesWritten, 0)
 		end)
+
+		it("should throw if a non-string input was passed", function()
+			local function convertWithInvalidInput()
+				iconv.convert(42, "CP949", "UTF-8")
+			end
+			local expectedErrorMessage =
+				"Expected argument input to be a string value, but received a number value instead"
+			assertThrows(convertWithInvalidInput, expectedErrorMessage)
+		end)
+
+		it("should throw if a non-string input encoding was passed", function()
+			local function convertWithInvalidInputEncoding()
+				iconv.convert("Hey!", 42, "UTF-8")
+			end
+			local expectedErrorMessage =
+				"Expected argument inputEncoding to be a string value, but received a number value instead"
+			assertThrows(convertWithInvalidInputEncoding, expectedErrorMessage)
+		end)
+
+		it("should throw if a non-string output encoding was passed", function()
+			local function convertWithInvalidOutputEncoding()
+				iconv.convert("Hello!", "CP949", 42)
+			end
+			local expectedErrorMessage =
+				"Expected argument outputEncoding to be a string value, but received a number value instead"
+			assertThrows(convertWithInvalidOutputEncoding, expectedErrorMessage)
+		end)
 	end)
 end)

--- a/Tests/BDD/iconv-library.spec.lua
+++ b/Tests/BDD/iconv-library.spec.lua
@@ -113,5 +113,11 @@ describe("iconv", function()
 				"Expected argument outputEncoding to be a string value, but received a number value instead"
 			assertThrows(convertWithInvalidOutputEncoding, expectedErrorMessage)
 		end)
+
+		it("should be able to deal with large inputs", function()
+			local largeInput = string.rep("A", 1000000)
+			local output = iconv.convert(largeInput, "UTF-8", "CP949")
+			assertEquals(largeInput, output)
+		end)
 	end)
 end)


### PR DESCRIPTION
Finally resolves #300 - it's about time. Despite the problem being so simple, clearly I had a huge blind spot there.