### PR TITLE
Colorize the interpreter's command line interface (and standardize some outputs)

### DIFF
--- a/Runtime/Libraries/transform.lua
+++ b/Runtime/Libraries/transform.lua
@@ -51,6 +51,22 @@ function transform.disable()
 	transform.ENABLE_TEXT_TRANSFORMATIONS = false
 end
 
+function transform.strip(coloredConsoleText)
+	if type(coloredConsoleText) ~= "string" then
+		error("Usage: transform.strip(text : string)", 0)
+	end
+
+	-- All credit goes to this fine gentleman: https://stackoverflow.com/users/3735873/tonypdmtr
+	local strippedConsoleText = coloredConsoleText
+		:gsub("\x1b%[%d+;%d+;%d+;%d+;%d+m", "")
+		:gsub("\x1b%[%d+;%d+;%d+;%d+m", "")
+		:gsub("\x1b%[%d+;%d+;%d+m", "")
+		:gsub("\x1b%[%d+;%d+m", "")
+		:gsub("\x1b%[%d+m", "")
+
+	return strippedConsoleText
+end
+
 local function transformText(text, color)
 	if type(text) ~= "string" then
 		error("Usage: transform." .. color .. "(text : string)", 0)

--- a/Tests/BDD/evo-library.spec.lua
+++ b/Tests/BDD/evo-library.spec.lua
@@ -1,5 +1,6 @@
 local console = require("console")
 local evo = require("evo")
+local transform = require("transform")
 local uv = require("uv")
 
 describe("evo", function()
@@ -8,6 +9,7 @@ describe("evo", function()
 			console.capture()
 			evo.showVersionStrings()
 			local capturedOutput = console.release()
+			capturedOutput = transform.strip(capturedOutput)
 
 			local VERSION_PATTERN = "%d+.%d+.%d+"
 			local WHITESPACE = "%s+"

--- a/Tests/BDD/transform-library.spec.lua
+++ b/Tests/BDD/transform-library.spec.lua
@@ -106,4 +106,16 @@ describe("transform", function()
 			transform.ENABLE_TEXT_TRANSFORMATIONS = true
 		end)
 	end)
+
+	describe("strip", function()
+		it("should remove color codes from the input without otherwise modifying it", function()
+			for name, transformation in pairs(transform) do
+				if type(transformation) == "function" and transform.colorCodes[name] then
+					local originalText = "Hello world"
+					local coloredText = transform.brightYellow(originalText)
+					assertEquals(transform.strip(coloredText), originalText)
+				end
+			end
+		end)
+	end)
 end)


### PR DESCRIPTION
This should help with readability, at least it does on my terminal.

I also took the liberty to reorganize the output functions a bit since that made it a lot easier to colorize. The color scheme itself is limited to a few select colors, used more or less consistently, but could use some more streamlining (later).

Some of the phrasing is updated to improve the consistency of CLI interactions, though the meaning is hopefully unchanged.