### PR TITLE
Replace the Lua implementation of stbi.replace_pixel_color_rgba with a C++ version

### DIFF
--- a/Benchmarks/stbi-color-replacement.lua
+++ b/Benchmarks/stbi-color-replacement.lua
@@ -1,0 +1,73 @@
+local console = require("console")
+local ffi = require("ffi")
+local stbi = require("stbi")
+
+local FIXTURES_DIR = path.join("Tests", "Fixtures")
+
+local SAMPLE_SIZE = 50000000
+
+function stbi.replace_pixel_color_rgba(image, sourceColor, replacementColor)
+	local pixelCount = image.width * image.height
+	local pixelBuffer = ffi.cast("stbi_color_t*", image.data)
+
+	for i = 0, pixelCount - 1 do
+		local pixel = pixelBuffer[i]
+
+		if
+			pixel.red == sourceColor.red
+			and pixel.green == sourceColor.green
+			and pixel.blue == sourceColor.blue
+			and pixel.alpha == sourceColor.alpha
+		then
+			pixelBuffer[i] = replacementColor
+		end
+	end
+end
+
+local image = ffi.new("stbi_image_t")
+local originalBitmapContents = C_FileSystem.ReadFile(path.join(FIXTURES_DIR, "8bpp-image-without-alpha.bmp"))
+stbi.bindings.stbi_load_rgba(originalBitmapContents, #originalBitmapContents, image)
+
+local sourceColor = ffi.new("stbi_color_t", { 0, 0, 255, 255 })
+local replacementColor = ffi.new("stbi_color_t", { 255, 0, 0, 255 })
+
+local function replacePixelColorsLua()
+	stbi.replace_pixel_color_rgba(image, sourceColor, replacementColor)
+end
+
+local function replacePixelColorsFFI()
+	stbi.bindings.stbi_replace_pixel_color_rgba(image, sourceColor, replacementColor)
+end
+
+math.randomseed(os.clock())
+local availableBenchmarks = {
+	function()
+		local label = "[FFI] Replace pixel colors"
+		console.startTimer(label)
+		for i = 1, SAMPLE_SIZE, 1 do
+			replacePixelColorsFFI()
+		end
+		console.stopTimer(label)
+	end,
+	function()
+		local label = "[Lua] Replace pixel colors"
+		console.startTimer(label)
+		for i = 1, SAMPLE_SIZE, 1 do
+			replacePixelColorsLua()
+		end
+		console.stopTimer(label)
+	end,
+}
+
+local function shuffle(tbl)
+	for i = #tbl, 2, -1 do
+		local j = math.random(i)
+		tbl[i], tbl[j] = tbl[j], tbl[i]
+	end
+end
+
+shuffle(availableBenchmarks)
+
+for _, benchmark in ipairs(availableBenchmarks) do
+	benchmark()
+end

--- a/Runtime/Bindings/FFI/stbi/stbi.lua
+++ b/Runtime/Bindings/FFI/stbi/stbi.lua
@@ -74,6 +74,7 @@ struct static_stbi_exports_table {
 	size_t (*stbi_get_required_tga_size)(stbi_image_t* image);
 
 	void (*stbi_abgr_to_rgba)(stbi_image_t* image);
+	void (*stbi_replace_pixel_color_rgba)(stbi_image_t* image, const stbi_color_t* source_color, const stbi_color_t* replacement_color);
 };
 
 ]]
@@ -84,24 +85,6 @@ end
 
 function stbi.version()
 	return ffi.string(stbi.bindings.stbi_version())
-end
-
-function stbi.replace_pixel_color_rgba(image, sourceColor, replacementColor)
-	local pixelCount = image.width * image.height
-	local pixelBuffer = ffi.cast("stbi_color_t*", image.data)
-
-	for i = 0, pixelCount - 1 do
-		local pixel = pixelBuffer[i]
-
-		if
-			pixel.red == sourceColor.red
-			and pixel.green == sourceColor.green
-			and pixel.blue == sourceColor.blue
-			and pixel.alpha == sourceColor.alpha
-		then
-			pixelBuffer[i] = replacementColor
-		end
-	end
 end
 
 return stbi

--- a/Runtime/Bindings/FFI/stbi/stbi_exports.h
+++ b/Runtime/Bindings/FFI/stbi/stbi_exports.h
@@ -55,4 +55,5 @@ struct static_stbi_exports_table {
 	size_t (*stbi_get_required_tga_size)(stbi_image_t* image);
 
 	void (*stbi_abgr_to_rgba)(stbi_image_t* image);
+	void (*stbi_replace_pixel_color_rgba)(stbi_image_t* image, const stbi_color_t* source_color, const stbi_color_t* replacement_color);
 };

