### PR TITLE
Enable building with n2 to avoid unnecessary recompilation of object files

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install Ninja
         run: sudo apt-get install ninja-build
 
+      - name: Install n2
+        run: cargo install --git https://github.com/evmar/n2
+
       # Can't actually be used on CI runners, but we need the headers for embedding webview
       - name: Install WebKitGTK
         run: sudo apt-get install gtk+-3.0-dev webkit2gtk-4.0-dev --yes

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ ninjabuild-*/
 build.ninja
 CHANGELOG.MD
 .DS_Store
+.n2_db

--- a/unixbuild.sh
+++ b/unixbuild.sh
@@ -15,7 +15,15 @@ $LUAJIT_EXE ninjabuild.lua
 # LuaJIT's jit module is implemented in Lua and needs to be loaded via LUA_PATH for bytecode generation
 export LUA_PATH="$BUILD_DIR/?.lua;./?.lua"
 
+if which n2 > /dev/null; then # Using n2 speeds up local development as it has better change detection
+    BUILD_TOOL=n2
+else # Ninja works just as well and is expected to be installed in all cases (required for building deps via CMake)
+    BUILD_TOOL=ninja
+fi
+
+echo "Selected build tool: $BUILD_TOOL"
+
 # This will only work after the dependencies have been built! (Run the deps/build-X.sh scripts manually at least once)
 # The reason this is excluded from the ninja build is to eliminate propagated errors that are difficult to debug/misleading
 # It's much easier to see if the dependencies could be built independently and they don't usually need rebuilding anyway
-ninja
+$BUILD_TOOL


### PR DESCRIPTION
For now it's just an experiment; no idea if it will work to build all the dependencies as well.

* Disabled (in the CI) for macOS since I want some insurance that both versions (`n2` and `ninja` work)
* Not enabled on Windows because I don't do much development there as it's too slow, may add support for `n2` later

Since this is purely an optimization and does nothing for CI runs, and also doesn't work for dependencies, this will do for now.