### PR TITLE
Remove a duplicated unit test for the printf global

### DIFF
--- a/Tests/BDD/globals.spec.lua
+++ b/Tests/BDD/globals.spec.lua
@@ -52,15 +52,6 @@ describe("_G", function()
 		assertEquals(type(versionString), "string")
 	end)
 
-	describe("printf", function()
-		it("should output formatted strings to stdout", function()
-			console.capture()
-			printf("Hello %s", "printf")
-			local capturedOutput = console.release()
-			assertEquals(capturedOutput, "Hello printf\n")
-		end)
-	end)
-
 	describe("extend", function()
 		it("should still work if the prototype object doesn't have a metatable", function()
 			local child = {}


### PR DESCRIPTION
It was seemingly copy/pasted to the console library tests when the function was moved there, but this instance wasn't deleted.