### PR TITLE
Add support for encoding cdata values (and other objects with a __tostring metamethod) to json.encode

### DIFF
--- a/Runtime/Bindings/rapidjson.hpp
+++ b/Runtime/Bindings/rapidjson.hpp
@@ -121,7 +121,17 @@ private:
 			}
 			[[fallthrough]];
 		default:
-			luaL_error(L, "unsupported value type : %s", lua_typename(L, t));
+			lua_pushvalue(L, idx);
+			lua_pushstring(L, "tostring");
+			lua_gettable(L, LUA_GLOBALSINDEX);
+			lua_pushvalue(L, -2);
+			lua_call(L, 1, 1);
+			const char* stringifiedValue = lua_tostring(L, -1);
+			if(stringifiedValue == nullptr) stringifiedValue = "nil";
+			lua_pop(L, 2);
+
+			lua_pushfstring(L, "Cannot encode value %s (only JSON-compatible primitive types are supported)", stringifiedValue);
+			lua_error(L);
 		}
 	}
 

--- a/Runtime/Bindings/rapidjson.hpp
+++ b/Runtime/Bindings/rapidjson.hpp
@@ -247,18 +247,11 @@ int luaopen_rapidjson(lua_State* L); // Declared here because there's no header 
 }
 
 static int json_encode_custom(lua_State* L) {
-	try {
-		CustomizedEncoder encode(L, 2);
-		StringBuffer s;
-		encode.encode(L, &s, 1);
-		lua_pushlstring(L, s.GetString(), s.GetSize());
-		return 1;
-	} catch(const std::exception& e) {
-		luaL_error(L, "error while encoding: %s", e.what());
-	} catch(...) {
-		luaL_error(L, "unknown error while encoding");
-	}
-	return 0;
+	CustomizedEncoder encode(L, 2);
+	StringBuffer s;
+	encode.encode(L, &s, 1);
+	lua_pushlstring(L, s.GetString(), s.GetSize());
+	return 1;
 }
 
 int json_get_version_string(lua_State* L) {

--- a/Tests/BDD/json-library.spec.lua
+++ b/Tests/BDD/json-library.spec.lua
@@ -1,5 +1,7 @@
+local ffi = require("ffi")
+local json = require("json")
+
 describe("json", function()
-	local json = require("json")
 	local exportedFunctions = {
 		"array",
 		"decode",
@@ -70,6 +72,11 @@ describe("json", function()
 				"Cannot encode value %s (only JSON-compatible primitive types are supported)",
 				tostring(print)
 			))
+		end)
+
+		it("should be able to stringify cdata values", function()
+			local cdata = ffi.new("uint32_t", 42)
+			assertEquals(json.stringify({ cdata = cdata }), '{"cdata":"' .. tostring(cdata) .. '"}')
 		end)
 	end)
 

--- a/Tests/BDD/json-library.spec.lua
+++ b/Tests/BDD/json-library.spec.lua
@@ -62,6 +62,15 @@ describe("json", function()
 		it("should be an alias of json.encode", function()
 			assertEquals(json.stringify, json.encode)
 		end)
+
+		it("should propagate encoding errors to the Lua environment", function()
+			assertThrows(function()
+				json.stringify(print)
+			end, format(
+				"Cannot encode value %s (only JSON-compatible primitive types are supported)",
+				tostring(print)
+			))
+		end)
 	end)
 
 	describe("pretty", function()


### PR DESCRIPTION
Resolves #499 - but doesn't cover all possible scenarios, i.e. the metamethod could be "accidentally" assigned (AKA misuse).