### PR TITLE
Fix the order of args being passed to zip apps

### DIFF
--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -95,6 +95,14 @@ function evo.run()
 
 	local zipApp = evo.readEmbeddedZipApp()
 	if zipApp then
+		-- The CLI args are shifted if not run from the interpreter CLI, which might break standalone apps
+		local correctedArgs = {}
+		for index, arg in ipairs(arg) do
+			correctedArgs[index + 1] = arg
+		end
+		correctedArgs[1] = arg[0]
+		_G.arg = correctedArgs
+		_G.arg[0] = uv.exepath()
 		return vfs.dofile(zipApp, evo.DEFAULT_ENTRY_POINT)
 	end
 

--- a/Tests/Fixtures/hello-world-app/main.lua
+++ b/Tests/Fixtures/hello-world-app/main.lua
@@ -1,1 +1,5 @@
 print("Hello world!")
+
+-- Depending on how the script is run, the order of args will be different (unless corrected)
+assert(arg[1] == "hi")
+assert(arg[2] == nil)

--- a/Tests/snapshot-test.lua
+++ b/Tests/snapshot-test.lua
@@ -62,8 +62,8 @@ local testCases = {
 		end,
 	},
 	["cli-run-script"] = {
-		humanReadableDescription = "Invoking the CLI with a Lua script path should execute the script",
-		programToRun = "evo Tests/Fixtures/hello-world-app/main.lua",
+		humanReadableDescription = "Invoking the CLI with a Lua script path should execute the script with the provided args",
+		programToRun = "evo Tests/Fixtures/hello-world-app/main.lua hi",
 		onExit = function(observedOutput, status, terminationReason, exitCodeOrSignalID)
 			local expectedOutput = "Hello world!\n"
 			assertEquals(observedOutput, expectedOutput)
@@ -310,8 +310,9 @@ C_Runtime.RunSnapshotTests(testCases)
 testCases = {
 	-- This relies on the hello-world-app being built first, but the order is not guaranteed
 	["cli-hello-world-app"] = {
-		humanReadableDescription = "Invoking the hello world app should execute the bundled app instead of the runtime CLI",
-		programToRun = ffi.os ~= "Windows" and "chmod +x hello-world-app && ./hello-world-app" or "hello-world-app.exe",
+		humanReadableDescription = "Invoking the hello world app should execute the bundled app instead of the runtime CLI with the provided args",
+		programToRun = ffi.os ~= "Windows" and "chmod +x hello-world-app && ./hello-world-app hi"
+			or "hello-world-app.exe hi",
 		onExit = function(observedOutput, status, terminationReason, exitCodeOrSignalID)
 			assertEquals(observedOutput, "Hello world!\n")
 			assertExitSuccess(observedOutput, status, terminationReason, exitCodeOrSignalID)


### PR DESCRIPTION
Normally, scripts are run from the interpreter CLI. In that case, `arg[0]` is the script name - just like when using PUC Lua or LuaJIT itself. However, when building a LUAZIP app with the build command, and subsequently running it with the same args as before, `arg[0]` is now the first actual CLI arg because there's no interpreter CLI that would have to receive the script name.

If shifting everything by one, the script should be able to function the same way regardless of whether it's running from the interpreter CLI or as a standalone app. Storing the app name instead of the script name is a bit questionable, and therefore untested (=undefined behavior).