### PR TITLE
Enable automatic version discovery for the stduuid library

### DIFF
--- a/BuildTools/BuildTarget.lua
+++ b/BuildTools/BuildTarget.lua
@@ -159,6 +159,10 @@ function BuildTarget:GetDefines()
 	local labsoundVersionString = string.match(labsoundVersionTag, "(%d+.%d+.%d+)")
 	defines = defines .. string.format(' -DLABSOUND_VERSION=\\"%s\\"', labsoundVersionString)
 
+	local stduuidVersionTag = discoveredLibraryVersions["deps/mariusbancila/stduuid"].tag
+	local stduuidVersionString = string.match(stduuidVersionTag, "(%d+.%d+.%d+)")
+	defines = defines .. string.format(' -DSTDUUID_VERSION=\\"%s\\"', stduuidVersionString)
+
 	return defines
 end
 

--- a/Runtime/Bindings/FFI/stduuid/stduuid.lua
+++ b/Runtime/Bindings/FFI/stduuid/stduuid.lua
@@ -8,6 +8,7 @@ stduuid.cdefs = [[
 typedef char uuid_rfc_string_t[37];
 
 struct static_stduuid_exports_table {
+	const char* (*stduuid_version)(void);
 	bool (*uuid_create_v4)(uuid_rfc_string_t* result);
 	bool (*uuid_create_mt19937)(uuid_rfc_string_t* result);
 	bool (*uuid_create_v5)(const char* namespace_uuid_str, const char* name, uuid_rfc_string_t* result);
@@ -21,8 +22,7 @@ function stduuid.initialize()
 end
 
 function stduuid.version()
-	-- Hardcoded because of laziness (may automate tag discovery later)
-	return "1.2.3"
+	return ffi.string(stduuid.bindings.stduuid_version())
 end
 
 return stduuid

--- a/Runtime/Bindings/FFI/stduuid/stduuid_exports.h
+++ b/Runtime/Bindings/FFI/stduuid/stduuid_exports.h
@@ -2,6 +2,7 @@
 typedef char uuid_rfc_string_t[37];
 
 struct static_stduuid_exports_table {
+	const char* (*stduuid_version)(void);
 	bool (*uuid_create_v4)(uuid_rfc_string_t* result);
 	bool (*uuid_create_mt19937)(uuid_rfc_string_t* result);
 	bool (*uuid_create_v5)(const char* namespace_uuid_str, const char* name, uuid_rfc_string_t* result);

--- a/Runtime/Bindings/FFI/stduuid/stduuid_ffi.cpp
+++ b/Runtime/Bindings/FFI/stduuid/stduuid_ffi.cpp
@@ -81,9 +81,14 @@ bool uuid_create_system(uuid_rfc_string_t* result) {
 
 namespace stduuid_ffi {
 
+	const char* stduuid_version() {
+		return STDUUID_VERSION;
+	}
+
 	void* getExportsTable() {
 		static struct static_stduuid_exports_table stduuid_exports_table;
 
+		stduuid_exports_table.stduuid_version = stduuid_version;
 		stduuid_exports_table.uuid_create_v4 = uuid_create_v4;
 		stduuid_exports_table.uuid_create_mt19937 = uuid_create_mt19937;
 		stduuid_exports_table.uuid_create_v5 = uuid_create_v5;


### PR DESCRIPTION
No need to hardcode it now that all versions are discovered automatically.

---

Resolves #194.