### PR TITLE
Disable the static analysis workflow for changelog updates

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,7 +3,9 @@ name: Static Analysis
 on:
   pull_request:
     paths-ignore:
-      - "README.MD"
+      - '**.md'
+      - 'changelog.lua'
+      - '.gitignore'
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:


### PR DESCRIPTION
The ignored paths should apply to all triggers, not just pushes to main, which can only happen after the CI has already run.