### PR TITLE
Introduce a new syslog library that provides standardized SYSLOG_MESSAGE events

### DIFF
--- a/BuildTools/Targets/EvoBuildTarget.lua
+++ b/BuildTools/Targets/EvoBuildTarget.lua
@@ -52,6 +52,7 @@ local EvoBuildTarget = {
 		"Runtime/Libraries/oop.lua",
 		"Runtime/Libraries/path.lua",
 		"Runtime/Libraries/profiler.lua",
+		"Runtime/Libraries/syslog.lua",
 		"Runtime/Libraries/transform.lua",
 		"Runtime/Libraries/uuid.lua",
 		"Runtime/Libraries/validation.lua",

--- a/Runtime/Libraries/etrace.lua
+++ b/Runtime/Libraries/etrace.lua
@@ -9,7 +9,6 @@ local tostring = tostring
 local type = type
 
 local format = string.format
-local table_copy = table.copy
 local table_insert = table.insert
 
 local etrace = {
@@ -154,7 +153,7 @@ end
 function etrace.filter(event)
 	if event == nil or (type(event) == "table" and #event == 0) then
 		-- This may be modified if other events are created
-		return table_copy(etrace.eventLog)
+		return table.copy(etrace.eventLog)
 	end
 
 	local events = {}

--- a/Runtime/Libraries/syslog.lua
+++ b/Runtime/Libraries/syslog.lua
@@ -1,0 +1,117 @@
+local etrace = require("etrace")
+local path = require("path") -- Not yet preloaded when the global aliases are set up
+local uv = require("uv")
+local validation = require("validation")
+
+local format = string.format
+local validateString = validation.validateString
+local validateNumber = validation.validateNumber
+
+-- Always register this so that scripts can use the API even if logging is currently disabled
+etrace.register("SYSLOG_MESSAGE")
+
+local SYSLOG_FACILITY_LOCAL0 = 16
+local RUNTIME_EXECUTABLE_NAME = path.basename(uv.exepath(), ".exe")
+local RUNTIME_PROCESS_ID = uv.os_getpid()
+
+local syslog = {
+	FACILITY_CODE = SYSLOG_FACILITY_LOCAL0,
+	APPLICATION_NAME = RUNTIME_EXECUTABLE_NAME,
+	PROCESS_ID = RUNTIME_PROCESS_ID,
+	HOST_NAME = uv.os_gethostname(),
+	severityLevels = {
+		DEBUG = 7,
+		INFO = 6,
+		NOTICE = 5,
+		WARNING = 4,
+		ERROR = 3,
+		CRITICAL = 2,
+		ALERT = 1,
+		EMERGENCY = 0,
+		-- Reverse lookup-table to more easily create human-readable output
+		[0] = "EMERGENCY",
+		[1] = "ALERT",
+		[2] = "CRITICAL",
+		[3] = "ERROR",
+		[4] = "WARNING",
+		[5] = "NOTICE",
+		[6] = "INFO",
+		[7] = "DEBUG",
+	},
+	messageTypes = {
+		DEFAULT_MESSAGE_TYPE = "DEFAULT",
+		GENERIC_EMERGENCY_MESSAGE = "EMERGENCY_GENERIC",
+		GENERIC_ALERT_MESSAGE = "ALERT_GENERIC",
+		GENERIC_CRITICAL_MESSAGE = "CRITICAL_GENERIC",
+		GENERIC_ERROR_MESSAGE = "ERROR_GENERIC",
+		GENERIC_WARNING_MESSAGE = "WARNING_GENERIC",
+		GENERIC_NOTICE_MESSAGE = "NOTICE_GENERIC",
+		GENERIC_INFO_MESSAGE = "INFO_GENERIC",
+		GENERIC_DEBUG_MESSAGE = "DEBUG_GENERIC",
+	},
+	errorStrings = {
+		INVALID_SEVERITY_LEVEL = "Severity level %s is not a valid syslog severity level",
+	},
+}
+
+syslog.time = os.time -- To allow providing an alternate clock in tests or user scripts
+
+function syslog.message(messageText, severityLevel, optionalMessageID)
+	optionalMessageID = optionalMessageID or syslog.messageTypes.DEFAULT_MESSAGE_TYPE
+
+	validateString(messageText, "messageText")
+	validateNumber(severityLevel, "severityLevel")
+	validateString(optionalMessageID, "optionalMessageID")
+	if not syslog.severityLevels[severityLevel] then
+		error(format(syslog.errorStrings.INVALID_SEVERITY_LEVEL, severityLevel), 0)
+	end
+
+	etrace.publish("SYSLOG_MESSAGE", {
+		severity = severityLevel,
+		timestamp = syslog.time(),
+		messageText = messageText,
+		typeID = optionalMessageID,
+	})
+end
+
+function syslog.emergency(messageText, optionalMessageID)
+	optionalMessageID = optionalMessageID or syslog.messageTypes.GENERIC_EMERGENCY_MESSAGE
+	syslog.message(messageText, syslog.severityLevels.EMERGENCY, optionalMessageID)
+end
+
+function syslog.alert(messageText, optionalMessageID)
+	optionalMessageID = optionalMessageID or syslog.messageTypes.GENERIC_ALERT_MESSAGE
+	syslog.message(messageText, syslog.severityLevels.ALERT, optionalMessageID)
+end
+
+function syslog.critical(messageText, optionalMessageID)
+	optionalMessageID = optionalMessageID or syslog.messageTypes.GENERIC_CRITICAL_MESSAGE
+	syslog.message(messageText, syslog.severityLevels.CRITICAL, optionalMessageID)
+end
+
+function syslog.error(messageText, optionalMessageID)
+	optionalMessageID = optionalMessageID or syslog.messageTypes.GENERIC_ERROR_MESSAGE
+	syslog.message(messageText, syslog.severityLevels.ERROR, optionalMessageID)
+end
+
+function syslog.warning(messageText, optionalMessageID)
+	optionalMessageID = optionalMessageID or syslog.messageTypes.GENERIC_WARNING_MESSAGE
+	syslog.message(messageText, syslog.severityLevels.WARNING, optionalMessageID)
+end
+
+function syslog.notice(messageText, optionalMessageID)
+	optionalMessageID = optionalMessageID or syslog.messageTypes.GENERIC_NOTICE_MESSAGE
+	syslog.message(messageText, syslog.severityLevels.NOTICE, optionalMessageID)
+end
+
+function syslog.info(messageText, optionalMessageID)
+	optionalMessageID = optionalMessageID or syslog.messageTypes.GENERIC_INFO_MESSAGE
+	syslog.message(messageText, syslog.severityLevels.INFO, optionalMessageID)
+end
+
+function syslog.debug(messageText, optionalMessageID)
+	optionalMessageID = optionalMessageID or syslog.messageTypes.GENERIC_DEBUG_MESSAGE
+	syslog.message(messageText, syslog.severityLevels.DEBUG, optionalMessageID)
+end
+
+return syslog

--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -2,6 +2,7 @@ local assertions = require("assertions")
 local bdd = require("bdd")
 local console = require("console")
 local crypto = require("crypto")
+local etrace = require("etrace")
 local ffi = require("ffi")
 local glfw = require("glfw")
 local jit = require("jit")
@@ -186,6 +187,7 @@ function evo.registerGlobalAliases()
 		CRITICAL = syslog.critical,
 		ALERT = syslog.alert,
 		EMERGENCY = syslog.emergency,
+		EVENT = etrace.publish,
 	}
 
 	for alias, target in pairs(evo.globalAliases) do

--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -15,6 +15,7 @@ local regex = require("regex")
 local rml = require("rml")
 local stbi = require("stbi")
 local stduuid = require("stduuid")
+local syslog = require("syslog")
 local transform = require("transform")
 local uv = require("uv")
 local uws = require("uws")
@@ -177,6 +178,14 @@ function evo.registerGlobalAliases()
 		printf = console.printf,
 		sizeof = ffi.sizeof,
 		typeof = ffi.typeof,
+		DEBUG = syslog.debug,
+		INFO = syslog.info,
+		NOTICE = syslog.notice,
+		WARNING = syslog.warning,
+		ERROR = syslog.error,
+		CRITICAL = syslog.critical,
+		ALERT = syslog.alert,
+		EMERGENCY = syslog.emergency,
 	}
 
 	for alias, target in pairs(evo.globalAliases) do

--- a/Tests/BDD/etrace-library.spec.lua
+++ b/Tests/BDD/etrace-library.spec.lua
@@ -2,6 +2,10 @@ local etrace = require("etrace")
 
 describe("etrace", function()
 	describe("clear", function()
+		before(function()
+			etrace.reset()
+		end)
+
 		after(function()
 			etrace.reset()
 		end)

--- a/Tests/BDD/globals.spec.lua
+++ b/Tests/BDD/globals.spec.lua
@@ -1,6 +1,7 @@
 local ffi = require("ffi")
 local bdd = require("bdd")
 local console = require("console")
+local etrace = require("etrace")
 local oop = require("oop")
 local syslog = require("syslog")
 
@@ -35,6 +36,7 @@ local globalAliases = {
 	["CRITICAL"] = syslog.critical,
 	["ALERT"] = syslog.alert,
 	["EMERGENCY"] = syslog.emergency,
+	["EVENT"] = etrace.publish,
 }
 
 local globalNamespaces = {

--- a/Tests/BDD/globals.spec.lua
+++ b/Tests/BDD/globals.spec.lua
@@ -2,6 +2,7 @@ local ffi = require("ffi")
 local bdd = require("bdd")
 local console = require("console")
 local oop = require("oop")
+local syslog = require("syslog")
 
 local globalAliases = {
 	["after"] = bdd.after,
@@ -25,6 +26,15 @@ local globalAliases = {
 	["new"] = ffi.new,
 	["sizeof"] = ffi.sizeof,
 	["typeof"] = ffi.typeof,
+	-- Capitalization avoids name clashes and emphasises the cross-cutting nature
+	["DEBUG"] = syslog.debug,
+	["INFO"] = syslog.info,
+	["NOTICE"] = syslog.notice,
+	["WARNING"] = syslog.warning,
+	["ERROR"] = syslog.error,
+	["CRITICAL"] = syslog.critical,
+	["ALERT"] = syslog.alert,
+	["EMERGENCY"] = syslog.emergency,
 }
 
 local globalNamespaces = {

--- a/Tests/BDD/syslog-library.spec.lua
+++ b/Tests/BDD/syslog-library.spec.lua
@@ -1,0 +1,184 @@
+local etrace = require("etrace")
+local syslog = require("syslog")
+
+local VIRTUAL_TIME_NOW = 12345 -- The actual value doesn't matter, just needs to be consistent
+
+local function resetTestEnvironment()
+	before(function()
+		etrace.clear()
+		etrace.enable("SYSLOG_MESSAGE")
+		syslog.time = function()
+			return VIRTUAL_TIME_NOW
+		end
+	end)
+
+	after(function()
+		etrace.disable("SYSLOG_MESSAGE")
+		syslog.time = os.time
+	end)
+end
+
+describe("syslog", function()
+	describe("debug", function()
+		resetTestEnvironment()
+		it("should publish a DEBUG message event with the expected payload", function()
+			local messageText = "This is a DEBUG message event created by the syslog library"
+			syslog.debug(messageText)
+			local events = etrace.filter()
+
+			assertEquals(#events, 1)
+			local syslogMessageEvent = events[1]
+			assertEquals(syslogMessageEvent.name, "SYSLOG_MESSAGE")
+			assertEquals(syslogMessageEvent.payload.messageText, messageText)
+			assertEquals(syslogMessageEvent.payload.typeID, syslog.messageTypes.GENERIC_DEBUG_MESSAGE)
+			assertEquals(syslogMessageEvent.payload.severity, syslog.severityLevels.DEBUG)
+			assertEquals(syslogMessageEvent.payload.timestamp, VIRTUAL_TIME_NOW)
+		end)
+	end)
+
+	describe("info", function()
+		resetTestEnvironment()
+		it("should publish an INFO message event with the expected payload", function()
+			local messageText = "This is an INFO message event created by the syslog library"
+			syslog.info(messageText)
+			local events = etrace.filter()
+
+			assertEquals(#events, 1)
+			local syslogMessageEvent = events[1]
+			assertEquals(syslogMessageEvent.name, "SYSLOG_MESSAGE")
+			assertEquals(syslogMessageEvent.payload.messageText, messageText)
+			assertEquals(syslogMessageEvent.payload.typeID, syslog.messageTypes.GENERIC_INFO_MESSAGE)
+			assertEquals(syslogMessageEvent.payload.severity, syslog.severityLevels.INFO)
+			assertEquals(syslogMessageEvent.payload.timestamp, VIRTUAL_TIME_NOW)
+		end)
+	end)
+
+	describe("notice", function()
+		resetTestEnvironment()
+		it("should publish a NOTICE message event with the expected payload", function()
+			local messageText = "This is a NOTICE message event created by the syslog library"
+			syslog.notice(messageText)
+			local events = etrace.filter()
+
+			assertEquals(#events, 1)
+			local syslogMessageEvent = events[1]
+			assertEquals(syslogMessageEvent.name, "SYSLOG_MESSAGE")
+			assertEquals(syslogMessageEvent.payload.messageText, messageText)
+			assertEquals(syslogMessageEvent.payload.typeID, syslog.messageTypes.GENERIC_NOTICE_MESSAGE)
+			assertEquals(syslogMessageEvent.payload.severity, syslog.severityLevels.NOTICE)
+			assertEquals(syslogMessageEvent.payload.timestamp, VIRTUAL_TIME_NOW)
+		end)
+	end)
+
+	describe("warning", function()
+		resetTestEnvironment()
+		it("should publish a WARNING message event with the expected payload", function()
+			local messageText = "This is a WARNING message event created by the syslog library"
+			syslog.warning(messageText)
+			local events = etrace.filter()
+
+			assertEquals(#events, 1)
+			local syslogMessageEvent = events[1]
+			assertEquals(syslogMessageEvent.name, "SYSLOG_MESSAGE")
+			assertEquals(syslogMessageEvent.payload.messageText, messageText)
+			assertEquals(syslogMessageEvent.payload.typeID, syslog.messageTypes.GENERIC_WARNING_MESSAGE)
+			assertEquals(syslogMessageEvent.payload.severity, syslog.severityLevels.WARNING)
+			assertEquals(syslogMessageEvent.payload.timestamp, VIRTUAL_TIME_NOW)
+		end)
+	end)
+
+	describe("error", function()
+		resetTestEnvironment()
+		it("should publish an ERROR message event with the expected payload", function()
+			local messageText = "This is an ERROR message event created by the syslog library"
+			syslog.error(messageText)
+			local events = etrace.filter()
+
+			assertEquals(#events, 1)
+			local syslogMessageEvent = events[1]
+			assertEquals(syslogMessageEvent.name, "SYSLOG_MESSAGE")
+			assertEquals(syslogMessageEvent.payload.messageText, messageText)
+			assertEquals(syslogMessageEvent.payload.typeID, syslog.messageTypes.GENERIC_ERROR_MESSAGE)
+			assertEquals(syslogMessageEvent.payload.severity, syslog.severityLevels.ERROR)
+			assertEquals(syslogMessageEvent.payload.timestamp, VIRTUAL_TIME_NOW)
+		end)
+	end)
+
+	describe("critical", function()
+		resetTestEnvironment()
+		it("should publish a CRITICAL message event with the expected payload", function()
+			local messageText = "This is a CRITICAL message event created by the syslog library"
+			syslog.critical(messageText)
+			local events = etrace.filter()
+
+			assertEquals(#events, 1)
+			local syslogMessageEvent = events[1]
+			assertEquals(syslogMessageEvent.name, "SYSLOG_MESSAGE")
+			assertEquals(syslogMessageEvent.payload.messageText, messageText)
+			assertEquals(syslogMessageEvent.payload.typeID, syslog.messageTypes.GENERIC_CRITICAL_MESSAGE)
+			assertEquals(syslogMessageEvent.payload.severity, syslog.severityLevels.CRITICAL)
+			assertEquals(syslogMessageEvent.payload.timestamp, VIRTUAL_TIME_NOW)
+		end)
+	end)
+
+	describe("alert", function()
+		resetTestEnvironment()
+		it("should publish an ALERT message event with the expected payload", function()
+			local messageText = "This is an ALERT message event created by the syslog library"
+			syslog.alert(messageText)
+			local events = etrace.filter()
+
+			assertEquals(#events, 1)
+			local syslogMessageEvent = events[1]
+			assertEquals(syslogMessageEvent.name, "SYSLOG_MESSAGE")
+			assertEquals(syslogMessageEvent.payload.messageText, messageText)
+			assertEquals(syslogMessageEvent.payload.typeID, syslog.messageTypes.GENERIC_ALERT_MESSAGE)
+			assertEquals(syslogMessageEvent.payload.severity, syslog.severityLevels.ALERT)
+			assertEquals(syslogMessageEvent.payload.timestamp, VIRTUAL_TIME_NOW)
+		end)
+	end)
+
+	describe("emergency", function()
+		resetTestEnvironment()
+		it("should publish an EMERGENCY message event with the expected payload", function()
+			local messageText = "This is an EMERGENCY message event created by the syslog library"
+			syslog.emergency(messageText)
+			local events = etrace.filter()
+
+			assertEquals(#events, 1)
+			local syslogMessageEvent = events[1]
+			assertEquals(syslogMessageEvent.name, "SYSLOG_MESSAGE")
+			assertEquals(syslogMessageEvent.payload.messageText, messageText)
+			assertEquals(syslogMessageEvent.payload.typeID, syslog.messageTypes.GENERIC_EMERGENCY_MESSAGE)
+			assertEquals(syslogMessageEvent.payload.severity, syslog.severityLevels.EMERGENCY)
+			assertEquals(syslogMessageEvent.payload.timestamp, VIRTUAL_TIME_NOW)
+		end)
+	end)
+
+	describe("message", function()
+		resetTestEnvironment()
+		it("should throw if the provided message text isn't a string value", function()
+			assertThrows(function()
+				syslog.message(42, syslog.severityLevels.DEBUG)
+			end, "Expected argument messageText to be a string value, but received a number value instead")
+		end)
+
+		it("should throw if the provided severity level isn't a number value", function()
+			assertThrows(function()
+				syslog.message("Almost got me there!", "42")
+			end, "Expected argument severityLevel to be a number value, but received a string value instead")
+		end)
+
+		it("should throw if the provided severity level text isn't a valid syslog severity level", function()
+			assertThrows(function()
+				syslog.message("42 is not a valid severity level", 42)
+			end, format(syslog.errorStrings.INVALID_SEVERITY_LEVEL, 42))
+		end)
+
+		it("should throw if the provided optional message ID isn't a string value", function()
+			assertThrows(function()
+				syslog.message("If you're gonna use it, do it right", syslog.severityLevels.DEBUG, 42)
+			end, "Expected argument optionalMessageID to be a string value, but received a number value instead")
+		end)
+	end)
+end)

--- a/Tests/BDD/syslog-library.spec.lua
+++ b/Tests/BDD/syslog-library.spec.lua
@@ -5,7 +5,8 @@ local VIRTUAL_TIME_NOW = 12345 -- The actual value doesn't matter, just needs to
 
 local function resetTestEnvironment()
 	before(function()
-		etrace.clear()
+		etrace.reset()
+		etrace.register("SYSLOG_MESSAGE")
 		etrace.enable("SYSLOG_MESSAGE")
 		syslog.time = function()
 			return VIRTUAL_TIME_NOW
@@ -13,7 +14,7 @@ local function resetTestEnvironment()
 	end)
 
 	after(function()
-		etrace.disable("SYSLOG_MESSAGE")
+		etrace.reset()
 		syslog.time = os.time
 	end)
 end

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -22,6 +22,7 @@ local specFiles = {
 	"Tests/BDD/stbi-library.spec.lua",
 	"Tests/BDD/stduuid-library.spec.lua",
 	"Tests/BDD/string-library.spec.lua",
+	"Tests/BDD/syslog-library.spec.lua",
 	"Tests/BDD/table-library.spec.lua",
 	"Tests/BDD/transform-library.spec.lua",
 	"Tests/BDD/uuid-library.spec.lua",


### PR DESCRIPTION
This is currently very basic, but hooks into the event registry and should allow future extension towards syslog-compatible output. There shouldn't be any performance overhead if logging is disabled as the JIT optimizes function calls out if they're NOOPs.

---

Resolves #54.