### PR TITLE
Use the fancy new-fangled macOS name consistently (instead of the "good old" Mac OS X)

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -1,4 +1,4 @@
-name: Build and Release (Mac OS)
+name: Build and Release (macOS)
 
 on:
   push:
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    name: Build for Mac OS
+    name: Build for macOS
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Not all of the included APIs are as user-friendly as I'd like, but that'll chang
 
 ## System Requirements
 
-The supported platforms are current versions of Windows, Linux, and Mac OS X.
+The supported platforms are current versions of Windows, Linux, and macOS.
 
 Automated testing covers all platforms equally:
 
@@ -28,7 +28,7 @@ Automated testing covers all platforms equally:
 ![https://github.com/evo-lua/evo-runtime/actions/workflows/ci-linux.yml/badge.svg](https://github.com/evo-lua/evo-runtime/actions/workflows/ci-linux.yml/badge.svg)
 ![https://github.com/evo-lua/evo-runtime/actions/workflows/ci-mac.yml/badge.svg](https://github.com/evo-lua/evo-runtime/actions/workflows/ci-mac.yml/badge.svg)
 
-Development happens on Windows 10 and Ubuntu. Mac OS support is given on a "best effort" basis.
+Development happens on Windows 10 and Ubuntu; macOS (especially M1) support is given on a "best effort" basis.
 
 ## Compatibility
 
@@ -57,7 +57,7 @@ In this repository, you'll find the following important directories:
 After building, you'll additionally find a temporary directory containing all build artifacts here:
 
 * ``ninjabuild-windows`` (Windows)
-* ``ninjabuild-unix`` (Linux or Mac OS)
+* ``ninjabuild-unix`` (Linux or macOS)
 
 There's also config files for GitHub actions and other tooling in the project root - a necessary evil.
 


### PR DESCRIPTION
Now get off my lawn, Mr. Jobs (or whoever decided to rename the OS back at the time). It'll always be OSX in *my* mind.