### PR TITLE
Add validation for all static exports tables

### DIFF
--- a/Runtime/Bindings/FFI/wgpu/wgpu_ffi.cpp
+++ b/Runtime/Bindings/FFI/wgpu/wgpu_ffi.cpp
@@ -51,6 +51,7 @@ namespace wgpu_ffi {
 		// CommandBuffer
 		wgpu_exports_table.wgpu_command_buffer_reference = wgpuCommandBufferReference;
 		wgpu_exports_table.wgpu_command_buffer_release = wgpuCommandBufferRelease;
+		wgpu_exports_table.wgpu_command_buffer_set_label = wgpuCommandBufferSetLabel;
 
 		// CommandEncoder
 		wgpu_exports_table.wgpu_command_encoder_begin_compute_pass = wgpuCommandEncoderBeginComputePass;

--- a/Runtime/Libraries/validation.lua
+++ b/Runtime/Libraries/validation.lua
@@ -1,3 +1,5 @@
+local ffi = require("ffi")
+
 local error = error
 local format = string.format
 local type = type
@@ -104,6 +106,19 @@ function validation.validateStruct(value, name)
 			0
 		)
 	end
+end
+
+function validation.validateExportsTable(exportsTable, cType)
+	local numExportedFunctions = ffi.sizeof(cType) / ffi.sizeof("void*")
+	local functionPointer = ffi.cast("void**", exportsTable)
+
+	for index = 0, numExportedFunctions - 1, 1 do
+		if functionPointer[index] == ffi.NULL then
+			return nil, index
+		end
+	end
+
+	return true, numExportedFunctions
 end
 
 return validation


### PR DESCRIPTION
This is a basic sanity check to detect missing bindings on load. In fact, it immediately found one function that I forgot to assign.