### PR TITLE
Introduce a shorthand for float equality assertions

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -26,6 +26,7 @@ globals = {
 	"assertCallsFunction",
 	"assertEqualStrings",
 	"assertEqualNumbers",
+	"assertApproximatelyEquals",
 	"assertEqualTables",
 	"assertEqualBooleans",
 	"assertEqualPointers",

--- a/Runtime/Libraries/assertions.lua
+++ b/Runtime/Libraries/assertions.lua
@@ -346,6 +346,7 @@ function assertions.export()
 		"assertCallsFunction",
 		"assertEqualStrings",
 		"assertEqualNumbers",
+		"assertApproximatelyEquals",
 		"assertEqualTables",
 		"assertEqualBooleans",
 		"assertEqualPointers",
@@ -356,6 +357,10 @@ function assertions.export()
 	for index, functionName in ipairs(functionsToExport) do
 		_G[functionName] = assertions[functionName]
 	end
+end
+
+function assertions.assertApproximatelyEquals(firstNumber, secondNumber)
+	return assertions.assertEqualNumbers(firstNumber, secondNumber, 1E-3)
 end
 
 return assertions

--- a/Tests/SmokeTests/assertions-library/test-assert-equal-numbers.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equal-numbers.lua
@@ -1,5 +1,6 @@
 local assertions = require("assertions")
 local assertEqualNumbers = assertions.assertEqualNumbers
+local assertApproximatelyEquals = assertions.assertApproximatelyEquals
 
 local num1 = 1
 local num2 = 1
@@ -76,6 +77,19 @@ local function testAlmostEqualNumbersCase()
 	)
 end
 
+local function testApproximatelyEqualsSuccessCase()
+	assert(assertApproximatelyEquals(num1, num5) == true, "assertApproximatelyEquals(num1, num6) should return true")
+end
+
+local function testApproximatelyEqualsFailureCase()
+	local success, errorMessage = pcall(assertApproximatelyEquals, 1.01, 1.02)
+	assert(success == false, "assertApproximatelyEquals(1.01, 1.02) should raise an error")
+	assert(
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected 1.02 but got 1.01 within delta 0.001$"),
+		"assertApproximatelyEquals(num5, num6) should raise an error with the correct message"
+	)
+end
+
 local function testAssertEqualNumbers()
 	testEqualNumbersCase()
 	testAlmostEqualFloatsWithoutDeltaCase()
@@ -85,6 +99,8 @@ local function testAssertEqualNumbers()
 	testDifferentNumbersCase()
 	testNumberAndStringCase()
 	testAlmostEqualNumbersCase()
+	testApproximatelyEqualsSuccessCase()
+	testApproximatelyEqualsFailureCase()
 end
 
 testAssertEqualNumbers()

--- a/Tests/SmokeTests/assertions-library/test-export.lua
+++ b/Tests/SmokeTests/assertions-library/test-export.lua
@@ -10,6 +10,7 @@ local expectedGlobalAssertions = {
 	"assertCallsFunction",
 	"assertEqualStrings",
 	"assertEqualNumbers",
+	"assertApproximatelyEquals",
 	"assertEqualTables",
 	"assertEqualBooleans",
 	"assertEqualPointers",


### PR DESCRIPTION
This is a common enough case that I'm annoyed by having to type out the epsilon every time. Could be rolled into the other assertions but I'd rather be explicit here to avoid surprises.