### PR TITLE
Streamline the input validation in the text transformation library

### DIFF
--- a/Runtime/Libraries/transform.lua
+++ b/Runtime/Libraries/transform.lua
@@ -1,3 +1,6 @@
+local validation = require("validation")
+local validateString = validation.validateString
+
 local transform = {
 	ENABLE_TEXT_TRANSFORMATIONS = true,
 	START_SEQUENCE = "\27[",
@@ -41,8 +44,6 @@ local transform = {
 	},
 }
 
-local type = type
-
 function transform.enable()
 	transform.ENABLE_TEXT_TRANSFORMATIONS = true
 end
@@ -52,9 +53,7 @@ function transform.disable()
 end
 
 function transform.strip(coloredConsoleText)
-	if type(coloredConsoleText) ~= "string" then
-		error("Usage: transform.strip(text : string)", 0)
-	end
+	validateString(coloredConsoleText, "coloredConsoleText")
 
 	-- All credit goes to this fine gentleman: https://stackoverflow.com/users/3735873/tonypdmtr
 	local strippedConsoleText = coloredConsoleText
@@ -68,9 +67,8 @@ function transform.strip(coloredConsoleText)
 end
 
 local function transformText(text, color)
-	if type(text) ~= "string" then
-		error("Usage: transform." .. color .. "(text : string)", 0)
-	end
+	validateString(text, "text")
+	validateString(color, "color")
 
 	if not transform.ENABLE_TEXT_TRANSFORMATIONS then
 		return text

--- a/Tests/BDD/transform-library.spec.lua
+++ b/Tests/BDD/transform-library.spec.lua
@@ -77,9 +77,13 @@ describe("transform", function()
 		}
 		for _, color in ipairs(supportedTerminalColors) do
 			for _, invalidValue in ipairs(invalidValues) do
+				local actualType = type(invalidValue)
 				assertThrows(function()
 					transform[color](invalidValue)
-				end, "Usage: transform." .. color .. "(text : string)")
+				end, format(
+					"Expected argument text to be a string value, but received a %s value instead",
+					actualType
+				))
 			end
 		end
 	end)
@@ -108,6 +112,12 @@ describe("transform", function()
 	end)
 
 	describe("strip", function()
+		it("should throw if a non-string value was passed", function()
+			assertThrows(function()
+				transform.strip(42)
+			end, "Expected argument coloredConsoleText to be a string value, but received a number value instead")
+		end)
+
 		it("should remove color codes from the input without otherwise modifying it", function()
 			for name, transformation in pairs(transform) do
 				if type(transformation) == "function" and transform.colorCodes[name] then


### PR DESCRIPTION
This code was copy/pasted from the previous iteration of the runtime, which didn't include a validation library.