### PR TITLE
Set up a global alias for oop.implements

### DIFF
--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -153,6 +153,7 @@ function evo.registerGlobalAliases()
 		dump = debug.dump,
 		extend = oop.extend,
 		format = string.format,
+		implements = oop.implements,
 		instanceof = oop.instanceof,
 		it = bdd.it,
 		mixin = oop.mixin,

--- a/Tests/BDD/globals.spec.lua
+++ b/Tests/BDD/globals.spec.lua
@@ -12,6 +12,7 @@ local globalAliases = {
 	["describe"] = bdd.describe,
 	["dump"] = debug.dump,
 	["extend"] = oop.extend,
+	["implements"] = oop.implements,
 	["instanceof"] = oop.instanceof,
 	["format"] = string.format,
 	["it"] = bdd.it,


### PR DESCRIPTION
This is only really useful for tests, where typing and requiring things is somewhat annoying.