### PR TITLE
Add GLFW input hooks to the RML bindings

### DIFF
--- a/Runtime/Bindings/rml.lua
+++ b/Runtime/Bindings/rml.lua
@@ -24,6 +24,14 @@ struct static_rml_exports_table {
 	SystemInterface_GLFW* (*rml_create_glfw_system_interface)(void);
 	void (*rml_destroy_glfw_system_interface)(SystemInterface_GLFW* glfw_system_interface);
 	void (*rml_set_system_interface)(SystemInterface_GLFW* glfw_system_interface);
+	bool (*rml_process_key_callback)(rml_context_t context_pointer, int key, int action, int mods);
+	bool (*rml_process_char_callback)(rml_context_t context_pointer, unsigned int codepoint);
+	bool (*rml_process_cursor_enter_callback)(rml_context_t context_pointer, int entered);
+	bool (*rml_process_cursor_pos_callback)(rml_context_t context_pointer, double xpos, double ypos, int mods);
+	bool (*rml_process_mouse_button_callback)(rml_context_t context_pointer, int button, int action, int mods);
+	bool (*rml_process_scroll_callback)(rml_context_t context_pointer, double yoffset, int mods);
+	void (*rml_process_framebuffer_size_callback)(rml_context_t context_pointer, int width, int height);
+	void (*rml_process_content_scale_callback)(rml_context_t context_pointer, float xscale);
 
 	// WebGPU integration
 	RenderInterface_WebGPU* (*rml_create_wgpu_render_interface)(wgpu_device_t existing_wgpu_device, deferred_event_queue_t queue);

--- a/Runtime/Bindings/rml_ffi.cpp
+++ b/Runtime/Bindings/rml_ffi.cpp
@@ -105,6 +105,62 @@ void rml_release_compiled_geometry(rml_geometry_info_t* geometry) {
 	delete geometry;
 }
 
+bool rml_process_key_callback(rml_context_t context_pointer, int key, int action, int mods) {
+	if(!context_pointer) return true;
+
+	auto context = static_cast<Rml::Context*>(context_pointer);
+	return RmlGLFW::ProcessKeyCallback(context, key, action, mods);
+}
+
+bool rml_process_char_callback(rml_context_t context_pointer, unsigned int codepoint) {
+	if(!context_pointer) return true;
+
+	auto context = static_cast<Rml::Context*>(context_pointer);
+	return RmlGLFW::ProcessCharCallback(context, codepoint);
+}
+
+bool rml_process_cursor_enter_callback(rml_context_t context_pointer, int entered) {
+	if(!context_pointer) return true;
+
+	auto context = static_cast<Rml::Context*>(context_pointer);
+	return RmlGLFW::ProcessCursorEnterCallback(context, entered);
+}
+
+bool rml_process_cursor_pos_callback(rml_context_t context_pointer, double xpos, double ypos, int mods) {
+	if(!context_pointer) return true;
+
+	auto context = static_cast<Rml::Context*>(context_pointer);
+	return RmlGLFW::ProcessCursorPosCallback(context, xpos, ypos, mods);
+}
+
+bool rml_process_mouse_button_callback(rml_context_t context_pointer, int button, int action, int mods) {
+	if(!context_pointer) return true;
+
+	auto context = static_cast<Rml::Context*>(context_pointer);
+	return RmlGLFW::ProcessMouseButtonCallback(context, button, action, mods);
+}
+
+bool rml_process_scroll_callback(rml_context_t context_pointer, double yoffset, int mods) {
+	if(!context_pointer) return true;
+
+	auto context = static_cast<Rml::Context*>(context_pointer);
+	return RmlGLFW::ProcessScrollCallback(context, yoffset, mods);
+}
+
+void rml_process_framebuffer_size_callback(rml_context_t context_pointer, int width, int height) {
+	if(!context_pointer) return;
+
+	auto context = static_cast<Rml::Context*>(context_pointer);
+	RmlGLFW::ProcessFramebufferSizeCallback(context, width, height);
+}
+
+void rml_process_content_scale_callback(rml_context_t context_pointer, float xscale) {
+	if(!context_pointer) return;
+
+	auto context = static_cast<Rml::Context*>(context_pointer);
+	RmlGLFW::ProcessContentScaleCallback(context, xscale);
+}
+
 namespace rml_ffi {
 
 	void* getExportsTable() {
@@ -127,6 +183,14 @@ namespace rml_ffi {
 		exports_table.rml_context_render = &rml_context_render;
 		exports_table.rml_context_remove = &rml_context_remove;
 		exports_table.rml_load_font_face = &rml_load_font_face;
+		exports_table.rml_process_key_callback = &rml_process_key_callback;
+		exports_table.rml_process_char_callback = &rml_process_char_callback;
+		exports_table.rml_process_cursor_enter_callback = &rml_process_cursor_enter_callback;
+		exports_table.rml_process_cursor_pos_callback = &rml_process_cursor_pos_callback;
+		exports_table.rml_process_mouse_button_callback = &rml_process_mouse_button_callback;
+		exports_table.rml_process_scroll_callback = &rml_process_scroll_callback;
+		exports_table.rml_process_framebuffer_size_callback = &rml_process_framebuffer_size_callback;
+		exports_table.rml_process_content_scale_callback = &rml_process_content_scale_callback;
 
 		return &exports_table;
 	}

--- a/Runtime/Bindings/rml_ffi.hpp
+++ b/Runtime/Bindings/rml_ffi.hpp
@@ -19,6 +19,14 @@ struct static_rml_exports_table {
 	SystemInterface_GLFW* (*rml_create_glfw_system_interface)(void);
 	void (*rml_destroy_glfw_system_interface)(SystemInterface_GLFW* glfw_system_interface);
 	void (*rml_set_system_interface)(SystemInterface_GLFW* glfw_system_interface);
+	bool (*rml_process_key_callback)(rml_context_t context_pointer, int key, int action, int mods);
+	bool (*rml_process_char_callback)(rml_context_t context_pointer, unsigned int codepoint);
+	bool (*rml_process_cursor_enter_callback)(rml_context_t context_pointer, int entered);
+	bool (*rml_process_cursor_pos_callback)(rml_context_t context_pointer, double xpos, double ypos, int mods);
+	bool (*rml_process_mouse_button_callback)(rml_context_t context_pointer, int button, int action, int mods);
+	bool (*rml_process_scroll_callback)(rml_context_t context_pointer, double yoffset, int mods);
+	void (*rml_process_framebuffer_size_callback)(rml_context_t context_pointer, int width, int height);
+	void (*rml_process_content_scale_callback)(rml_context_t context_pointer, float xscale);
 
 	// WebGPU integration
 	RenderInterface_WebGPU* (*rml_create_wgpu_render_interface)(wgpu_device_t existing_wgpu_device, deferred_event_queue_t queue);


### PR DESCRIPTION
This should allow forwarding events to the RML document as needed. It's "should" because there's no automated testing for these due to the complex setup required (wgpu, GLFW, and RML).

That's obviously not ideal, but I've yet to implement APIs that take care of the boilerplate in a way that's general enough.