### PR TITLE
Enable xvfb for automated tests in the Linux build workflow

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -98,10 +98,10 @@ jobs:
         run: evo Tests/snapshot-test.lua
 
       - name: Run unit tests
-        run: evo Tests/unit-test.lua
+        run: xvfb-run evo Tests/unit-test.lua
 
       - name: Run integration tests
-        run: evo Tests/integration-test.lua
+        run: xvfb-run evo Tests/integration-test.lua
 
       - name: Prepare artifacts
         run: cp evo evo-linux-x64

--- a/Tests/Integration/glfw-cursor-image.lua
+++ b/Tests/Integration/glfw-cursor-image.lua
@@ -2,8 +2,9 @@ local ffi = require("ffi")
 local glfw = require("glfw")
 local stbi = require("stbi")
 
-local isWindows = (ffi.os == "Windows")
-if not isWindows then
+local isMacOS = (ffi.os == "OSX")
+if isMacOS then
+	-- CI runner gets stuck after the window closes. See https://github.com/glfw/glfw/issues/1766
 	return
 end
 

--- a/Tests/Integration/glfw-cursor-position.lua
+++ b/Tests/Integration/glfw-cursor-position.lua
@@ -1,8 +1,9 @@
 local ffi = require("ffi")
 local glfw = require("glfw")
 
-local isWindows = (ffi.os == "Windows")
-if not isWindows then
+local isMacOS = (ffi.os == "OSX")
+if isMacOS then
+	-- CI runner gets stuck after the window closes. See https://github.com/glfw/glfw/issues/1766
 	return
 end
 

--- a/Tests/Integration/glfw-poll-button-state.lua
+++ b/Tests/Integration/glfw-poll-button-state.lua
@@ -1,8 +1,9 @@
 local ffi = require("ffi")
 local glfw = require("glfw")
 
-local isWindows = (ffi.os == "Windows")
-if not isWindows then
+local isMacOS = (ffi.os == "OSX")
+if isMacOS then
+	-- CI runner gets stuck after the window closes. See https://github.com/glfw/glfw/issues/1766
 	return
 end
 

--- a/Tests/Integration/glfw-webgpu-surface.lua
+++ b/Tests/Integration/glfw-webgpu-surface.lua
@@ -2,12 +2,9 @@ local ffi = require("ffi")
 local glfw = require("glfw")
 local webgpu = require("webgpu")
 
-local isWindows = (ffi.os == "Windows")
-if not isWindows then
-	local transform = require("transform")
-	-- GitHub's Unix runners can't request adapters (might not have a "real" GPU or at least it isn't exposed)
-	-- On OSX, the issue is, presumably, that WebView and GLFW both try to manage the shared app delegate
-	print(transform.yellow("Skipping WebGPU/GLFW surface test (currently only works on Windows runners)"))
+local isMacOS = (ffi.os == "OSX")
+if isMacOS then
+	-- CI runner gets stuck after the window closes. See https://github.com/glfw/glfw/issues/1766
 	return
 end
 

--- a/Tests/Integration/glfw-window-size.lua
+++ b/Tests/Integration/glfw-window-size.lua
@@ -1,8 +1,9 @@
 local ffi = require("ffi")
 local glfw = require("glfw")
 
-local isWindows = (ffi.os == "Windows")
-if not isWindows then
+local isMacOS = (ffi.os == "OSX")
+if isMacOS then
+	-- CI runner gets stuck after the window closes. See https://github.com/glfw/glfw/issues/1766
 	return
 end
 


### PR DESCRIPTION
This allows unskipping the currently Windows-only tests that require access to a display.

They still won't work on macOS due to a GLFW issue (if I understand correctly, anyway).