### PR TITLE
Enable verbose output for Lua files in the autoformat script

### DIFF
--- a/autoformat.sh
+++ b/autoformat.sh
@@ -1,6 +1,6 @@
 echo "Formatting Lua sources ..."
 
-stylua .
+stylua . --verbose
 
 echo "Discovering C/C++ sources ..."
 


### PR DESCRIPTION
No functional difference, just better feedback and easier troubleshooting.