### PR TITLE
Increase the delay for various HTTP integration tests

### DIFF
--- a/Tests/Integration/http-event-queue.lua
+++ b/Tests/Integration/http-event-queue.lua
@@ -56,14 +56,14 @@ function Test:CreateServer()
 end
 
 function Test:Run()
-	C_Timer.After(100, function()
+	C_Timer.After(1000, function()
 		self.client:shutdown()
 		self.client:close()
 
-		C_Timer.After(100, function()
+		C_Timer.After(1000, function()
 			self.server:StopListening()
 
-			C_Timer.After(100, function()
+			C_Timer.After(1000, function()
 				uv.stop()
 			end)
 		end)

--- a/Tests/Integration/http-json-response.lua
+++ b/Tests/Integration/http-json-response.lua
@@ -57,9 +57,9 @@ function Test:CreateClient()
 end
 
 function Test:Run()
-	C_Timer.After(100, function()
+	C_Timer.After(1000, function()
 		self.server:StopListening()
-		C_Timer.After(100, function()
+		C_Timer.After(1000, function()
 			uv.stop()
 		end)
 	end)

--- a/Tests/Integration/http-response-status.lua
+++ b/Tests/Integration/http-response-status.lua
@@ -56,9 +56,9 @@ function Test:CreateClient()
 end
 
 function Test:Run()
-	C_Timer.After(100, function()
+	C_Timer.After(1000, function()
 		self.server:StopListening()
-		C_Timer.After(100, function()
+		C_Timer.After(1000, function()
 			uv.stop()
 		end)
 	end)

--- a/Tests/Integration/http-shutdown-with-503.lua
+++ b/Tests/Integration/http-shutdown-with-503.lua
@@ -51,9 +51,9 @@ function Test:CreateClient()
 end
 
 function Test:Run()
-	C_Timer.After(100, function()
+	C_Timer.After(1000, function()
 		self.server:StopListening() -- Should force shutdown with 503 response code since the client is still connected
-		C_Timer.After(100, function()
+		C_Timer.After(1000, function()
 			uv.stop() -- Client should have received the 503 response by now
 		end)
 	end)


### PR DESCRIPTION
These are somewhat flaky because the entire approach to testing is poorly thought-out. I don't have time to implement a better one right now (and it doesn't matter until there's a reason to change the code), so for now just work around the flakiness by reducing the chance of messages not being sent in time. Of course the tests will take longer, but their execution time currently pales in comparison to the build time, so that's irrelevant.