### PR TITLE
Update the StyLua version used for autoformat to v0.19.1

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --check . --verbose
-          version: v0.15.1
+          version: v0.19.1
 
       - name: Run autoformat
         run: ./autoformat.sh


### PR DESCRIPTION
This fixes an issue with LuaJIT-specific number formats (e.g., ULL).