### PR TITLE
Add a new debug command to the interpreter CLI

### DIFF
--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -125,6 +125,10 @@ A list of supported profiling modes and their combinations can be found here: %s
 			transform.brightYellow("CTRL+C"),
 			transform.brightYellow("os.exit()")
 		),
+		DEBUG_COMMAND_USAGE_INFO = transform.bold("Usage: evo debug script.lua ..."),
+		EVENT_TRACING_NOTICE = transform.brightGreen(
+			"Event tracing is now enabled globally; all events should be recorded"
+		),
 	},
 }
 
@@ -229,6 +233,7 @@ function evo.setUpCommandLineInterface()
 	C_CommandLine.RegisterCommand("build", evo.buildZipApp, "Create a self-contained executable")
 	C_CommandLine.RegisterCommand("test", evo.discoverAndRunTests, "Run tests from files or directories")
 	C_CommandLine.RegisterCommand("profile", evo.runScriptWhileProfiling, "Enable LuaJIT's built-in CPU profiler")
+	C_CommandLine.RegisterCommand("debug", evo.runWhileTracing, "Run script with debug logging enabled")
 
 	C_CommandLine.SetAlias("help", "-h")
 	C_CommandLine.SetAlias("version", "-v")
@@ -236,6 +241,7 @@ function evo.setUpCommandLineInterface()
 	C_CommandLine.SetAlias("build", "-b")
 	C_CommandLine.SetAlias("test", "-t")
 	C_CommandLine.SetAlias("profile", "-p")
+	C_CommandLine.SetAlias("debug", "-d")
 
 	C_CommandLine.SetDefaultHandler(evo.onInvalidCommand)
 end
@@ -569,6 +575,23 @@ function evo.onInvalidCommand(command, argv)
 	end
 
 	evo.displayHelpText()
+end
+
+function evo.runWhileTracing(_, argv)
+	local scriptFilePath = argv[1]
+	if not scriptFilePath then
+		print(evo.messageStrings.DEBUG_COMMAND_USAGE_INFO)
+		os.exit(1, true)
+	end
+
+	etrace.isForceEnabled = true
+
+	local message = evo.messageStrings.EVENT_TRACING_NOTICE
+	local separator = string.rep("-", #message)
+	printf("%s\n%s", message, separator)
+
+	table.remove(argv, 1)
+	return evo.onInvalidCommand(scriptFilePath, argv)
 end
 
 return evo

--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -232,7 +232,7 @@ function evo.setUpCommandLineInterface()
 	C_CommandLine.RegisterCommand("eval", evo.evaluateChunk, "Evaluate expressions live or from input")
 	C_CommandLine.RegisterCommand("build", evo.buildZipApp, "Create a self-contained executable")
 	C_CommandLine.RegisterCommand("test", evo.discoverAndRunTests, "Run tests from files or directories")
-	C_CommandLine.RegisterCommand("profile", evo.runScriptWhileProfiling, "Enable LuaJIT's built-in CPU profiler")
+	C_CommandLine.RegisterCommand("profile", evo.runScriptWhileProfiling, "Run script with CPU profiling enabled")
 	C_CommandLine.RegisterCommand("debug", evo.runWhileTracing, "Run script with debug logging enabled")
 
 	C_CommandLine.SetAlias("help", "-h")

--- a/Tests/Fixtures/etrace-test.lua
+++ b/Tests/Fixtures/etrace-test.lua
@@ -1,0 +1,33 @@
+local etrace = require("etrace")
+
+etrace.register("SOME_EVENT")
+etrace.register("ANOTHER_EVENT")
+etrace.register("NO_PAYLOAD")
+
+etrace.record("SOME_EVENT", { 42 })
+etrace.record("ANOTHER_EVENT", { hello = "world" })
+etrace.record("NO_PAYLOAD")
+
+local events = {
+	{
+		name = "SOME_EVENT",
+		payload = { 42 },
+	},
+	{
+		name = "ANOTHER_EVENT",
+		payload = {
+			hello = "world",
+		},
+	},
+	{
+		name = "NO_PAYLOAD",
+		payload = {},
+	},
+}
+
+local generatedTraceLog = {}
+for index, event in ipairs(events) do
+	table.insert(generatedTraceLog, etrace.stringify(event.name, event.payload))
+end
+
+return table.concat(generatedTraceLog, "\n")

--- a/Tests/snapshot-test.lua
+++ b/Tests/snapshot-test.lua
@@ -351,6 +351,41 @@ local testCases = {
 			assertEquals(profilingResults, "[No samples collected]\n[No samples collected]\n")
 		end,
 	},
+	["cli-debug-events"] = {
+		humanReadableDescription = "Invoking the CLI debug command while passing a file that records events should display them",
+		programToRun = "evo debug Tests/Fixtures/etrace-test.lua",
+		onExit = function(observedOutput, status, terminationReason, exitCodeOrSignalID)
+			local separator = string.rep("-", #evo.messageStrings.EVENT_TRACING_NOTICE)
+			local expectedTraceLog = require("Tests.Fixtures.etrace-test")
+			local expectedOutput = evo.messageStrings.EVENT_TRACING_NOTICE
+				.. "\n"
+				.. separator
+				.. "\n"
+				.. expectedTraceLog
+				.. "\n"
+			assertEquals(observedOutput, expectedOutput)
+			assertExitSuccess(observedOutput, status, terminationReason, exitCodeOrSignalID)
+		end,
+	},
+	["cli-debug-no-events"] = {
+		humanReadableDescription = "Invoking the CLI debug command while passing a file that doesn't record events should not display event log entries",
+		programToRun = "evo debug Tests/Fixtures/empty.spec.lua",
+		onExit = function(observedOutput, status, terminationReason, exitCodeOrSignalID)
+			local separator = string.rep("-", #evo.messageStrings.EVENT_TRACING_NOTICE)
+			local expectedOutput = evo.messageStrings.EVENT_TRACING_NOTICE .. "\n" .. separator .. "\n"
+			assertEquals(observedOutput, expectedOutput)
+			assertExitSuccess(observedOutput, status, terminationReason, exitCodeOrSignalID)
+		end,
+	},
+	["cli-debug-noargs"] = {
+		humanReadableDescription = "Invoking the debug command without args should display a help text ",
+		programToRun = "evo debug",
+		onExit = function(observedOutput, status, terminationReason, exitCodeOrSignalID)
+			local expectedOutput = evo.messageStrings.DEBUG_COMMAND_USAGE_INFO .. "\n"
+			assertEquals(observedOutput, expectedOutput)
+			assertExitFailure(observedOutput, status, terminationReason, exitCodeOrSignalID)
+		end,
+	},
 }
 
 C_Runtime.RunSnapshotTests(testCases)


### PR DESCRIPTION
Currently, it only activates event logging (recording and a simple console output with stringified JSON payloads). More later.

Edit: Note that some parts aren't covered by additional unit tests since they're expected to see a redesign soon.

---

Resolves #313.