### PR TITLE
Reorganize the autoformat workflow to remove clutter

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -51,6 +51,8 @@ jobs:
   autoformat-macos:
     name: Enforce consistent formatting on macOS
     runs-on: macos-latest
+    # Introduce a dependency to eliminate visual clutter in the PR UI
+    needs: [autoformat-windows]
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
@@ -75,6 +77,8 @@ jobs:
   autoformat-linux:
     name: Enforce consistent formatting on Linux
     runs-on: ubuntu-latest
+    # Introduce a dependency to eliminate visual clutter in the PR UI
+    needs: [autoformat-macos]
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -12,23 +12,21 @@ on:
       - "README.MD"
       - '.gitignore'
 
-jobs:
-  check-format:
-    name: Enforce consistent formatting
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+env:
+  STYLUA_VERSION: v0.19.1
 
+jobs:
+  autoformat-windows:
+    name: Enforce consistent formatting on Windows
+    runs-on: windows-latest
     steps:
-      # MSYS needs to be available before running any git commands
       - name: Install clang-format (via MSYS)
-        if: runner.os == 'Windows'
         uses: msys2/setup-msys2@v2
         with:
           install: git mingw-w64-x86_64-clang
 
-      - name: Disable autocrlf # Messes up everything on Windows since the formatter applies \n
+      # Messes up everything on Windows since the formatter writes \n
+      - name: Disable autocrlf
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
@@ -41,19 +39,59 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --check . --verbose
-          version: v0.19.1
+          version: ${{ env.STYLUA_VERSION }}
 
-        # The preinstalled version is positively antique; replace with the latest and greatest (to match MSYS)
-      - name: Install clang-format (via APT)
-        if: runner.os == 'Linux'
-        run: ./deps/install-clang-format.sh
-
-      - name: Install clang-format (via Homebrew)
-        if: runner.os == 'macOS'
-        run: brew install clang-format
-        
       - name: Run autoformat
         run: ./autoformat.sh
 
       - name: Check for inconsistent formatting
-        run: git --no-pager diff --exit-code -b . #The -b is for inconsistent newlines, which we ignore (for now)
+        # The -b is for inconsistent newlines, which we ignore (for now)
+        run: git --no-pager diff --exit-code -b .
+
+  autoformat-macos:
+    name: Enforce consistent formatting on macOS
+    runs-on: macos-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Set up StyLua
+        uses: JohnnyMorganz/stylua-action@v1.1.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --check . --verbose
+          version: ${{ env.STYLUA_VERSION }}
+
+      - name: Install clang-format (via Homebrew)
+        run: brew install clang-format
+
+      - name: Run autoformat
+        run: ./autoformat.sh
+
+      - name: Check for inconsistent formatting
+        # The -b is for inconsistent newlines, which we ignore (for now)
+        run: git --no-pager diff --exit-code -b .
+
+  autoformat-linux:
+    name: Enforce consistent formatting on Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Set up StyLua
+        uses: JohnnyMorganz/stylua-action@v1.1.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --check . --verbose
+          version: ${{ env.STYLUA_VERSION }}
+
+      - name: Install clang-format (via APT)
+        run: ./deps/install-clang-format.sh
+
+      - name: Run autoformat
+        run: ./autoformat.sh
+
+      - name: Check for inconsistent formatting
+        # The -b is for inconsistent newlines, which we ignore (for now)
+        run: git --no-pager diff --exit-code -b .

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -45,8 +45,7 @@ jobs:
         run: ./autoformat.sh
 
       - name: Check for inconsistent formatting
-        # The -b is for inconsistent newlines, which we ignore (for now)
-        run: git --no-pager diff --exit-code -b .
+        run: git --no-pager diff --exit-code .
 
   autoformat-macos:
     name: Enforce consistent formatting on macOS
@@ -71,8 +70,7 @@ jobs:
         run: ./autoformat.sh
 
       - name: Check for inconsistent formatting
-        # The -b is for inconsistent newlines, which we ignore (for now)
-        run: git --no-pager diff --exit-code -b .
+        run: git --no-pager diff --exit-code .
 
   autoformat-linux:
     name: Enforce consistent formatting on Linux
@@ -97,5 +95,4 @@ jobs:
         run: ./autoformat.sh
 
       - name: Check for inconsistent formatting
-        # The -b is for inconsistent newlines, which we ignore (for now)
-        run: git --no-pager diff --exit-code -b .
+        run: git --no-pager diff --exit-code .

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -16,15 +16,13 @@ env:
   STYLUA_VERSION: v0.19.1
 
 jobs:
-  autoformat-windows:
-    name: Enforce consistent formatting on Windows
-    runs-on: windows-latest
+  autoformat:
+    name: Enforce consistent formatting on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
-      - name: Install clang-format (via MSYS)
-        uses: msys2/setup-msys2@v2
-        with:
-          install: git mingw-w64-x86_64-clang
-
       # Messes up everything on Windows since the formatter writes \n
       - name: Disable autocrlf
         run: |
@@ -41,55 +39,21 @@ jobs:
           args: --check . --verbose
           version: ${{ env.STYLUA_VERSION }}
 
-      - name: Run autoformat
-        run: ./autoformat.sh
-
-      - name: Check for inconsistent formatting
-        run: git --no-pager diff --exit-code .
-
-  autoformat-macos:
-    name: Enforce consistent formatting on macOS
-    runs-on: macos-latest
-    # Introduce a dependency to eliminate visual clutter in the PR UI
-    needs: [autoformat-windows]
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v4
-
-      - name: Set up StyLua
-        uses: JohnnyMorganz/stylua-action@v1.1.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --check . --verbose
-          version: ${{ env.STYLUA_VERSION }}
-
-      - name: Install clang-format (via Homebrew)
-        run: brew install clang-format
-
-      - name: Run autoformat
-        run: ./autoformat.sh
-
-      - name: Check for inconsistent formatting
-        run: git --no-pager diff --exit-code .
-
-  autoformat-linux:
-    name: Enforce consistent formatting on Linux
-    runs-on: ubuntu-latest
-    # Introduce a dependency to eliminate visual clutter in the PR UI
-    needs: [autoformat-macos]
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v4
-
-      - name: Set up StyLua
-        uses: JohnnyMorganz/stylua-action@v1.1.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --check . --verbose
-          version: ${{ env.STYLUA_VERSION }}
-
-      - name: Install clang-format (via APT)
-        run: ./deps/install-clang-format.sh
+      - name: Install clang-format
+        run: |
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            echo "Setting up for Windows"
+            git config --global core.autocrlf false
+            git config --global core.eol lf
+            msys2 setup-msys2@v2
+            msys2 install git mingw-w64-x86_64-clang
+          elif [ "${{ matrix.os }}" == "macos-latest" ]; then
+            echo "Setting up for macOS"
+            brew install clang-format
+          elif [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
+            echo "Setting up for Ubuntu"
+            ./deps/install-clang-format.sh
+          fi
 
       - name: Run autoformat
         run: ./autoformat.sh


### PR DESCRIPTION
It might seem silly to duplicate the common functionality, but bear with me: Currently, the workflow starts three separate jobs, which run in parallel. So far, so good - but they clutter up the PR UI and there's very little informational value in more than one display. That's why there was only one workflow running on Linux previously.

However, now that there's three to identify issues with different formatter versions on the supported platforms, it makes more sense to have them run sequentially (gasp). This leads to the entire workflow only showing one status update in the PR, and the parallelism doesn't matter here because all three of them run sequentially will still be way faster than any one build workflow.