### PR TITLE
Update the luacheck config to ignore jit modules

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3,6 +3,7 @@ max_line_length = false
 exclude_files = {
 	"luacheckrc",
 	"deps/",
+	"ninjabuild-*/",
 }
 ignore = {
 	"142", -- setting undefined field of global (likely a nonstandard extension)


### PR DESCRIPTION
These are generated during the build process and needn't be scanned.