--- a/Runtime/Bindings/FFI/stbi/stbi_ffi.cpp
+++ b/Runtime/Bindings/FFI/stbi/stbi_ffi.cpp
@@ -200,6 +200,25 @@ void stbi_abgr_to_rgba(stbi_image_t* image) {
 	}
 }
 
+void stbi_replace_pixel_color_rgba(stbi_image_t* image, const stbi_color_t* source_color, const stbi_color_t* replacement_color) {
+	if(!image) return;
+	if(!image->data) return;
+
+	size_t pixelCount
+		= static_cast<size_t>(image->width) * static_cast<size_t>(image->height);
+	stbi_color_t* pixelBuffer = reinterpret_cast<stbi_color_t*>(image->data);
+
+	for(size_t index = 0; index < pixelCount; ++index) {
+		stbi_color_t* pixel = &pixelBuffer[index];
+
+		bool shouldReplacePixel = pixel->red == source_color->red && pixel->green == source_color->green && pixel->blue == source_color->blue && pixel->alpha == source_color->alpha;
+
+		if(shouldReplacePixel) {
+			*pixel = *replacement_color;
+		}
+	}
+}
+
 namespace stbi_ffi {
 
 	void* getExportsTable() {
@@ -229,6 +248,7 @@ namespace stbi_ffi {
 		stbi_exports_table.stbi_get_required_tga_size = stbi_get_required_tga_size;
 
 		stbi_exports_table.stbi_abgr_to_rgba = stbi_abgr_to_rgba;
+		stbi_exports_table.stbi_replace_pixel_color_rgba = stbi_replace_pixel_color_rgba;
 
 		return &stbi_exports_table;
 	}

--- a/Tests/BDD/stbi-library.spec.lua
+++ b/Tests/BDD/stbi-library.spec.lua
@@ -864,50 +864,50 @@ describe("stbi", function()
 				assertEquals(image.data[7], 8)
 			end)
 		end)
-	end)
 
-	describe("replace_pixel_color_rgba", function()
-		it("should replace all pixels of the given color", function()
-			local image = ffi.new("stbi_image_t")
-			local originalBitmapContents =
-				C_FileSystem.ReadFile(path.join(FIXTURES_DIR, "8bpp-image-without-alpha.bmp"))
-			stbi.bindings.stbi_load_rgba(originalBitmapContents, #originalBitmapContents, image)
+		describe("replace_pixel_color_rgba", function()
+			it("should replace all pixels of the given color", function()
+				local image = ffi.new("stbi_image_t")
+				local originalBitmapContents =
+					C_FileSystem.ReadFile(path.join(FIXTURES_DIR, "8bpp-image-without-alpha.bmp"))
+				stbi.bindings.stbi_load_rgba(originalBitmapContents, #originalBitmapContents, image)
 
-			local sourceColor = ffi.new("stbi_color_t", { 0, 0, 255, 255 })
-			local replacementColor = ffi.new("stbi_color_t", { 255, 0, 0, 255 })
-			stbi.replace_pixel_color_rgba(image, sourceColor, replacementColor)
+				local sourceColor = ffi.new("stbi_color_t", { 0, 0, 255, 255 })
+				local replacementColor = ffi.new("stbi_color_t", { 255, 0, 0, 255 })
+				stbi.bindings.stbi_replace_pixel_color_rgba(image, sourceColor, replacementColor)
 
-			local expectedPixels = {
-				255,
-				0,
-				0,
-				255,
-				255,
-				0,
-				0,
-				255,
-				255,
-				0,
-				0,
-				255,
-				255,
-				0,
-				0,
-				255,
-				255,
-				0,
-				0,
-				255,
-				255,
-				0,
-				0,
-				255,
-			}
+				local expectedPixels = {
+					255,
+					0,
+					0,
+					255,
+					255,
+					0,
+					0,
+					255,
+					255,
+					0,
+					0,
+					255,
+					255,
+					0,
+					0,
+					255,
+					255,
+					0,
+					0,
+					255,
+					255,
+					0,
+					0,
+					255,
+				}
 
-			local BYTES_PER_PIXEL = 4 -- RGBA
-			for i = 0, image.width * image.height * BYTES_PER_PIXEL - 1 do
-				assertEquals(image.data[i], expectedPixels[i + 1])
-			end
+				local BYTES_PER_PIXEL = 4 -- RGBA
+				for i = 0, image.width * image.height * BYTES_PER_PIXEL - 1 do
+					assertEquals(image.data[i], expectedPixels[i + 1])
+				end
+			end)
 		end)
 	end)
 


### PR DESCRIPTION
Same thing, but significantly faster. Probably not all that relevant, but there's no reason to not take the easy win here.