### PR TITLE
Enable Lua script handlers inside RML documents

### DIFF
--- a/BuildTools/Targets/EvoBuildTarget.lua
+++ b/BuildTools/Targets/EvoBuildTarget.lua
@@ -108,6 +108,7 @@ local EvoBuildTarget = {
 		"uSockets.a",
 		"zlibstatic.a",
 		"libRmlCore.a",
+		"libRmlLua.a",
 		"libfreetype.a",
 	},
 	sharedLibraries = {

--- a/Runtime/Bindings/rml_ffi.hpp
+++ b/Runtime/Bindings/rml_ffi.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <RmlUi/Lua.h>
 #include <RmlUi_Platform_GLFW.h>
 #include <RmlUi_Renderer_WebGPU.hpp>
 
@@ -49,5 +50,7 @@ struct static_rml_exports_table {
 };
 
 namespace rml_ffi {
+	void assignLuaState(lua_State* L);
+	lua_State* getAssignedLuaState();
 	void* getExportsTable();
 }

--- a/Runtime/main.cpp
+++ b/Runtime/main.cpp
@@ -51,6 +51,8 @@ int main(int argc, char* argv[]) {
 	luaVM->CreateGlobalNamespace("C_Runtime");
 	luaVM->AssignGlobalVariable("EVO_VERSION", "" EVO_VERSION "");
 
+	rml_ffi::assignLuaState(luaVM->GetState());
+
 	// A bit of a hack; Can't use uv_default_loop because luv maintains a separate "default" loop of its own
 	uv_loop_t* loop = luv_loop(luaVM->GetState());
 	auto uwsEventLoop = uws_ffi::assignEventLoop(loop);


### PR DESCRIPTION
This allows running script handlers written in Lua from inside RML documents, as well as access to the Lua plugin from within the runtime's Lua environment (once `rml_initialise` was called).

It's not as non-intrusive as I'd like, but enough to start experimenting.