### PR TITLE
Pin the clang-format version used by CI runs

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -28,6 +28,10 @@ jobs:
           args: --check . --verbose
           version: v0.19.1
 
+      # The preinstalled version is positively antique; replace with the latest and greatest (to match MSYS)
+      - name: Install the clang-format
+        run: ./deps/install-clang-format.sh
+
       - name: Run autoformat
         run: ./autoformat.sh
 

--- a/autoformat.sh
+++ b/autoformat.sh
@@ -1,3 +1,8 @@
+echo "Installed formatters:\n"
+
+echo "* " $(stylua --version)
+echo "* " $(clang-format --version)
+
 echo "Formatting Lua sources ..."
 
 stylua . --verbose

--- a/autoformat.sh
+++ b/autoformat.sh
@@ -1,7 +1,11 @@
+# See deps/install-clang-format.sh for the required version (should always match)
+REQUIRED_CLANG_FORMAT_VERSION="18"
+CLANG_FORMAT="clang-format-$REQUIRED_CLANG_FORMAT_VERSION"
+
 echo "Installed formatters:\n"
 
 echo "* " $(stylua --version)
-echo "* " $(clang-format --version)
+echo "* " $($CLANG_FORMAT --version)
 
 echo "Formatting Lua sources ..."
 
@@ -16,7 +20,7 @@ if [ -n "$RELEVANT_C_FILES_TO_FORMAT" ]; then
 	echo $RELEVANT_C_FILES_TO_FORMAT
 
 	echo "Formatting C sources ..."
-	clang-format -i --verbose $RELEVANT_C_FILES_TO_FORMAT
+	$CLANG_FORMAT -i --verbose $RELEVANT_C_FILES_TO_FORMAT
 else
 	echo "NO relevant C sources found"
 fi
@@ -26,5 +30,4 @@ echo "Discovered C++ sources:"
 echo $RELEVANT_CPP_FILES_TO_FORMAT
 
 echo "Formatting C++ sources ..."
-clang-format -i --verbose $RELEVANT_CPP_FILES_TO_FORMAT
-
+$CLANG_FORMAT -i --verbose $RELEVANT_CPP_FILES_TO_FORMAT

--- a/deps/install-clang-format.sh
+++ b/deps/install-clang-format.sh
@@ -1,0 +1,25 @@
+REQUIRED_CLANG_FORMAT_VERSION="18"
+CLANG_FORMAT_DOWNLOAD_URL="https://apt.llvm.org/llvm.sh"
+
+echo "Downloading LLVM install script from $CLANG_FORMAT_DOWNLOAD_URL"
+wget -O llvm.sh $CLANG_FORMAT_DOWNLOAD_URL
+chmod +x llvm.sh
+echo
+
+echo "You should inspect the contents of llvm.sh (e.g. via cat llvm.sh)"
+echo "Don't blindly run code that was downloaded from the internet"
+echo
+
+echo "The script will now attempt to install clang-format-$REQUIRED_CLANG_FORMAT_VERSION \n"
+echo
+
+# This should prompt the user, giving them time to inspect llvm.sh if so desired (not in CI runs)
+sudo ./llvm.sh $REQUIRED_CLANG_FORMAT_VERSION
+sudo apt install clang-format-$REQUIRED_CLANG_FORMAT_VERSION
+echo
+
+echo "Cleanup: Removing llvm.sh"
+echo
+rm -rf llvm.sh
+
+echo $(clang-format-$REQUIRED_CLANG_FORMAT_VERSION --version)


### PR DESCRIPTION
Split off from #433 because the number of changes is too large already, and this is unrelated/generally useful.

It's slightly annoying that the required version is defined in both the autoformat and the install script, but it's not a big deal.