### PR TITLE
Remove an unused typedef for lua_CFunction from the LuaVirtualMachine header

### DIFF
--- a/Runtime/LuaVirtualMachine.hpp
+++ b/Runtime/LuaVirtualMachine.hpp
@@ -4,9 +4,6 @@
 #include <optional>
 #include <lua.hpp>
 
-// As per convention, any C function that creates a table with the library APIs and pushes it to the stack
-typedef int (*luaopen_function)(lua_State* L);
-
 class LuaVirtualMachine {
 public:
 	LuaVirtualMachine();


### PR DESCRIPTION
Looks like an oversight? At least it isn't used anywhere right now. Nor is it needed...