### PR TITLE
Update the autoformat workflow to use the latest StyLua version (and action)

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up StyLua
-        uses: JohnnyMorganz/stylua-action@v1.1.2
+        uses: JohnnyMorganz/stylua-action@v3.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --check . --verbose

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --check . --verbose
-          version: v0.19.1
+          version: v0.20.0
 
         # The preinstalled version is positively antique; replace with the latest and greatest (to match MSYS)
       - name: Install clang-format (via APT)


### PR DESCRIPTION
Removes the annoying deprecation warning from the GitHub Actions UI... or so I hope.