### PR TITLE
Repair nested setup and teardown functions in the bdd library

### DIFF
--- a/Runtime/Libraries/bdd.lua
+++ b/Runtime/Libraries/bdd.lua
@@ -180,7 +180,7 @@ function bdd.getReport()
 	return tostring(bdd.reportBuffer)
 end
 
-function bdd.describe(label, testFunction)
+function bdd.startSection(label, testFunction)
 	validateString(label, "label")
 	validateFunction(testFunction, "testFunction")
 
@@ -211,7 +211,7 @@ function bdd.describe(label, testFunction)
 	bdd.reportIndentationLevel = bdd.reportIndentationLevel - 1
 end
 
-function bdd.it(label, testFunction)
+function bdd.startSubsection(label, testFunction)
 	validateString(label, "label")
 	validateFunction(testFunction, "testFunction")
 
@@ -330,5 +330,8 @@ function bdd.after(teardownFunction)
 	validateFunction(teardownFunction, "teardownFunction")
 	table_insert(bdd.registeredTeardownFunctions, teardownFunction)
 end
+
+bdd.describe = bdd.startSection
+bdd.it = bdd.startSubsection
 
 return bdd

--- a/Tests/BDD/globals.spec.lua
+++ b/Tests/BDD/globals.spec.lua
@@ -4,6 +4,8 @@ local bdd = require("bdd")
 local console = require("console")
 
 local globalAliases = {
+	["after"] = bdd.after,
+	["before"] = bdd.before,
 	["buffer"] = require("string.buffer"),
 	["describe"] = bdd.describe,
 	["dump"] = debug.dump,

--- a/Tests/Fixtures/before-after.spec.lua
+++ b/Tests/Fixtures/before-after.spec.lua
@@ -1,0 +1,109 @@
+local stack = _G.CALLSTACK -- Let's just pretend you didn't see this
+
+function stack:push(item)
+	table.insert(stack, item)
+	print(format("PUSH\t%d\t%s", #stack, item))
+end
+
+stack:push("start main chunk")
+
+-- Silently ignored (hooks are stashed when describe runs)
+before(function()
+	error("Setup in main scope should never run")
+end)
+
+-- Silently ignored (hooks are stashed when describe runs)
+after(function()
+	error("Teardown in main scope should never run")
+end)
+
+stack:push("continue main chunk")
+
+describe("section 1", function()
+	stack:push("start section 1")
+
+	before(function()
+		stack:push("setup subsection (section 1)")
+	end)
+
+	after(function()
+		stack:push("teardown subsection (section 1)")
+	end)
+
+	it("subsection 1.1", function()
+		stack:push("start subsection 1.1 (section 1)")
+	end)
+
+	it("subsection 1.2", function()
+		stack:push("start subsection 1.2 (section 1)")
+	end)
+
+	stack:push("continue section 1")
+
+	describe("section 2", function()
+		stack:push("start section 2 (section 1)")
+
+		before(function()
+			stack:push("setup subsection (section 2)")
+		end)
+
+		after(function()
+			stack:push("teardown subsection (section 2)")
+		end)
+
+		stack:push("continue section 2 (section 1)")
+
+		it("subsection 2.1", function()
+			stack:push("start subsection 2.1 (section 2)")
+		end)
+
+		it("subsection 2.2", function()
+			stack:push("start subsection 2.1 (section 2)")
+		end)
+
+		stack:push("end of section 2 reached (section 1)")
+	end)
+
+	stack:push("continue section 1")
+
+	describe("section 3", function()
+		stack:push("start section 3 (section 1)")
+
+		describe("section 4", function()
+			stack:push("start section 4")
+
+			-- There's no more subsections to run in here (as there aren't any it blocks)
+			before(function()
+				error("Setup in empty section should never run")
+			end)
+
+			after(function()
+				error("Teardown in empty section should never run")
+			end)
+		end)
+
+		it("subsection 3.1", function()
+			stack:push("start subsection 3.1 (section 3)")
+		end)
+
+		it("subsection 3.2", function()
+			stack:push("start subsection 3.2 (section 3)")
+		end)
+
+		stack:push("end of section 3 reached (section 1)")
+	end)
+
+	stack:push("end of section 1 reached")
+end)
+
+stack:push("continue with main chunk")
+
+describe("section 5", function()
+	stack:push("start section 5")
+
+	it("subsection 5.1", function()
+		stack:push("start subsection 5.1 (section 5)")
+	end)
+end)
+
+stack:push("EOF reached in main chunk")

--- a/Tests/SmokeTests/bdd-library/test-start-runner.lua
+++ b/Tests/SmokeTests/bdd-library/test-start-runner.lua
@@ -296,6 +296,85 @@ local function testDetailedFailingSectionsCase()
 	assertEquals(type(errorDetails[3].stackTrace), "string")
 end
 
+local function testSetupTeardownHookNestingCase()
+	_G.CALLSTACK = {} -- Yeah, yeah...
+
+	bdd.startTestRunner({ "Tests/Fixtures/before-after.spec.lua" })
+
+	local expectedCallStack = {
+		"start main chunk",
+		"continue main chunk",
+		"start section 1",
+		"setup subsection (section 1)",
+		"start subsection 1.1 (section 1)",
+		"teardown subsection (section 1)",
+		"setup subsection (section 1)",
+		"start subsection 1.2 (section 1)",
+		"teardown subsection (section 1)",
+		"continue section 1",
+		"start section 2 (section 1)",
+		"continue section 2 (section 1)",
+		"setup subsection (section 2)",
+		"start subsection 2.1 (section 2)",
+		"teardown subsection (section 2)",
+		"setup subsection (section 2)",
+		"start subsection 2.1 (section 2)",
+		"teardown subsection (section 2)",
+		"end of section 2 reached (section 1)",
+		"continue section 1",
+		"start section 3 (section 1)",
+		"start section 4",
+		"start subsection 3.1 (section 3)",
+		"start subsection 3.2 (section 3)",
+		"end of section 3 reached (section 1)",
+		"end of section 1 reached",
+		"continue with main chunk",
+		"start section 5",
+		"start subsection 5.1 (section 5)",
+		"EOF reached in main chunk",
+	}
+
+	for index, event in ipairs(expectedCallStack) do
+		local status = (event == _G.CALLSTACK[index]) and "OK" or "FAIL"
+		print(format("%s\t%s\tExpected: %s -- Found: %s", status, index, event, _G.CALLSTACK[index]))
+	end
+
+	assertEquals(#_G.CALLSTACK, #expectedCallStack)
+
+	assertEquals(_G.CALLSTACK[1], expectedCallStack[1])
+	assertEquals(_G.CALLSTACK[2], expectedCallStack[2])
+	assertEquals(_G.CALLSTACK[3], expectedCallStack[3])
+	assertEquals(_G.CALLSTACK[4], expectedCallStack[4])
+	assertEquals(_G.CALLSTACK[5], expectedCallStack[5])
+	assertEquals(_G.CALLSTACK[6], expectedCallStack[6])
+	assertEquals(_G.CALLSTACK[7], expectedCallStack[7])
+	assertEquals(_G.CALLSTACK[8], expectedCallStack[8])
+	assertEquals(_G.CALLSTACK[9], expectedCallStack[9])
+	assertEquals(_G.CALLSTACK[10], expectedCallStack[10])
+	assertEquals(_G.CALLSTACK[11], expectedCallStack[11])
+	assertEquals(_G.CALLSTACK[12], expectedCallStack[12])
+	assertEquals(_G.CALLSTACK[13], expectedCallStack[13])
+	assertEquals(_G.CALLSTACK[14], expectedCallStack[14])
+	assertEquals(_G.CALLSTACK[15], expectedCallStack[15])
+	assertEquals(_G.CALLSTACK[16], expectedCallStack[16])
+	assertEquals(_G.CALLSTACK[17], expectedCallStack[17])
+	assertEquals(_G.CALLSTACK[18], expectedCallStack[18])
+	assertEquals(_G.CALLSTACK[19], expectedCallStack[19])
+	assertEquals(_G.CALLSTACK[20], expectedCallStack[20])
+	assertEquals(_G.CALLSTACK[21], expectedCallStack[21])
+	assertEquals(_G.CALLSTACK[22], expectedCallStack[22])
+	assertEquals(_G.CALLSTACK[23], expectedCallStack[23])
+	assertEquals(_G.CALLSTACK[24], expectedCallStack[24])
+	assertEquals(_G.CALLSTACK[25], expectedCallStack[25])
+	assertEquals(_G.CALLSTACK[26], expectedCallStack[26])
+	assertEquals(_G.CALLSTACK[27], expectedCallStack[27])
+	assertEquals(_G.CALLSTACK[28], expectedCallStack[28])
+	assertEquals(_G.CALLSTACK[29], expectedCallStack[29])
+	assertEquals(_G.CALLSTACK[30], expectedCallStack[30])
+
+	_G.CALLSTACK = nil -- Is it a crime if there aren't any witnesses?
+end
+
 local function testStartTestRunner()
 	testNoFilesCase()
 	testInvalidFileCase()
@@ -313,6 +392,7 @@ local function testStartTestRunner()
 	testDetailedEmptyTestCase()
 	testDetailedPassingTestCase()
 	testDetailedFailingTestCase()
+	testSetupTeardownHookNestingCase()
 end
 
 testStartTestRunner()


### PR DESCRIPTION
Registering multiple functions would cause the previous ones to no longer be executed.

Now, it's a stack that should unwind in order. Revolutionary, I know.