### PR TITLE
Streamline the build process for lua-rapidjson

### DIFF
--- a/deps/rapidjson-unixbuild.sh
+++ b/deps/rapidjson-unixbuild.sh
@@ -3,29 +3,26 @@ set -e
 echo "Building target rapidjson"
 
 SRC_DIR=$(pwd)/deps/xpol/lua-rapidjson
+BUILD_DIR=$SRC_DIR/cmakebuild-unix
 OUT_DIR=$(pwd)/ninjabuild-unix
-BUILD_DIR=$OUT_DIR/deps/xpol/lua-rapidjson
 LUAJIT_DIR=$(pwd)/deps/LuaJIT/LuaJIT
 LUAJIT_SOURCE_DIR=$LUAJIT_DIR/src
-RAPIDJSON_INCLUDE_DIR=$SRC_DIR/rapidjson/include
 
-mkdir -p $BUILD_DIR
+cleanup() {
+    echo "Reverting CMakeLists patch (to make sure the build is idempotent)"
+    cd $SRC_DIR
+    git apply -R ../cmakebuild-static.diff
+    cd -
+}
 
-# Replicated version detection from CMakeLists.txt
+trap cleanup EXIT
+
+echo "Applying CMakeLists patch (this should hopefully be temporary)"
 cd $SRC_DIR
-DISCOVERED_VERSION_TAG=$(git describe --tags --abbrev=0)
-echo "Discovered lua-rapidjson version: $DISCOVERED_VERSION_TAG"
+git apply ../cmakebuild-static.diff
 cd -
 
-# The CMakeLists.txt file doesn't support static builds, so homebrew it is...
-echo "Compiling sources from $SRC_DIR"
-echo "Using rapidjson from $RAPIDJSON_INCLUDE_DIR"
+cmake -S $SRC_DIR -B $BUILD_DIR -G Ninja -DLUA_INCLUDE_DIR=$LUAJIT_SOURCE_DIR -DCMAKE_C_COMPILER=gcc
+cmake --build $BUILD_DIR --clean-first
 
-for file in $(find $SRC_DIR -name "*.cpp")
-do
-    file_name=$(basename $file .cpp)
-    g++ -c -o $BUILD_DIR/${file_name}.o $file -I $LUAJIT_SOURCE_DIR -I $RAPIDJSON_INCLUDE_DIR -DLUA_RAPIDJSON_VERSION=\"$DISCOVERED_VERSION_TAG\" -std=c++11
-done
-
-echo "Creating static library $OUT_DIR/librapidjson.a"
-ar rcs $OUT_DIR/librapidjson.a $BUILD_DIR/*.o
+cp $BUILD_DIR/rapidjson.a $OUT_DIR/librapidjson.a

--- a/deps/rapidjson-windowsbuild.sh
+++ b/deps/rapidjson-windowsbuild.sh
@@ -3,29 +3,27 @@ set -e
 echo "Building target rapidjson"
 
 SRC_DIR=$(pwd)/deps/xpol/lua-rapidjson
+BUILD_DIR=$SRC_DIR/cmakebuild-windows
 OUT_DIR=$(pwd)/ninjabuild-windows
-BUILD_DIR=$OUT_DIR/deps/xpol/lua-rapidjson
 LUAJIT_DIR=$(pwd)/deps/LuaJIT/LuaJIT
 LUAJIT_SOURCE_DIR=$LUAJIT_DIR/src
-RAPIDJSON_INCLUDE_DIR=$SRC_DIR/rapidjson/include
+LUA_LIBRARIES=$BUILD_DIR/libluajit.a
 
-mkdir -p $BUILD_DIR
+cleanup() {
+    echo "Reverting CMakeLists patch (to make sure the build is idempotent)"
+    cd $SRC_DIR
+    git apply -R ../cmakebuild-static.diff
+    cd -
+}
 
-# Replicated version detection from CMakeLists.txt
+trap cleanup EXIT
+
+echo "Applying CMakeLists patch (this should hopefully be temporary)"
 cd $SRC_DIR
-DISCOVERED_VERSION_TAG=$(git describe --tags --abbrev=0)
-echo "Discovered lua-rapidjson version: $DISCOVERED_VERSION_TAG"
+git apply ../cmakebuild-static.diff
 cd -
 
-# The CMakeLists.txt file doesn't support static builds, so homebrew it is...
-echo "Compiling sources from $SRC_DIR"
-echo "Using rapidjson from $RAPIDJSON_INCLUDE_DIR"
+cmake -S $SRC_DIR -B $BUILD_DIR -G Ninja -DLUA_INCLUDE_DIR=$LUAJIT_SOURCE_DIR -DLUA_LIBRARIES=$LUA_LIBRARIES -DCMAKE_C_COMPILER=gcc
+cmake --build $BUILD_DIR --clean-first
 
-for file in $(find $SRC_DIR -name "*.cpp")
-do
-    file_name=$(basename $file .cpp)
-    g++ -c -o $BUILD_DIR/${file_name}.o $file -I $LUAJIT_SOURCE_DIR -I $RAPIDJSON_INCLUDE_DIR -DLUA_RAPIDJSON_VERSION=\"$DISCOVERED_VERSION_TAG\" -std=c++11
-done
-
-echo "Creating static library $OUT_DIR/librapidjson.a"
-ar rcs $OUT_DIR/librapidjson.a $BUILD_DIR/*.o
+cp $BUILD_DIR/rapidjson.a $OUT_DIR/librapidjson.a

--- a/deps/xpol/cmakebuild-static.diff
+++ b/deps/xpol/cmakebuild-static.diff
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ddc8716..735e9d0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -68,7 +68,7 @@ set(SOURCES
+     src/values.hpp
+ )
+ 
+-add_library(lua-rapidjson MODULE ${SOURCES})
++add_library(lua-rapidjson STATIC ${SOURCES})
+ if(${CMAKE_VERSION} VERSION_LESS "3.1.0")
+     if(CMAKE_COMPILER_IS_GNUCXX)
+         execute_process(COMMAND "${CMAKE_CXX_COMPILER} -dumpversion" OUTPUT_VARIABLE GCC_VERSION)


### PR DESCRIPTION
Hardcoding compiler commands makes it more painful to fix the shellcheck warnings, while also being more difficult to maintain.

Unfortunately, the build system doesn't support static builds, but it's probably easier to just patch it since the repo isn't very active.