### PR TITLE
Add a missing cleanup step to the snapshot test for the profiling command

### DIFF
--- a/Tests/snapshot-test.lua
+++ b/Tests/snapshot-test.lua
@@ -341,6 +341,7 @@ local testCases = {
 			local expectedOutput = "Detected LUAJIT_PROFILEMODE: 3si4m1\n"
 				.. "Detected LUAJIT_PROFILEFILE: results.txt\n"
 			local profilingResults = C_FileSystem.ReadFile("results.txt")
+			C_FileSystem.Delete("results.txt")
 			profilingResults = profilingResults:gsub("\r\n", "\n") -- LuaJIT opens the file in text mode
 			assertEquals(observedOutput, expectedOutput)
 			assertExitSuccess(observedOutput, status, terminationReason, exitCodeOrSignalID)


### PR DESCRIPTION
The profiling results are saved to a separate file by LuaJIT, which should of course be removed after the test has run.