### PR TITLE
Disable build workflow runs on feature branch creation

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
     paths-ignore:
       - '**.md'
   pull_request:
@@ -14,8 +16,6 @@ on:
       - '**.md'
       - 'changelog.lua'
       - '.gitignore'
-  create:
-    # Any branch or tag
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
     paths-ignore:
       - '**.md'
   pull_request:
@@ -14,8 +16,6 @@ on:
       - '**.md'
       - 'changelog.lua'
       - '.gitignore'
-  create:
-    # Any branch or tag
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
     paths-ignore:
       - '**.md'
   pull_request:
@@ -14,8 +16,6 @@ on:
       - '**.md'
       - 'changelog.lua'
       - '.gitignore'
-  create:
-    # Any branch or tag
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Not sure where I copy/pasted that part of the configuration from, but it's definitely triggering the build workflows to run when branches are first created (which is pointless and wasteful). Before a PR is opened and merged, there's really no point in running any CI workflows, especially with how long they take to complete.