### PR TITLE
Add some usage instructions to the interpreter's "live edit" (REPL) interface

### DIFF
--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -101,6 +101,16 @@ A list of supported profiling modes and their combinations can be found here: %s
 			transform.brightYellow("LUAJIT_PROFILEFILE=results.txt evo profile script.lua ..."),
 			transform.brightBlue("https://luajit.org/ext_profiler.html")
 		),
+		REPL_WELCOME_TEXT = format(
+			transform.brightGreen("Welcome to Evo.lua %s (REPL powered by LuaJIT)"),
+			EVO_VERSION
+		),
+		REPL_USAGE_INSTRUCTIONS = format(
+			"Evaluating code in %s mode. To exit, press %s or type %s.",
+			transform.brightMagenta("live edit"),
+			transform.brightYellow("CTRL+C"),
+			transform.brightYellow("os.exit()")
+		),
 	},
 }
 
@@ -355,13 +365,8 @@ function evo.evaluateChunk(commandName, argv)
 	local luaCodeToEvaluate = unpack(argv)
 
 	if not luaCodeToEvaluate then
-		printf(transform.brightGreen("Welcome to Evo.lua %s (REPL powered by LuaJIT)"), EVO_VERSION)
-		printf(
-			"Evaluating code in %s mode. To exit, press %s or type %s.",
-			transform.brightMagenta("live edit"),
-			transform.brightYellow("CTRL+C"),
-			transform.brightYellow("os.exit()")
-		)
+		print(evo.messageStrings.REPL_WELCOME_TEXT)
+		print(evo.messageStrings.REPL_USAGE_INSTRUCTIONS)
 		runtime.bindings.runtime_repl_start()
 		return
 	end

--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -356,6 +356,12 @@ function evo.evaluateChunk(commandName, argv)
 
 	if not luaCodeToEvaluate then
 		printf(transform.brightGreen("Welcome to Evo.lua %s (REPL powered by LuaJIT)"), EVO_VERSION)
+		printf(
+			"Evaluating code in %s mode. To exit, press %s or type %s.",
+			transform.brightMagenta("live edit"),
+			transform.brightYellow("CTRL+C"),
+			transform.brightYellow("os.exit()")
+		)
 		runtime.bindings.runtime_repl_start()
 		return
 	end

--- a/Tests/snapshot-test.lua
+++ b/Tests/snapshot-test.lua
@@ -112,9 +112,12 @@ local testCases = {
 			.. SHELL_ESCAPE_SYMBOL
 			.. " | evo eval",
 		onExit = function(observedOutput, status, terminationReason, exitCodeOrSignalID)
-			local welcomeText =
-				transform.brightGreen(format("Welcome to Evo.lua %s (REPL powered by LuaJIT)", EVO_VERSION))
-			local expectedOutput = welcomeText .. "\n" .. "> Hello from the REPL!" .. "\n"
+			local expectedOutput = evo.messageStrings.REPL_WELCOME_TEXT
+				.. "\n"
+				.. evo.messageStrings.REPL_USAGE_INSTRUCTIONS
+				.. "\n"
+				.. "> Hello from the REPL!"
+				.. "\n"
 			assertEquals(observedOutput, expectedOutput)
 			assertExitFailure(observedOutput, status, terminationReason, exitCodeOrSignalID)
 		end,


### PR DESCRIPTION
Basic stuff, but it makes it feel much nicer to use. Not sure about the colors, but they need streamlining (later) anyway.