### PR TITLE
Disable the static analysis workflow for changelog updates

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,7 +9,8 @@ on:
     branches:
       - main
     paths-ignore:
-      - "README.MD"
+      - '**.md'
+      - 'changelog.lua'
       - '.gitignore'
 
 jobs:


### PR DESCRIPTION
No point in doing this, really. It's just wasting time and energy.