### PR TITLE
Add a new table.invert standard library extension

### DIFF
--- a/Runtime/Extensions/tablex.lua
+++ b/Runtime/Extensions/tablex.lua
@@ -66,5 +66,16 @@ function table.reverse(tableToReverse)
 	return reversedTable
 end
 
+function table.invert(tableToInvert)
+	validation.validateTable(tableToInvert, "tableToInvert")
+
+	local invertedTable = {}
+	for key, value in pairs(tableToInvert) do
+		invertedTable[value] = key
+	end
+
+	return invertedTable
+end
+
 table.clear = require("table.clear")
 table.new = require("table.new")

--- a/Tests/BDD/table-library.spec.lua
+++ b/Tests/BDD/table-library.spec.lua
@@ -139,4 +139,18 @@ describe("table", function()
 			assertEquals(table.reverse(input), expectedOutput)
 		end)
 	end)
+
+	describe("invert", function()
+		it("should throw if a non-table value was passed", function()
+			assertThrows(function()
+				table.invert(42)
+			end, "Expected argument tableToInvert to be a table value, but received a number value instead")
+		end)
+
+		it("should return a copy of the table with the keys and values swapped", function()
+			local input = { "A", "B", "C" }
+			local expectedOutput = { A = 1, B = 2, C = 3 }
+			assertEquals(table.invert(input), expectedOutput)
+		end)
+	end)
 end)


### PR DESCRIPTION
Mostly useful for Lua enums. Low cost, moderate benefit = OK to add, I guess.