### PR TITLE
Prevent event notifications from being suppressed if logging for the given event happens to be disabled

### DIFF
--- a/Runtime/Libraries/etrace.lua
+++ b/Runtime/Libraries/etrace.lua
@@ -287,11 +287,6 @@ function etrace.notify(event, payload)
 		return
 	end
 
-	local isEventEnabled = (etrace.registeredEvents[event] == true)
-	if not isEventEnabled then
-		return
-	end
-
 	for listener, eventHandler in pairs(subscribers) do
 		if type(listener) == "table" then -- Enable use of : syntax
 			eventHandler(listener, event, payload)

--- a/Tests/BDD/etrace-library.spec.lua
+++ b/Tests/BDD/etrace-library.spec.lua
@@ -715,7 +715,7 @@ describe("etrace", function()
 			assertEquals(providedArguments.functionListener, { "MEEP", {} })
 		end)
 
-		it("should have no effect if the given event is disabled", function()
+		it("should still work if logging for the given event is disabled", function()
 			local providedArguments = {}
 
 			local function functionListener(event, payload)
@@ -723,9 +723,11 @@ describe("etrace", function()
 			end
 
 			etrace.register("MEEP")
+			etrace.disable("MEEP")
 			etrace.subscribe("MEEP", functionListener)
 			etrace.notify("MEEP", { hello = 42 })
-			assertEquals(providedArguments.functionListener, nil)
+			assertEquals(providedArguments.functionListener[1], "MEEP")
+			assertEquals(providedArguments.functionListener[2].hello, 42)
 		end)
 	end)
 
@@ -777,7 +779,7 @@ describe("etrace", function()
 			assertEquals(providedArguments.functionListener, { "MEEP", { hello = 42 } })
 		end)
 
-		it("should have no effect if the given event is disabled", function()
+		it("should still work if logging for the given event is disabled", function()
 			local providedArguments = {}
 
 			local function functionListener(event, payload)
@@ -787,7 +789,11 @@ describe("etrace", function()
 			etrace.register("MEEP")
 			etrace.subscribe("MEEP", functionListener)
 			etrace.publish("MEEP", { hello = 42 })
-			assertEquals(providedArguments.functionListener, nil)
+			-- Disabling event notifications would break any listener relying on the event system
+			assertEquals(providedArguments.functionListener[1], "MEEP")
+			assertEquals(providedArguments.functionListener[2].hello, 42)
+
+			-- The log should be empty, however as logging was indeed disabled
 			assertEquals(etrace.filter(), {})
 		end)
 	end)


### PR DESCRIPTION
The behavior as specified doesn't make any sense, as it conflates the event log with the actual event registry. Disabling logging should of course not disable notifications as that would completely break any code that expects to get notified.

Maybe this is a sign the intent needs to be made clearer, seeing how the "minimal" naming convention selected here (which is typically used in Lua and C) doesn't sufficiently express this nuance. Will have to consider this when streamlining the API...