### PR TITLE
Streamline the initialization of the FFI bindings

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -12,9 +12,6 @@ ignore = {
 	"213", -- unused loop variable (kept for readability's sake)
 }
 globals = {
-	-- C++ entry point
-	"EVO_VERSION",
-
 	-- assertions library
 	"assertTrue",
 	"assertFalse",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -14,7 +14,6 @@ ignore = {
 globals = {
 	-- C++ entry point
 	"EVO_VERSION",
-	"STATIC_FFI_EXPORTS",
 
 	-- assertions library
 	"assertTrue",

--- a/Runtime/API/C_Runtime.lua
+++ b/Runtime/API/C_Runtime.lua
@@ -1,6 +1,7 @@
 local assertions = require("assertions")
 local bdd = require("bdd")
 local ffi = require("ffi")
+local runtime = require("runtime")
 local transform = require("transform")
 local uv = require("uv")
 local validation = require("validation")
@@ -74,7 +75,8 @@ function C_Runtime.EvaluateString(luaCode)
 end
 
 function C_Runtime.PrintVersionString()
-	print(EVO_VERSION)
+	local semanticVersionString = runtime.version()
+	print(semanticVersionString)
 end
 
 local function shell_exec(command, environmentVariables)

--- a/Runtime/Bindings/runtime.lua
+++ b/Runtime/Bindings/runtime.lua
@@ -4,6 +4,9 @@ local runtime = {}
 
 runtime.cdefs = [[
 	struct static_runtime_exports_table {
+		// Build configuration
+		const char* (*runtime_version)(void);
+
 		// REPL
 		void (*runtime_repl_start)(void);
 	};
@@ -11,6 +14,14 @@ runtime.cdefs = [[
 
 function runtime.initialize()
 	ffi.cdef(runtime.cdefs)
+end
+
+function runtime.version()
+	local cStringPointer = runtime.bindings.runtime_version()
+	local versionString = ffi.string(cStringPointer)
+
+	local majorVersion, minorVersion, patchVersion = versionString:match("(%d+)%.(%d+)%.*(%d*)")
+	return versionString, tonumber(majorVersion), tonumber(minorVersion), tonumber(patchVersion)
 end
 
 return runtime

--- a/Runtime/Bindings/runtime_ffi.cpp
+++ b/Runtime/Bindings/runtime_ffi.cpp
@@ -11,12 +11,19 @@ namespace runtime_ffi {
 		assignedLuaState = L;
 	}
 
+	const char* runtime_version() {
+		return EVO_VERSION;
+	}
+
 	void runtime_repl_start() {
 		dotty(assignedLuaState);
 	}
 
 	void* getExportsTable() {
 		static struct static_runtime_exports_table exports_table;
+
+		// Build configuration
+		exports_table.runtime_version = &runtime_version;
 
 		// REPL
 		exports_table.runtime_repl_start = &runtime_repl_start;

--- a/Runtime/Bindings/runtime_ffi.hpp
+++ b/Runtime/Bindings/runtime_ffi.hpp
@@ -3,11 +3,18 @@
 #include "lua.hpp"
 
 struct static_runtime_exports_table {
+	// Build configuration
+	const char* (*runtime_version)(void);
+
+	// REPL
 	void (*runtime_repl_start)(void);
 };
 
 namespace runtime_ffi {
 	void assignLuaState(lua_State* L);
+
+	// Build configuration
+	const char* runtime_version();
 
 	// REPL
 	void runtime_repl_start();

--- a/Runtime/LuaVirtualMachine.cpp
+++ b/Runtime/LuaVirtualMachine.cpp
@@ -1,5 +1,6 @@
 #include <cstring>
 #include <iostream>
+#include <optional>
 
 #include "macros.hpp"
 #include "uws_ffi.hpp"
@@ -80,11 +81,17 @@ LuaVirtualMachine::~LuaVirtualMachine() {
 	lua_close(m_luaState);
 }
 
-bool LuaVirtualMachine::LoadPackage(std::string packageName, luaopen_function packageLoader) {
+bool LuaVirtualMachine::LoadPackage(std::string packageName) {
+	return LoadPackage(packageName, std::nullopt);
+}
+
+bool LuaVirtualMachine::LoadPackage(std::string packageName, std::optional<lua_CFunction> packageLoader) {
+	lua_CFunction loader = packageLoader.value_or(emptyPackageLoader);
+
 	lua_getglobal(m_luaState, "package");
 	lua_getfield(m_luaState, -1, "loaded");
 
-	lua_pushcfunction(m_luaState, packageLoader);
+	lua_pushcfunction(m_luaState, loader);
 	lua_call(m_luaState, 0, 1);
 	lua_setfield(m_luaState, -2, packageName.c_str());
 

--- a/Runtime/LuaVirtualMachine.cpp
+++ b/Runtime/LuaVirtualMachine.cpp
@@ -80,7 +80,7 @@ LuaVirtualMachine::~LuaVirtualMachine() {
 	lua_close(m_luaState);
 }
 
-bool LuaVirtualMachine::PreloadPackage(std::string packageName, luaopen_function packageLoader) {
+bool LuaVirtualMachine::LoadPackage(std::string packageName, luaopen_function packageLoader) {
 	lua_getglobal(m_luaState, "package");
 	lua_getfield(m_luaState, -1, "loaded");
 

--- a/Runtime/LuaVirtualMachine.cpp
+++ b/Runtime/LuaVirtualMachine.cpp
@@ -61,10 +61,6 @@ LuaVirtualMachine::LuaVirtualMachine() {
 	lua_pushcfunction(m_luaState, onLuaError);
 	m_onLuaErrorIndex = lua_gettop(m_luaState);
 
-	// This global table simply exports the static APIs embedded within the runtime for the FFI to call into
-	lua_newtable(m_luaState);
-	lua_setglobal(m_luaState, "STATIC_FFI_EXPORTS");
-
 	// Not pretty, but os.exit doesn't unassign the uws loop (which crashes the runtime if close=true)
 	lua_getglobal(m_luaState, "os");
 	lua_getfield(m_luaState, -1, "exit");
@@ -163,10 +159,17 @@ bool LuaVirtualMachine::SetGlobalArgs(int argc, char* argv[]) {
 	return true; // Can this even fail? If so, the smoke tests should catch it anyway...
 }
 
-void LuaVirtualMachine::BindStaticLibraryExports(std::string fieldName, void* staticExportsTable) {
-	lua_getglobal(m_luaState, "STATIC_FFI_EXPORTS");
-	lua_pushlightuserdata(m_luaState, staticExportsTable);
-	lua_setfield(m_luaState, -2, fieldName.c_str());
+void LuaVirtualMachine::BindStaticLibraryExports(const std::string fieldName, void* staticExportsTable) {
+	lua_getglobal(m_luaState, "package");
+	lua_getfield(m_luaState, -1, "loaded");
+	lua_getfield(m_luaState, -1, "bindings");
+
+	if(lua_istable(m_luaState, -1)) {
+		lua_pushlightuserdata(m_luaState, staticExportsTable);
+		lua_setfield(m_luaState, -2, fieldName.c_str());
+	}
+
+	lua_pop(m_luaState, 3);
 }
 
 void LuaVirtualMachine::CreateGlobalNamespace(std::string name) {

--- a/Runtime/LuaVirtualMachine.hpp
+++ b/Runtime/LuaVirtualMachine.hpp
@@ -11,7 +11,7 @@ public:
 	LuaVirtualMachine();
 	~LuaVirtualMachine();
 
-	bool PreloadPackage(std::string packageName, luaopen_function packageLoader);
+	bool LoadPackage(std::string packageName, luaopen_function packageLoader);
 	bool DoFile(std::string filePath);
 	bool DoString(std::string chunk, std::string chunkName);
 	bool CompileChunk(std::string chunk, std::string chunkName);

--- a/Runtime/LuaVirtualMachine.hpp
+++ b/Runtime/LuaVirtualMachine.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <optional>
 #include <lua.hpp>
 
 // As per convention, any C function that creates a table with the library APIs and pushes it to the stack
@@ -11,7 +12,8 @@ public:
 	LuaVirtualMachine();
 	~LuaVirtualMachine();
 
-	bool LoadPackage(std::string packageName, luaopen_function packageLoader);
+	bool LoadPackage(std::string packageName);
+	bool LoadPackage(std::string packageName, std::optional<lua_CFunction> packageLoader);
 	bool DoFile(std::string filePath);
 	bool DoString(std::string chunk, std::string chunkName);
 	bool CompileChunk(std::string chunk, std::string chunkName);
@@ -30,4 +32,9 @@ private:
 	// Getting these offsets wrong will cause segfaults, so let's just track them and get it over with...
 	int m_numExpectedArgsFromLuaMain;
 	int m_relativeStackOffset;
+
+	static int emptyPackageLoader(lua_State* m_luaState) {
+		lua_newtable(m_luaState);
+		return 1;
+	}
 };

--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -151,17 +151,17 @@ function evo.loadNonstandardExtensions()
 end
 
 function evo.initializeStaticLibraryExports()
-	local staticLibraryExports = _G.STATIC_FFI_EXPORTS
-	if not staticLibraryExports then
+	local bindings = require("bindings")
+	if not bindings then
 		return
 	end
 
 	-- See https://evo-lua.github.io/docs/background-information/luajit/static-ffi-bindings/
-	for libraryName, staticWrapperObject in pairs(staticLibraryExports) do
+	for libraryName, staticExportsTable in pairs(bindings) do
 		local ffiBindings = require(libraryName)
 		ffiBindings.initialize()
 		local expectedStructName = "struct static_" .. libraryName .. "_exports_table*"
-		local ffiExportsTable = ffi.cast(expectedStructName, staticWrapperObject)
+		local ffiExportsTable = ffi.cast(expectedStructName, staticExportsTable)
 		ffiBindings.bindings = ffiExportsTable
 	end
 end

--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -117,7 +117,7 @@ A list of supported profiling modes and their combinations can be found here: %s
 		),
 		REPL_WELCOME_TEXT = format(
 			transform.brightGreen("Welcome to Evo.lua %s (REPL powered by LuaJIT)"),
-			EVO_VERSION
+			runtime.version()
 		),
 		REPL_USAGE_INSTRUCTIONS = format(
 			"Evaluating code in %s mode. To exit, press %s or type %s.",
@@ -261,7 +261,7 @@ Commands:
 end
 
 function evo.displayRuntimeVersion(commandName, ...)
-	print(EVO_VERSION)
+	print(runtime.version())
 end
 
 function evo.showVersionStrings(commandName, ...)
@@ -274,7 +274,7 @@ end
 function evo.getVersionText()
 	local versionText = format(
 		"This is %s (powered by %s)",
-		transform.brightGreen("Evo.lua " .. EVO_VERSION),
+		transform.brightGreen("Evo.lua " .. runtime.version()),
 		transform.brightBlue(jit.version)
 	) .. "\n\n"
 

--- a/Runtime/main.cpp
+++ b/Runtime/main.cpp
@@ -42,7 +42,9 @@ int main(int argc, char* argv[]) {
 	luaVM->LoadPackage("utf8", luaopen_utf8);
 	luaVM->LoadPackage("zlib", luaopen_zlib);
 
-	// The embedded libraries are statically linked in, so we require some glue code to access them via FFI
+	// This package exports APIs for the embedded libraries; they're statically linked in and can't just use require
+	// Some glue code is needed to access them via FFI, but calls have lower overhead and they're easier to extend
+	luaVM->LoadPackage("bindings");
 	luaVM->BindStaticLibraryExports("crypto", crypto_ffi::getExportsTable());
 	luaVM->BindStaticLibraryExports("glfw", glfw_ffi::getExportsTable());
 	luaVM->BindStaticLibraryExports("iconv", iconv_ffi::getExportsTable());

--- a/Runtime/main.cpp
+++ b/Runtime/main.cpp
@@ -33,14 +33,14 @@ int main(int argc, char* argv[]) {
 	luaVM->SetGlobalArgs(argc, argv);
 
 	// luv sets up its metatables when initialized; deferring this may break some internals (not sure why)
-	luaVM->PreloadPackage("uv", luaopen_luv);
-	luaVM->PreloadPackage("lpeg", luaopen_lpeg);
-	luaVM->PreloadPackage("miniz", luaopen_miniz);
-	luaVM->PreloadPackage("openssl", luaopen_openssl);
-	luaVM->PreloadPackage("regex", luaopen_rex_pcre2);
-	luaVM->PreloadPackage("json", luaopen_rapidjson_modified);
-	luaVM->PreloadPackage("utf8", luaopen_utf8);
-	luaVM->PreloadPackage("zlib", luaopen_zlib);
+	luaVM->LoadPackage("uv", luaopen_luv);
+	luaVM->LoadPackage("lpeg", luaopen_lpeg);
+	luaVM->LoadPackage("miniz", luaopen_miniz);
+	luaVM->LoadPackage("openssl", luaopen_openssl);
+	luaVM->LoadPackage("regex", luaopen_rex_pcre2);
+	luaVM->LoadPackage("json", luaopen_rapidjson_modified);
+	luaVM->LoadPackage("utf8", luaopen_utf8);
+	luaVM->LoadPackage("zlib", luaopen_zlib);
 
 	// The embedded libraries are statically linked in, so we require some glue code to access them via FFI
 	luaVM->BindStaticLibraryExports("crypto", crypto_ffi::getExportsTable());

--- a/Runtime/main.cpp
+++ b/Runtime/main.cpp
@@ -60,7 +60,6 @@ int main(int argc, char* argv[]) {
 
 	// Some namespaces cannot be created from Lua because they store info only available in C++ land (like #defines)
 	luaVM->CreateGlobalNamespace("C_Runtime");
-	luaVM->AssignGlobalVariable("EVO_VERSION", "" EVO_VERSION "");
 
 	runtime_ffi::assignLuaState(luaVM->GetState());
 	rml_ffi::assignLuaState(luaVM->GetState());

--- a/Tests/BDD/globals.spec.lua
+++ b/Tests/BDD/globals.spec.lua
@@ -57,15 +57,4 @@ describe("_G", function()
 			assert(alias == target, globalName)
 		end)
 	end
-
-	it("should export important defines from the native entry point", function()
-		local runtimeVersionDefinedAtBuildTime = EVO_VERSION
-		-- Technically git describe adds more information in between releases, but it's still "semver-like" enough
-		assertEquals(type(runtimeVersionDefinedAtBuildTime), "string")
-
-		local expectedVersionStringPattern = "(v%d+%.%d+%.%d+.*)" --vMAJOR.MINOR.PATCH-optionalGitDescribeSuffix
-		local versionString = string.match(runtimeVersionDefinedAtBuildTime, expectedVersionStringPattern)
-
-		assertEquals(type(versionString), "string")
-	end)
 end)

--- a/Tests/BDD/runtime-library.spec.lua
+++ b/Tests/BDD/runtime-library.spec.lua
@@ -1,0 +1,19 @@
+local runtime = require("runtime")
+
+describe("runtime", function()
+	describe("version", function()
+		it("should export the EVO_VERSION define from the native entry point", function()
+			local runtimeVersionDefinedAtBuildTime, majorVersion, minorVersion, patchVersion = runtime.version()
+			-- Technically git describe adds more information in between releases, but it's still "semver-like" enough
+			assertEquals(type(runtimeVersionDefinedAtBuildTime), "string")
+
+			local expectedVersionStringPattern = "(v%d+%.%d+%.%d+.*)" --vMAJOR.MINOR.PATCH-optionalGitDescribeSuffix
+			local versionString = string.match(runtimeVersionDefinedAtBuildTime, expectedVersionStringPattern)
+
+			assertEquals(type(versionString), "string")
+			assertEquals(type(majorVersion), "number")
+			assertEquals(type(minorVersion), "number")
+			assertEquals(type(patchVersion), "number")
+		end)
+	end)
+end)

--- a/Tests/BDD/runtime-namespace.spec.lua
+++ b/Tests/BDD/runtime-namespace.spec.lua
@@ -1,4 +1,5 @@
 local console = require("console")
+local runtime = require("runtime")
 
 describe("C_Runtime", function()
 	-- Ideally there should be some high-level snapshot tests, but more plumbing is needed
@@ -56,7 +57,7 @@ describe("C_Runtime", function()
 
 			local SEMANTIC_VERSION_STRING_PATTERN = "(v(%d+)%.(%d+)%.(%d+).*)"
 			local versionString, expectedMajorVersion, expectedMinorVersion, expectedPatchVersion =
-				string.match(EVO_VERSION, SEMANTIC_VERSION_STRING_PATTERN)
+				string.match(runtime.version(), SEMANTIC_VERSION_STRING_PATTERN)
 			local displayedVersionString, displayedMajorVersion, displayedMinorVersion, displayedPatchVersion =
 				string.match(capturedOutput, SEMANTIC_VERSION_STRING_PATTERN)
 

--- a/Tests/smoke-test.lua
+++ b/Tests/smoke-test.lua
@@ -1,4 +1,5 @@
 local assertions = require("assertions")
+local bindings = require("bindings")
 local bdd = require("bdd")
 local inspect = require("inspect")
 local transform = require("transform")
@@ -46,7 +47,7 @@ local testCases = {
 		description = "The validation library should be preloaded",
 	},
 	{
-		actual = type(_G.STATIC_FFI_EXPORTS),
+		actual = type(bindings),
 		expected = "table",
 		description = "The static FFI bindings should be available",
 	},

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -18,6 +18,7 @@ local specFiles = {
 	"Tests/BDD/path-library.spec.lua",
 	"Tests/BDD/profiler-library.spec.lua",
 	"Tests/BDD/regex-library.spec.lua",
+	"Tests/BDD/runtime-library.spec.lua",
 	"Tests/BDD/rml-library.spec.lua",
 	"Tests/BDD/stbi-library.spec.lua",
 	"Tests/BDD/stduuid-library.spec.lua",

--- a/evo.yml
+++ b/evo.yml
@@ -1,9 +1,6 @@
 ---
 base: lua51
 globals:
-  EVO_VERSION:
-    any: true
-    property: read-only
   # API namespaces
   C_CommandLine:
     any: true


### PR DESCRIPTION
A tiny step closer towards separating the interpreter CLI and the runtime environment, which is currently just one module.

---

Resolves #57 (I think, anyway).