### PR TITLE
Fix an outdated section label in the etrace unit tests

### DIFF
--- a/Tests/BDD/etrace-library.spec.lua
+++ b/Tests/BDD/etrace-library.spec.lua
@@ -302,7 +302,7 @@ describe("etrace", function()
 		end)
 	end)
 
-	describe("put", function()
+	describe("record", function()
 		after(function()
 			etrace.reset()
 		end)


### PR DESCRIPTION
In the original prototype, `etrace.record` was `etrace.put` - but that hasn't made it into the runtime.