### PR TITLE
Add a missing installation step for PulseAudio to the CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,9 @@ jobs:
     - name: Install WebKitGTK
       run: sudo apt-get install gtk+-3.0-dev webkit2gtk-4.0-dev --yes
 
+    - name: Install PulseAudio
+      run: sudo apt-get install pulseaudio libpulse-dev --yes
+
     - name: Configure environment
       run: |
             export PATH="/usr/lib/ccache:$PATH"


### PR DESCRIPTION
This is required to build on Linux (unfortunately), so the run fails.