### PR TITLE
Ensure the clang-format install script fails on error

### DIFF
--- a/deps/install-clang-format.sh
+++ b/deps/install-clang-format.sh
@@ -1,3 +1,5 @@
+set -e
+
 REQUIRED_CLANG_FORMAT_VERSION="17"
 CLANG_FORMAT_DOWNLOAD_URL="https://apt.llvm.org/llvm.sh"
 


### PR DESCRIPTION
It's unlikely the CI autoformat run would successfully complete if this fails, but it may move the failure to an unrelated later step.