### PR TITLE
Fix some inconsistencies in the json library

### DIFF
--- a/Runtime/Extensions/jsonx.lua
+++ b/Runtime/Extensions/jsonx.lua
@@ -3,13 +3,8 @@ local json = require("json")
 local json_decode = json.decode
 local json_encode = json.encode
 
-function json.parse(jsonString)
-	return json_decode(jsonString)
-end
-
-function json.stringify(luaTable)
-	return json_encode(luaTable)
-end
+json.parse = json_decode
+json.stringify = json_encode
 
 function json.pretty(jsonStringOrTable)
 	local encodingOptions = {
@@ -18,11 +13,11 @@ function json.pretty(jsonStringOrTable)
 	}
 
 	if type(jsonStringOrTable) == "string" then
-		return json.encode(json.decode(jsonStringOrTable), encodingOptions)
+		return json_encode(json.decode(jsonStringOrTable), encodingOptions)
 	end
 
 	if type(jsonStringOrTable) == "table" then
-		return json.encode(jsonStringOrTable, encodingOptions)
+		return json_encode(jsonStringOrTable, encodingOptions)
 	end
 
 	return nil, "string or table expected, got " .. type(jsonStringOrTable)
@@ -35,11 +30,11 @@ function json.prettier(jsonStringOrTable)
 	}
 
 	if type(jsonStringOrTable) == "string" then
-		return json.encode(json.decode(jsonStringOrTable), encodingOptions)
+		return json_encode(json.decode(jsonStringOrTable), encodingOptions)
 	end
 
 	if type(jsonStringOrTable) == "table" then
-		return json.encode(jsonStringOrTable, encodingOptions)
+		return json_encode(jsonStringOrTable, encodingOptions)
 	end
 
 	return nil, "string or table expected, got " .. type(jsonStringOrTable)

--- a/Tests/BDD/json-library.spec.lua
+++ b/Tests/BDD/json-library.spec.lua
@@ -34,6 +34,10 @@ describe("json", function()
 			local jsonTable = json.parse(jsonString)
 			assertEquals(jsonTable, luaTable)
 		end)
+
+		it("should be an alias of json.decode", function()
+			assertEquals(json.parse, json.decode)
+		end)
 	end)
 
 	describe("stringify", function()
@@ -42,6 +46,21 @@ describe("json", function()
 			assertEquals(json.stringify({ 3, "false", false }), '[3,"false",false]')
 			assertEquals(json.stringify({ x = { 10, json.null, 42 } }), '{"x":[10,null,42]}')
 			assertEquals(json.stringify({ x = { 10, nil, 42 } }), '{"x":[10]}')
+		end)
+
+		it("should forward the encoding options if any have been passed", function()
+			local input = { result = true, count = 42 }
+			local expectedOutput = '{\n\t"count": 42,\n\t"result": true\n}'
+			local encodingOptions = {
+				prettier = true,
+				sort_keys = true,
+			}
+			local formattedInput = json.stringify(input, encodingOptions)
+			assertEquals(formattedInput, expectedOutput)
+		end)
+
+		it("should be an alias of json.encode", function()
+			assertEquals(json.stringify, json.encode)
 		end)
 	end)
 


### PR DESCRIPTION
Duplicating the functionality is just silly, and more importantly:

The alias is missing the `encodingOptions` parameter, which is clearly an oversight.