### PR TITLE
Reverse the order of error details that are being displayed by the test runner

### DIFF
--- a/Runtime/API/C_Runtime.lua
+++ b/Runtime/API/C_Runtime.lua
@@ -18,7 +18,7 @@ function C_Runtime.RunBasicTests(specFiles)
 	print(bdd.getReport())
 
 	local errorDetails = bdd.getErrorDetails()
-	for index, errorInfo in ipairs(errorDetails) do
+	for index, errorInfo in ipairs(table.reverse(errorDetails)) do
 		print(format("(Error #%d) in %s", index, transform.bold(errorInfo.specFile)))
 		print(transform.brightRed(errorInfo.stackTrace))
 		print()
@@ -38,7 +38,7 @@ function C_Runtime.RunMinimalTests(specFiles)
 	print(bdd.getReport())
 
 	local errorDetails = bdd.getErrorDetails()
-	for index, errorInfo in ipairs(errorDetails) do
+	for index, errorInfo in ipairs(table.reverse(errorDetails)) do
 		print(format("(Error #%d) in %s", index, transform.bold(errorInfo.specFile)))
 		print(transform.brightRed(errorInfo.stackTrace))
 		print()
@@ -58,7 +58,7 @@ function C_Runtime.RunDetailedTests(specFiles)
 	print(bdd.getReport())
 
 	local errorDetails = bdd.getErrorDetails()
-	for index, errorInfo in ipairs(errorDetails) do
+	for index, errorInfo in ipairs(table.reverse(errorDetails)) do
 		print(format("(Error #%d) in %s", index, transform.bold(errorInfo.specFile)))
 		print(transform.brightRed(errorInfo.stackTrace))
 		print()

--- a/Runtime/Extensions/tablex.lua
+++ b/Runtime/Extensions/tablex.lua
@@ -53,5 +53,18 @@ function table.scopy(source)
 	return shallowCopy
 end
 
+function table.reverse(tableToReverse)
+	validation.validateTable(tableToReverse, "tableToReverse")
+
+	local reversedTable = {}
+
+	for index, value in ipairs(tableToReverse) do
+		local reversedIndex = #tableToReverse - index + 1
+		reversedTable[reversedIndex] = value
+	end
+
+	return reversedTable
+end
+
 table.clear = require("table.clear")
 table.new = require("table.new")

--- a/Tests/BDD/table-library.spec.lua
+++ b/Tests/BDD/table-library.spec.lua
@@ -113,4 +113,30 @@ describe("table", function()
 			assertEquals(table.clear, require("table.clear"))
 		end)
 	end)
+
+	describe("reverse", function()
+		it("should throw if a non-table value was passed", function()
+			assertThrows(function()
+				table.reverse(42)
+			end, "Expected argument tableToReverse to be a table value, but received a number value instead")
+		end)
+
+		it("should return a copy of the table with all array elements reversed", function()
+			local input = { "A", "B", "C" }
+			local expectedOutput = { "C", "B", "A" }
+			assertEquals(table.reverse(input), expectedOutput)
+		end)
+
+		it("should return an empty table if only the dictionary part of the table was used", function()
+			local input = { A = "A", B = "B", C = "C" }
+			local expectedOutput = {}
+			assertEquals(table.reverse(input), expectedOutput)
+		end)
+
+		it("should ignore all dictionary entries if the table is mixed", function()
+			local input = { "A", "B", "C", Hello = "world", something = print }
+			local expectedOutput = { "C", "B", "A" }
+			assertEquals(table.reverse(input), expectedOutput)
+		end)
+	end)
 end)


### PR DESCRIPTION
Sometimes there can be a cascade of errors, e.g,. because an earlier test failed and leaves the environment in an inconsistent state. In such scenarios, seeing tons of errors in the console is to be expected. However, the natural approach of trying to fix the error that's immediately in view first (i.e., the last one displayed in the console) will only lead to frustration as there might not be anything wrong with the test case itself.

In GCC and other tools there's a way to stop cascading errors and halt execution after the first, which however doesn't seem desirable here. Instead, an arguably more useful approach: The errors can simply be reported in reverse order. This way, the last one displayed is actually the first and no scrolling will be needed, but no information is lost.