### PR TITLE
Exclude .DS_Store from VCS tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ ninjabuild-*/
 .ninja_log
 build.ninja
 CHANGELOG.MD
+.DS_Store


### PR DESCRIPTION
Annoying file system spam. Too lazy to delete it again and again.