### PR TITLE
Streamline the static exports table creation using C++ initializers

### DIFF
--- a/Runtime/Bindings/FFI/cpp/cpp_ffi.cpp
+++ b/Runtime/Bindings/FFI/cpp/cpp_ffi.cpp
@@ -7,13 +7,13 @@ namespace cpp_ffi {
 	}
 
 	void* getExportsTable() {
-		static struct static_cpp_exports_table exports_table;
+		static struct static_cpp_exports_table exports = {
+			.bit_ceil = &std::bit_ceil,
+			.bit_floor = &std::bit_floor,
+			.bit_width = &std_bit_width,
+			.has_single_bit = &std::has_single_bit,
+		};
 
-		exports_table.bit_ceil = &std::bit_ceil;
-		exports_table.bit_floor = &std::bit_floor;
-		exports_table.bit_width = &std_bit_width;
-		exports_table.has_single_bit = &std::has_single_bit;
-
-		return &exports_table;
+		return &exports;
 	}
 }

--- a/Runtime/Bindings/FFI/crypto/crypto_ffi.cpp
+++ b/Runtime/Bindings/FFI/crypto/crypto_ffi.cpp
@@ -106,19 +106,19 @@ fail:
 namespace crypto_ffi {
 
 	void* getExportsTable() {
-		static struct static_crypto_exports_table exports_table;
+		static struct static_crypto_exports_table exports = {
+			.version_text = &getVersionText,
+			.version_number = &getVersionNumber,
 
-		exports_table.version_text = &getVersionText;
-		exports_table.version_number = &getVersionNumber;
+			.openssl_to_base64 = &openssl_to_base64,
+			.openssl_from_base64 = &openssl_from_base64,
+			.argon2_to_base64 = &argon2_to_base64,
+			.argon2_from_base64 = &argon2_from_base64,
+			.openssl_kdf_derive = &openssl_kdf_derive,
+			.openssl_crypto_memcmp = &CRYPTO_memcmp,
+		};
 
-		exports_table.openssl_to_base64 = &openssl_to_base64;
-		exports_table.openssl_from_base64 = &openssl_from_base64;
-		exports_table.argon2_to_base64 = &argon2_to_base64;
-		exports_table.argon2_from_base64 = &argon2_from_base64;
-		exports_table.openssl_kdf_derive = &openssl_kdf_derive;
-		exports_table.openssl_crypto_memcmp = &CRYPTO_memcmp;
-
-		return &exports_table;
+		return &exports;
 	}
 
 	const char* getVersionText() {

--- a/Runtime/Bindings/FFI/glfw/glfw_ffi.cpp
+++ b/Runtime/Bindings/FFI/glfw/glfw_ffi.cpp
@@ -225,48 +225,48 @@ void glfw_set_character_input_callback(GLFWwindow* window, std::queue<deferred_e
 namespace glfw_ffi {
 
 	void* getExportsTable() {
-		static struct static_glfw_exports_table glfw_exports_table;
+		static struct static_glfw_exports_table exports;
 
-		glfw_exports_table.glfw_version = glfw_version;
-		glfw_exports_table.glfw_find_constant = glfw_find_constant;
+		exports.glfw_version = glfw_version;
+		exports.glfw_find_constant = glfw_find_constant;
 
-		glfw_exports_table.glfw_get_wgpu_surface = glfwGetWGPUSurface;
+		exports.glfw_get_wgpu_surface = glfwGetWGPUSurface;
 
-		glfw_exports_table.glfw_init = glfwInit;
-		glfw_exports_table.glfw_terminate = glfwTerminate;
-		glfw_exports_table.glfw_poll_events = glfwPollEvents;
+		exports.glfw_init = glfwInit;
+		exports.glfw_terminate = glfwTerminate;
+		exports.glfw_poll_events = glfwPollEvents;
 
-		glfw_exports_table.glfw_create_window = glfwCreateWindow;
-		glfw_exports_table.glfw_destroy_window = glfwDestroyWindow;
-		glfw_exports_table.glfw_window_should_close = glfwWindowShouldClose;
-		glfw_exports_table.glfw_window_hint = glfwWindowHint;
-		glfw_exports_table.glfw_set_window_pos = glfwSetWindowPos;
-		glfw_exports_table.glfw_get_framebuffer_size = glfwGetFramebufferSize;
-		glfw_exports_table.glfw_get_window_size = glfwGetWindowSize;
-		glfw_exports_table.glfw_maximize_window = glfwMaximizeWindow;
-		glfw_exports_table.glfw_restore_window = glfwRestoreWindow;
-		glfw_exports_table.glfw_hide_window = glfwHideWindow;
-		glfw_exports_table.glfw_show_window = glfwShowWindow;
-		glfw_exports_table.glfw_get_window_attrib = glfwGetWindowAttrib;
-		glfw_exports_table.glfw_set_window_icon = glfwSetWindowIcon;
+		exports.glfw_create_window = glfwCreateWindow;
+		exports.glfw_destroy_window = glfwDestroyWindow;
+		exports.glfw_window_should_close = glfwWindowShouldClose;
+		exports.glfw_window_hint = glfwWindowHint;
+		exports.glfw_set_window_pos = glfwSetWindowPos;
+		exports.glfw_get_framebuffer_size = glfwGetFramebufferSize;
+		exports.glfw_get_window_size = glfwGetWindowSize;
+		exports.glfw_maximize_window = glfwMaximizeWindow;
+		exports.glfw_restore_window = glfwRestoreWindow;
+		exports.glfw_hide_window = glfwHideWindow;
+		exports.glfw_show_window = glfwShowWindow;
+		exports.glfw_get_window_attrib = glfwGetWindowAttrib;
+		exports.glfw_set_window_icon = glfwSetWindowIcon;
 
-		glfw_exports_table.glfw_register_events = glfw_register_events;
+		exports.glfw_register_events = glfw_register_events;
 
-		glfw_exports_table.glfw_get_primary_monitor = glfwGetPrimaryMonitor;
-		glfw_exports_table.glfw_get_monitors = glfwGetMonitors;
-		glfw_exports_table.glfw_get_window_monitor = glfwGetWindowMonitor;
-		glfw_exports_table.glfw_set_window_monitor = glfwSetWindowMonitor;
-		glfw_exports_table.glfw_get_video_mode = glfwGetVideoMode;
+		exports.glfw_get_primary_monitor = glfwGetPrimaryMonitor;
+		exports.glfw_get_monitors = glfwGetMonitors;
+		exports.glfw_get_window_monitor = glfwGetWindowMonitor;
+		exports.glfw_set_window_monitor = glfwSetWindowMonitor;
+		exports.glfw_get_video_mode = glfwGetVideoMode;
 
-		glfw_exports_table.glfw_get_cursor_pos = glfwGetCursorPos;
-		glfw_exports_table.glfw_create_cursor = glfwCreateCursor;
-		glfw_exports_table.glfw_set_cursor = glfwSetCursor;
-		glfw_exports_table.glfw_destroy_cursor = glfwDestroyCursor;
+		exports.glfw_get_cursor_pos = glfwGetCursorPos;
+		exports.glfw_create_cursor = glfwCreateCursor;
+		exports.glfw_set_cursor = glfwSetCursor;
+		exports.glfw_destroy_cursor = glfwDestroyCursor;
 
-		glfw_exports_table.glfw_get_key = glfwGetKey;
-		glfw_exports_table.glfw_get_mouse_button = glfwGetMouseButton;
+		exports.glfw_get_key = glfwGetKey;
+		exports.glfw_get_mouse_button = glfwGetMouseButton;
 
-		return &glfw_exports_table;
+		return &exports;
 	}
 
 }

--- a/Runtime/Bindings/FFI/iconv/iconv_ffi.cpp
+++ b/Runtime/Bindings/FFI/iconv/iconv_ffi.cpp
@@ -48,11 +48,11 @@ iconv_result_t iconv_convert(char* input, size_t input_length, const char* input
 namespace iconv_ffi {
 
 	void* getExportsTable() {
-		static struct static_iconv_exports_table exports_table;
+		static struct static_iconv_exports_table exports = {
+			.iconv_convert = &iconv_convert,
+		};
 
-		exports_table.iconv_convert = &iconv_convert;
-
-		return &exports_table;
+		return &exports;
 	}
 
 }

--- a/Runtime/Bindings/FFI/interop/interop_ffi.cpp
+++ b/Runtime/Bindings/FFI/interop/interop_ffi.cpp
@@ -43,15 +43,15 @@ void queue_destroy(std::queue<deferred_event_t>* queue) {
 namespace interop_ffi {
 
 	void* getExportsTable() {
-		static struct static_interop_exports_table exports_table;
+		static struct static_interop_exports_table exports = {
+			.queue_create = &queue_create,
+			.queue_size = &queue_size,
+			.queue_push_event = &queue_push_event,
+			.queue_pop_event = &queue_pop_event,
+			.queue_destroy = &queue_destroy,
+		};
 
-		exports_table.queue_create = &queue_create;
-		exports_table.queue_destroy = &queue_destroy;
-		exports_table.queue_size = &queue_size;
-		exports_table.queue_push_event = &queue_push_event;
-		exports_table.queue_pop_event = &queue_pop_event;
-
-		return &exports_table;
+		return &exports;
 	}
 
 }

--- a/Runtime/Bindings/FFI/labsound/labsound_ffi.cpp
+++ b/Runtime/Bindings/FFI/labsound/labsound_ffi.cpp
@@ -394,64 +394,64 @@ void labsound_print_graph(labsound_audio_node_t root_node) {
 namespace labsound_ffi {
 
 	void* getExportsTable() {
-		static struct static_labsound_exports_table exports_table;
+		static struct static_labsound_exports_table exports = {
 
-		exports_table.labsound_version = &labsound_version;
+			.labsound_version = &labsound_version,
 
-		// AudioDevice
-		exports_table.labsound_get_device_count = &labsound_get_device_count;
-		exports_table.labsound_get_device_info = &labsound_get_device_info;
-		exports_table.labsound_get_default_device_config = &labsound_get_default_device_config;
-		exports_table.labsound_device_create = &labsound_device_create;
-		exports_table.labsound_device_destroy = &labsound_device_destroy;
+			// AudioDevice
+			.labsound_get_device_count = &labsound_get_device_count,
+			.labsound_get_device_info = &labsound_get_device_info,
+			.labsound_get_default_device_config = &labsound_get_default_device_config,
+			.labsound_device_create = &labsound_device_create,
+			.labsound_device_destroy = &labsound_device_destroy,
 
-		// AudioContext
-		exports_table.labsound_context_create = &labsound_context_create;
-		exports_table.labsound_context_destroy = &labsound_context_destroy;
-		exports_table.labsound_context_connect = &labsound_context_connect;
-		exports_table.labsound_context_disconnect = &labsound_context_disconnect;
-		exports_table.labsound_context_load_hrtf_database = &labsound_context_load_hrtf_database;
-		exports_table.labsound_context_listener_set_forward = &labsound_context_listener_set_forward;
-		exports_table.labsound_context_listener_set_up_vector = &labsound_context_listener_set_up_vector;
-		exports_table.labsound_context_listener_set_position = &labsound_context_listener_set_position;
-		exports_table.labsound_context_listener_set_velocity = &labsound_context_listener_set_velocity;
-		exports_table.labsound_context_synchronize_connections = &labsound_context_synchronize_connections;
+			// AudioContext
+			.labsound_context_create = &labsound_context_create,
+			.labsound_context_destroy = &labsound_context_destroy,
+			.labsound_context_connect = &labsound_context_connect,
+			.labsound_context_disconnect = &labsound_context_disconnect,
+			.labsound_context_load_hrtf_database = &labsound_context_load_hrtf_database,
+			.labsound_context_listener_set_forward = &labsound_context_listener_set_forward,
+			.labsound_context_listener_set_up_vector = &labsound_context_listener_set_up_vector,
+			.labsound_context_listener_set_position = &labsound_context_listener_set_position,
+			.labsound_context_listener_set_velocity = &labsound_context_listener_set_velocity,
+			.labsound_context_synchronize_connections = &labsound_context_synchronize_connections,
 
-		// AudioDestinationNode
-		exports_table.labsound_destination_node_create = &labsound_destination_node_create;
-		exports_table.labsound_destination_node_destroy = &labsound_destination_node_destroy;
+			// AudioDestinationNode
+			.labsound_destination_node_create = &labsound_destination_node_create,
+			.labsound_destination_node_destroy = &labsound_destination_node_destroy,
 
-		// GainNode
-		exports_table.labsound_gain_node_create = &labsound_gain_node_create;
-		exports_table.labsound_gain_node_destroy = &labsound_gain_node_destroy;
-		exports_table.labsound_gain_node_set_value = &labsound_gain_node_set_value;
+			// GainNode
+			.labsound_gain_node_create = &labsound_gain_node_create,
+			.labsound_gain_node_destroy = &labsound_gain_node_destroy,
+			.labsound_gain_node_set_value = &labsound_gain_node_set_value,
 
-		// PannerNode
-		exports_table.labsound_panner_node_create = &labsound_panner_node_create;
-		exports_table.labsound_panner_node_destroy = &labsound_panner_node_destroy;
-		exports_table.labsound_panner_node_set_panning_model = &labsound_panner_node_set_panning_model;
-		exports_table.labsound_panner_node_set_velocity = &labsound_panner_node_set_velocity;
-		exports_table.labsound_panner_node_set_position = &labsound_panner_node_set_position;
-		exports_table.labsound_panner_node_set_orientation = &labsound_panner_node_set_orientation;
-		exports_table.labsound_panner_node_set_distance_model = &labsound_panner_node_set_distance_model;
-		exports_table.labsound_panner_node_set_ref_distance = &labsound_panner_node_set_ref_distance;
-		exports_table.labsound_panner_node_set_max_distance = &labsound_panner_node_set_max_distance;
-		exports_table.labsound_panner_node_set_rolloff_factor = &labsound_panner_node_set_rolloff_factor;
-		exports_table.labsound_panner_node_set_cone_inner_angle = &labsound_panner_node_set_cone_inner_angle;
-		exports_table.labsound_panner_node_set_cone_outer_angle = &labsound_panner_node_set_cone_outer_angle;
-		exports_table.labsound_panner_node_set_cone_outer_gain = &labsound_panner_node_set_cone_outer_gain;
+			// PannerNode
+			.labsound_panner_node_create = &labsound_panner_node_create,
+			.labsound_panner_node_destroy = &labsound_panner_node_destroy,
+			.labsound_panner_node_set_velocity = &labsound_panner_node_set_velocity,
+			.labsound_panner_node_set_position = &labsound_panner_node_set_position,
+			.labsound_panner_node_set_orientation = &labsound_panner_node_set_orientation,
+			.labsound_panner_node_set_panning_model = &labsound_panner_node_set_panning_model,
+			.labsound_panner_node_set_distance_model = &labsound_panner_node_set_distance_model,
+			.labsound_panner_node_set_ref_distance = &labsound_panner_node_set_ref_distance,
+			.labsound_panner_node_set_max_distance = &labsound_panner_node_set_max_distance,
+			.labsound_panner_node_set_rolloff_factor = &labsound_panner_node_set_rolloff_factor,
+			.labsound_panner_node_set_cone_inner_angle = &labsound_panner_node_set_cone_inner_angle,
+			.labsound_panner_node_set_cone_outer_angle = &labsound_panner_node_set_cone_outer_angle,
+			.labsound_panner_node_set_cone_outer_gain = &labsound_panner_node_set_cone_outer_gain,
 
-		// SampledAudioNode
-		exports_table.labsound_sampled_audio_node_from_file = &labsound_sampled_audio_node_from_file;
-		exports_table.labsound_sampled_audio_node_from_memory = &labsound_sampled_audio_node_from_memory;
-		exports_table.labsound_sampled_audio_node_destroy = &labsound_sampled_audio_node_destroy;
-		exports_table.labsound_sampled_audio_node_start = &labsound_sampled_audio_node_start;
-		exports_table.labsound_sampled_audio_node_stop = &labsound_sampled_audio_node_stop;
+			// SampledAudioNode
+			.labsound_sampled_audio_node_from_file = &labsound_sampled_audio_node_from_file,
+			.labsound_sampled_audio_node_from_memory = &labsound_sampled_audio_node_from_memory,
+			.labsound_sampled_audio_node_destroy = &labsound_sampled_audio_node_destroy,
+			.labsound_sampled_audio_node_start = &labsound_sampled_audio_node_start,
+			.labsound_sampled_audio_node_stop = &labsound_sampled_audio_node_stop,
 
-		exports_table.labsound_print_graph = &labsound_print_graph;
-		exports_table.labsound_log_set_quiet = &log_set_quiet;
+			.labsound_log_set_quiet = &log_set_quiet,
+			.labsound_print_graph = &labsound_print_graph,
+		};
 
-		return &exports_table;
+		return &exports;
 	}
-
 }

--- a/Runtime/Bindings/FFI/rml/rml_ffi.cpp
+++ b/Runtime/Bindings/FFI/rml/rml_ffi.cpp
@@ -188,35 +188,45 @@ namespace rml_ffi {
 	}
 
 	void* getExportsTable() {
-		static struct static_rml_exports_table exports_table;
+		static struct static_rml_exports_table exports = {
+			.rml_version = &rml_version,
+			.rml_initialise = &rml_initialise,
+			.rml_shutdown = &rml_shutdown,
 
-		exports_table.rml_version = &rml_version;
-		exports_table.rml_initialise = &rml_initialise;
-		exports_table.rml_shutdown = &rml_shutdown;
-		exports_table.rml_create_glfw_system_interface = &rml_create_glfw_system_interface;
-		exports_table.rml_destroy_glfw_system_interface = &rml_destroy_glfw_system_interface;
-		exports_table.rml_create_wgpu_render_interface = &rml_create_wgpu_render_interface;
-		exports_table.rml_destroy_wgpu_render_interface = &rml_destroy_wgpu_render_interface;
-		exports_table.rml_release_compiled_geometry = &rml_release_compiled_geometry;
-		exports_table.rml_set_system_interface = &rml_set_system_interface;
-		exports_table.rml_set_render_interface = &rml_set_render_interface;
-		exports_table.rml_context_create = &rml_context_create;
-		exports_table.rml_context_load_document = &rml_context_load_document;
-		exports_table.rml_document_show = &rml_document_show;
-		exports_table.rml_context_update = &rml_context_update;
-		exports_table.rml_context_render = &rml_context_render;
-		exports_table.rml_context_remove = &rml_context_remove;
-		exports_table.rml_load_font_face = &rml_load_font_face;
-		exports_table.rml_process_key_callback = &rml_process_key_callback;
-		exports_table.rml_process_char_callback = &rml_process_char_callback;
-		exports_table.rml_process_cursor_enter_callback = &rml_process_cursor_enter_callback;
-		exports_table.rml_process_cursor_pos_callback = &rml_process_cursor_pos_callback;
-		exports_table.rml_process_mouse_button_callback = &rml_process_mouse_button_callback;
-		exports_table.rml_process_scroll_callback = &rml_process_scroll_callback;
-		exports_table.rml_process_framebuffer_size_callback = &rml_process_framebuffer_size_callback;
-		exports_table.rml_process_content_scale_callback = &rml_process_content_scale_callback;
+			// GLFW integration
+			.rml_create_glfw_system_interface = &rml_create_glfw_system_interface,
+			.rml_destroy_glfw_system_interface = &rml_destroy_glfw_system_interface,
+			.rml_set_system_interface = &rml_set_system_interface,
+			.rml_process_key_callback = &rml_process_key_callback,
+			.rml_process_char_callback = &rml_process_char_callback,
+			.rml_process_cursor_enter_callback = &rml_process_cursor_enter_callback,
+			.rml_process_cursor_pos_callback = &rml_process_cursor_pos_callback,
+			.rml_process_mouse_button_callback = &rml_process_mouse_button_callback,
+			.rml_process_scroll_callback = &rml_process_scroll_callback,
+			.rml_process_framebuffer_size_callback = &rml_process_framebuffer_size_callback,
+			.rml_process_content_scale_callback = &rml_process_content_scale_callback,
 
-		return &exports_table;
+			// WebGPU integration
+			.rml_create_wgpu_render_interface = &rml_create_wgpu_render_interface,
+			.rml_destroy_wgpu_render_interface = &rml_destroy_wgpu_render_interface,
+			.rml_set_render_interface = &rml_set_render_interface,
+			.rml_release_compiled_geometry = &rml_release_compiled_geometry,
+
+			// Rml::Document APIs
+			.rml_document_show = &rml_document_show,
+
+			// Rml::Context APIs
+			.rml_context_create = &rml_context_create,
+			.rml_context_update = &rml_context_update,
+			.rml_context_render = &rml_context_render,
+			.rml_context_remove = &rml_context_remove,
+			.rml_context_load_document = &rml_context_load_document,
+
+			// Font management APIs
+			.rml_load_font_face = &rml_load_font_face,
+		};
+
+		return &exports;
 	}
 
 }

--- a/Runtime/Bindings/FFI/runtime/runtime_ffi.cpp
+++ b/Runtime/Bindings/FFI/runtime/runtime_ffi.cpp
@@ -20,15 +20,14 @@ namespace runtime_ffi {
 	}
 
 	void* getExportsTable() {
-		static struct static_runtime_exports_table exports_table;
+		static struct static_runtime_exports_table exports = {
+			// Build configuration
+			.runtime_version = &runtime_version,
 
-		// Build configuration
-		exports_table.runtime_version = &runtime_version;
+			// REPL
+			.runtime_repl_start = &runtime_repl_start,
+		};
 
-		// REPL
-		exports_table.runtime_repl_start = &runtime_repl_start;
-
-		return &exports_table;
+		return &exports;
 	}
-
 }

--- a/Runtime/Bindings/FFI/stbi/stbi_ffi.cpp
+++ b/Runtime/Bindings/FFI/stbi/stbi_ffi.cpp
@@ -222,35 +222,35 @@ void stbi_replace_pixel_color_rgba(stbi_image_t* image, const stbi_color_t* sour
 namespace stbi_ffi {
 
 	void* getExportsTable() {
-		static struct static_stbi_exports_table stbi_exports_table;
+		static struct static_stbi_exports_table exports = {
 
-		stbi_exports_table.stbi_version = stbi_version;
+			.stbi_version = stbi_version,
 
-		stbi_exports_table.stbi_image_info = stbi_image_info;
-		stbi_exports_table.stbi_load_image = stbi_load_image;
-		stbi_exports_table.stbi_image_free = stbi_image_free;
+			.stbi_image_info = stbi_image_info,
+			.stbi_load_image = stbi_load_image,
+			.stbi_image_free = stbi_image_free,
 
-		stbi_exports_table.stbi_encode_bmp = stbi_encode_bmp;
-		stbi_exports_table.stbi_encode_jpg = stbi_encode_jpg;
-		stbi_exports_table.stbi_encode_png = stbi_encode_png;
-		stbi_exports_table.stbi_encode_tga = stbi_encode_tga;
+			.stbi_load_rgb = stbi_load_rgb,
+			.stbi_load_rgba = stbi_load_rgba,
+			.stbi_load_monochrome = stbi_load_monochrome,
+			.stbi_load_monochrome_with_alpha = stbi_load_monochrome_with_alpha,
 
-		stbi_exports_table.stbi_load_rgb = stbi_load_rgb;
-		stbi_exports_table.stbi_load_rgba = stbi_load_rgba;
-		stbi_exports_table.stbi_load_monochrome = stbi_load_monochrome;
-		stbi_exports_table.stbi_load_monochrome_with_alpha = stbi_load_monochrome_with_alpha;
+			.stbi_encode_bmp = stbi_encode_bmp,
+			.stbi_encode_png = stbi_encode_png,
+			.stbi_encode_jpg = stbi_encode_jpg,
+			.stbi_encode_tga = stbi_encode_tga,
 
-		stbi_exports_table.stbi_flip_vertically_on_write = stbi_flip_vertically_on_write;
+			.stbi_flip_vertically_on_write = stbi_flip_vertically_on_write,
 
-		stbi_exports_table.stbi_get_required_bmp_size = stbi_get_required_bmp_size;
-		stbi_exports_table.stbi_get_required_png_size = stbi_get_required_png_size;
-		stbi_exports_table.stbi_get_required_jpg_size = stbi_get_required_jpg_size;
-		stbi_exports_table.stbi_get_required_tga_size = stbi_get_required_tga_size;
+			.stbi_get_required_bmp_size = stbi_get_required_bmp_size,
+			.stbi_get_required_png_size = stbi_get_required_png_size,
+			.stbi_get_required_jpg_size = stbi_get_required_jpg_size,
+			.stbi_get_required_tga_size = stbi_get_required_tga_size,
 
-		stbi_exports_table.stbi_abgr_to_rgba = stbi_abgr_to_rgba;
-		stbi_exports_table.stbi_replace_pixel_color_rgba = stbi_replace_pixel_color_rgba;
+			.stbi_abgr_to_rgba = stbi_abgr_to_rgba,
+			.stbi_replace_pixel_color_rgba = stbi_replace_pixel_color_rgba,
+		};
 
-		return &stbi_exports_table;
+		return &exports;
 	}
-
 }

--- a/Runtime/Bindings/FFI/stduuid/stduuid_ffi.cpp
+++ b/Runtime/Bindings/FFI/stduuid/stduuid_ffi.cpp
@@ -86,14 +86,15 @@ namespace stduuid_ffi {
 	}
 
 	void* getExportsTable() {
-		static struct static_stduuid_exports_table stduuid_exports_table;
+		static struct static_stduuid_exports_table exports = {
 
-		stduuid_exports_table.stduuid_version = stduuid_version;
-		stduuid_exports_table.uuid_create_v4 = uuid_create_v4;
-		stduuid_exports_table.uuid_create_mt19937 = uuid_create_mt19937;
-		stduuid_exports_table.uuid_create_v5 = uuid_create_v5;
-		stduuid_exports_table.uuid_create_system = uuid_create_system;
+			.stduuid_version = stduuid_version,
+			.uuid_create_v4 = uuid_create_v4,
+			.uuid_create_mt19937 = uuid_create_mt19937,
+			.uuid_create_v5 = uuid_create_v5,
+			.uuid_create_system = uuid_create_system,
+		};
 
-		return &stduuid_exports_table;
+		return &exports;
 	}
 }

--- a/Runtime/Bindings/FFI/uws/uws_ffi.cpp
+++ b/Runtime/Bindings/FFI/uws/uws_ffi.cpp
@@ -194,61 +194,62 @@ void uws_webserver_add_any_route(uws_webserver_t server, const char* route) {
 namespace uws_ffi {
 
 	void* getExportsTable() {
-		static struct static_uws_exports_table uwebsockets_exports_table;
+		static struct static_uws_exports_table exports = {
 
-		// uws
-		uwebsockets_exports_table.uws_version = uws_version;
-		uwebsockets_exports_table.uws_event_name = uws_event_name;
+			// uws
+			.uws_version = uws_version,
+			.uws_event_name = uws_event_name,
 
-		// WebServer
-		uwebsockets_exports_table.uws_webserver_create = uws_webserver_create;
-		uwebsockets_exports_table.uws_webserver_listen = uws_webserver_listen;
-		uwebsockets_exports_table.uws_webserver_has_event = uws_webserver_has_event;
-		uwebsockets_exports_table.uws_webserver_get_next_event = uws_webserver_get_next_event;
-		uwebsockets_exports_table.uws_webserver_stop = uws_webserver_stop;
-		uwebsockets_exports_table.uws_webserver_delete = uws_webserver_delete;
+			// WebServer
+			.uws_webserver_create = uws_webserver_create,
+			.uws_webserver_listen = uws_webserver_listen,
+			.uws_webserver_has_event = uws_webserver_has_event,
+			.uws_webserver_get_next_event = uws_webserver_get_next_event,
+			.uws_webserver_stop = uws_webserver_stop,
+			.uws_webserver_delete = uws_webserver_delete,
 
-		uwebsockets_exports_table.uws_webserver_set_echo_mode = uws_webserver_set_echo_mode;
-		uwebsockets_exports_table.uws_webserver_dump_config = uws_webserver_dump_config;
-		uwebsockets_exports_table.uws_webserver_dump_events = uws_webserver_dump_events;
+			.uws_webserver_set_echo_mode = uws_webserver_set_echo_mode,
+			.uws_webserver_dump_config = uws_webserver_dump_config,
+			.uws_webserver_dump_events = uws_webserver_dump_events,
 
-		uwebsockets_exports_table.uws_webserver_get_client_count = uws_webserver_get_client_count;
-		uwebsockets_exports_table.uws_webserver_get_event_count = uws_webserver_get_event_count;
-		uwebsockets_exports_table.uws_webserver_payload_size = uws_webserver_payload_size;
-		uwebsockets_exports_table.uws_webserver_purge_connections = uws_webserver_purge_connections;
+			.uws_webserver_get_client_count = uws_webserver_get_client_count,
+			.uws_webserver_get_event_count = uws_webserver_get_event_count,
+			.uws_webserver_payload_size = uws_webserver_payload_size,
+			.uws_webserver_purge_connections = uws_webserver_purge_connections,
 
-		uwebsockets_exports_table.uws_webserver_broadcast_text = uws_webserver_broadcast_text;
-		uwebsockets_exports_table.uws_webserver_broadcast_binary = uws_webserver_broadcast_binary;
-		uwebsockets_exports_table.uws_webserver_broadcast_compressed = uws_webserver_broadcast_compressed;
-		uwebsockets_exports_table.uws_webserver_send_text = uws_webserver_send_text;
-		uwebsockets_exports_table.uws_webserver_send_binary = uws_webserver_send_binary;
-		uwebsockets_exports_table.uws_webserver_send_compressed = uws_webserver_send_compressed;
+			.uws_webserver_broadcast_text = uws_webserver_broadcast_text,
+			.uws_webserver_broadcast_binary = uws_webserver_broadcast_binary,
+			.uws_webserver_broadcast_compressed = uws_webserver_broadcast_compressed,
+			.uws_webserver_send_text = uws_webserver_send_text,
+			.uws_webserver_send_binary = uws_webserver_send_binary,
+			.uws_webserver_send_compressed = uws_webserver_send_compressed,
 
-		uwebsockets_exports_table.uws_webserver_response_write = uws_webserver_response_write;
-		uwebsockets_exports_table.uws_webserver_response_end = uws_webserver_response_end;
-		uwebsockets_exports_table.uws_webserver_response_try_end = uws_webserver_response_try_end;
-		uwebsockets_exports_table.uws_webserver_response_status = uws_webserver_response_status;
-		uwebsockets_exports_table.uws_webserver_response_header = uws_webserver_response_header;
+			.uws_webserver_response_write = uws_webserver_response_write,
+			.uws_webserver_response_end = uws_webserver_response_end,
+			.uws_webserver_response_try_end = uws_webserver_response_try_end,
+			.uws_webserver_response_status = uws_webserver_response_status,
+			.uws_webserver_response_header = uws_webserver_response_header,
 
-		uwebsockets_exports_table.uws_webserver_has_request = uws_webserver_has_request;
-		uwebsockets_exports_table.uws_webserver_request_method = uws_webserver_request_method;
-		uwebsockets_exports_table.uws_webserver_request_url = uws_webserver_request_url;
-		uwebsockets_exports_table.uws_webserver_request_query = uws_webserver_request_query;
-		uwebsockets_exports_table.uws_webserver_request_endpoint = uws_webserver_request_endpoint;
-		uwebsockets_exports_table.uws_webserver_request_serialized_headers = uws_webserver_request_serialized_headers;
-		uwebsockets_exports_table.uws_webserver_request_header_value = uws_webserver_request_header_value;
+			.uws_webserver_has_request = uws_webserver_has_request,
+			.uws_webserver_request_method = uws_webserver_request_method,
+			.uws_webserver_request_url = uws_webserver_request_url,
+			.uws_webserver_request_query = uws_webserver_request_query,
+			.uws_webserver_request_endpoint = uws_webserver_request_endpoint,
+			.uws_webserver_request_serialized_headers = uws_webserver_request_serialized_headers,
+			.uws_webserver_request_header_value = uws_webserver_request_header_value,
 
-		uwebsockets_exports_table.uws_webserver_add_websocket_route = uws_webserver_add_websocket_route;
-		uwebsockets_exports_table.uws_webserver_add_get_route = uws_webserver_add_get_route;
-		uwebsockets_exports_table.uws_webserver_add_post_route = uws_webserver_add_post_route;
-		uwebsockets_exports_table.uws_webserver_add_options_route = uws_webserver_add_options_route;
-		uwebsockets_exports_table.uws_webserver_add_delete_route = uws_webserver_add_delete_route;
-		uwebsockets_exports_table.uws_webserver_add_patch_route = uws_webserver_add_patch_route;
-		uwebsockets_exports_table.uws_webserver_add_put_route = uws_webserver_add_put_route;
-		uwebsockets_exports_table.uws_webserver_add_head_route = uws_webserver_add_head_route;
-		uwebsockets_exports_table.uws_webserver_add_any_route = uws_webserver_add_any_route;
+			.uws_webserver_add_websocket_route = uws_webserver_add_websocket_route,
+			.uws_webserver_add_get_route = uws_webserver_add_get_route,
+			.uws_webserver_add_post_route = uws_webserver_add_post_route,
+			.uws_webserver_add_options_route = uws_webserver_add_options_route,
+			.uws_webserver_add_delete_route = uws_webserver_add_delete_route,
+			.uws_webserver_add_patch_route = uws_webserver_add_patch_route,
+			.uws_webserver_add_put_route = uws_webserver_add_put_route,
+			.uws_webserver_add_head_route = uws_webserver_add_head_route,
+			.uws_webserver_add_any_route = uws_webserver_add_any_route,
+		};
 
-		return &uwebsockets_exports_table;
+		return &exports;
 	}
 
 	uWS::Loop* assignEventLoop(void* existing_native_loop) {

--- a/Runtime/Bindings/FFI/webview/webview_ffi.cpp
+++ b/Runtime/Bindings/FFI/webview/webview_ffi.cpp
@@ -110,29 +110,29 @@ namespace webview_ffi {
 	}
 
 	void* getExportsTable() {
-		static struct static_webview_exports_table webview_exports_table;
+		static struct static_webview_exports_table exports = {
+			.webview_create = webview_create,
+			.webview_destroy = webview_destroy,
+			.webview_toggle_fullscreen = webview_toggle_fullscreen,
+			.webview_run = webview_run,
+			.webview_run_once = webview_run_once,
+			.webview_terminate = webview_terminate,
+			.webview_dispatch = webview_dispatch,
+			.webview_get_window = webview_get_window,
+			.webview_set_title = webview_set_title,
+			.webview_set_size = webview_set_size,
+			.webview_navigate = webview_navigate,
+			.webview_set_html = webview_set_html,
+			.webview_init = webview_init,
+			.webview_eval = webview_eval,
+			.webview_bind = webview_bind,
+			.webview_unbind = webview_unbind,
+			.webview_return = webview_return,
+			.webview_version = webview_version,
+			.webview_set_icon = webview_set_icon,
+			.webview_get_native_handle = webview_get_native_handle,
+		};
 
-		webview_exports_table.webview_bind = webview_bind;
-		webview_exports_table.webview_create = webview_create;
-		webview_exports_table.webview_destroy = webview_destroy;
-		webview_exports_table.webview_toggle_fullscreen = webview_toggle_fullscreen;
-		webview_exports_table.webview_dispatch = webview_dispatch;
-		webview_exports_table.webview_eval = webview_eval;
-		webview_exports_table.webview_get_window = webview_get_window;
-		webview_exports_table.webview_init = webview_init;
-		webview_exports_table.webview_navigate = webview_navigate;
-		webview_exports_table.webview_return = webview_return;
-		webview_exports_table.webview_run = webview_run;
-		webview_exports_table.webview_run_once = webview_run_once;
-		webview_exports_table.webview_set_html = webview_set_html;
-		webview_exports_table.webview_set_size = webview_set_size;
-		webview_exports_table.webview_set_title = webview_set_title;
-		webview_exports_table.webview_terminate = webview_terminate;
-		webview_exports_table.webview_unbind = webview_unbind;
-		webview_exports_table.webview_version = webview_version;
-		webview_exports_table.webview_set_icon = webview_set_icon;
-		webview_exports_table.webview_get_native_handle = webview_get_native_handle;
-
-		return &webview_exports_table;
+		return &exports;
 	}
 }

--- a/Runtime/Bindings/FFI/wgpu/wgpu_ffi.cpp
+++ b/Runtime/Bindings/FFI/wgpu/wgpu_ffi.cpp
@@ -7,259 +7,261 @@ const char* wgpu_version() {
 namespace wgpu_ffi {
 
 	void* getExportsTable() {
-		static struct static_wgpu_exports_table wgpu_exports_table;
+		static struct static_wgpu_exports_table exports = {
 
-		// Custom
-		wgpu_exports_table.wgpu_version = wgpu_version;
+			// Custom
+			.wgpu_version = wgpu_version,
 
-		// Global
-		wgpu_exports_table.wgpu_create_instance = wgpuCreateInstance;
-		wgpu_exports_table.wgpu_get_proc_address = wgpuGetProcAddress;
+			// Global
+			.wgpu_create_instance = wgpuCreateInstance,
+			.wgpu_get_proc_address = wgpuGetProcAddress,
 
-		// Adapter
-		wgpu_exports_table.wgpu_adapter_enumerate_features = wgpuAdapterEnumerateFeatures;
-		wgpu_exports_table.wgpu_adapter_get_limits = wgpuAdapterGetLimits;
-		wgpu_exports_table.wgpu_adapter_get_properties = wgpuAdapterGetProperties;
-		wgpu_exports_table.wgpu_adapter_has_feature = wgpuAdapterHasFeature;
-		wgpu_exports_table.wgpu_adapter_request_device = wgpuAdapterRequestDevice;
-		wgpu_exports_table.wgpu_adapter_reference = wgpuAdapterReference;
-		wgpu_exports_table.wgpu_adapter_release = wgpuAdapterRelease;
+			// Adapter
+			.wgpu_adapter_enumerate_features = wgpuAdapterEnumerateFeatures,
+			.wgpu_adapter_get_limits = wgpuAdapterGetLimits,
+			.wgpu_adapter_get_properties = wgpuAdapterGetProperties,
+			.wgpu_adapter_has_feature = wgpuAdapterHasFeature,
+			.wgpu_adapter_request_device = wgpuAdapterRequestDevice,
+			.wgpu_adapter_reference = wgpuAdapterReference,
+			.wgpu_adapter_release = wgpuAdapterRelease,
 
-		// BindGroup
-		wgpu_exports_table.wgpu_bind_group_set_label = wgpuBindGroupSetLabel;
-		wgpu_exports_table.wgpu_bind_group_reference = wgpuBindGroupReference;
-		wgpu_exports_table.wgpu_bind_group_release = wgpuBindGroupRelease;
+			// BindGroup
+			.wgpu_bind_group_set_label = wgpuBindGroupSetLabel,
+			.wgpu_bind_group_reference = wgpuBindGroupReference,
+			.wgpu_bind_group_release = wgpuBindGroupRelease,
 
-		// BindGroupLayout
-		wgpu_exports_table.wgpu_bind_group_layout_set_label = wgpuBindGroupLayoutSetLabel;
-		wgpu_exports_table.wgpu_bind_group_layout_reference = wgpuBindGroupLayoutReference;
-		wgpu_exports_table.wgpu_bind_group_layout_release = wgpuBindGroupLayoutRelease;
+			// BindGroupLayout
+			.wgpu_bind_group_layout_set_label = wgpuBindGroupLayoutSetLabel,
+			.wgpu_bind_group_layout_reference = wgpuBindGroupLayoutReference,
+			.wgpu_bind_group_layout_release = wgpuBindGroupLayoutRelease,
 
-		// Buffer
-		wgpu_exports_table.wgpu_buffer_destroy = wgpuBufferDestroy;
-		wgpu_exports_table.wgpu_buffer_get_const_mapped_range = wgpuBufferGetConstMappedRange;
-		wgpu_exports_table.wgpu_buffer_get_map_state = wgpuBufferGetMapState;
-		wgpu_exports_table.wgpu_buffer_get_mapped_range = wgpuBufferGetMappedRange;
-		wgpu_exports_table.wgpu_buffer_get_size = wgpuBufferGetSize;
-		wgpu_exports_table.wgpu_buffer_get_usage = wgpuBufferGetUsage;
-		wgpu_exports_table.wgpu_buffer_map_async = wgpuBufferMapAsync;
-		wgpu_exports_table.wgpu_buffer_set_label = wgpuBufferSetLabel;
-		wgpu_exports_table.wgpu_buffer_unmap = wgpuBufferUnmap;
-		wgpu_exports_table.wgpu_buffer_reference = wgpuBufferReference;
-		wgpu_exports_table.wgpu_buffer_release = wgpuBufferRelease;
+			// Buffer
+			.wgpu_buffer_destroy = wgpuBufferDestroy,
+			.wgpu_buffer_get_const_mapped_range = wgpuBufferGetConstMappedRange,
+			.wgpu_buffer_get_map_state = wgpuBufferGetMapState,
+			.wgpu_buffer_get_mapped_range = wgpuBufferGetMappedRange,
+			.wgpu_buffer_get_size = wgpuBufferGetSize,
+			.wgpu_buffer_get_usage = wgpuBufferGetUsage,
+			.wgpu_buffer_map_async = wgpuBufferMapAsync,
+			.wgpu_buffer_set_label = wgpuBufferSetLabel,
+			.wgpu_buffer_unmap = wgpuBufferUnmap,
+			.wgpu_buffer_reference = wgpuBufferReference,
+			.wgpu_buffer_release = wgpuBufferRelease,
 
-		// CommandBuffer
-		wgpu_exports_table.wgpu_command_buffer_reference = wgpuCommandBufferReference;
-		wgpu_exports_table.wgpu_command_buffer_release = wgpuCommandBufferRelease;
-		wgpu_exports_table.wgpu_command_buffer_set_label = wgpuCommandBufferSetLabel;
+			// CommandBuffer
+			.wgpu_command_buffer_set_label = wgpuCommandBufferSetLabel,
+			.wgpu_command_buffer_reference = wgpuCommandBufferReference,
+			.wgpu_command_buffer_release = wgpuCommandBufferRelease,
 
-		// CommandEncoder
-		wgpu_exports_table.wgpu_command_encoder_begin_compute_pass = wgpuCommandEncoderBeginComputePass;
-		wgpu_exports_table.wgpu_command_encoder_begin_render_pass = wgpuCommandEncoderBeginRenderPass;
-		wgpu_exports_table.wgpu_command_encoder_clear_buffer = wgpuCommandEncoderClearBuffer;
-		wgpu_exports_table.wgpu_command_encoder_copy_buffer_to_buffer = wgpuCommandEncoderCopyBufferToBuffer;
-		wgpu_exports_table.wgpu_command_encoder_copy_buffer_to_texture = wgpuCommandEncoderCopyBufferToTexture;
-		wgpu_exports_table.wgpu_command_encoder_copy_texture_to_buffer = wgpuCommandEncoderCopyTextureToBuffer;
-		wgpu_exports_table.wgpu_command_encoder_copy_texture_to_texture = wgpuCommandEncoderCopyTextureToTexture;
-		wgpu_exports_table.wgpu_command_encoder_finish = wgpuCommandEncoderFinish;
-		wgpu_exports_table.wgpu_command_encoder_insert_debug_marker = wgpuCommandEncoderInsertDebugMarker;
-		wgpu_exports_table.wgpu_command_encoder_pop_debug_group = wgpuCommandEncoderPopDebugGroup;
-		wgpu_exports_table.wgpu_command_encoder_push_debug_group = wgpuCommandEncoderPushDebugGroup;
-		wgpu_exports_table.wgpu_command_encoder_resolve_query_set = wgpuCommandEncoderResolveQuerySet;
-		wgpu_exports_table.wgpu_command_encoder_set_label = wgpuCommandEncoderSetLabel;
-		wgpu_exports_table.wgpu_command_encoder_write_timestamp = wgpuCommandEncoderWriteTimestamp;
-		wgpu_exports_table.wgpu_command_encoder_reference = wgpuCommandEncoderReference;
-		wgpu_exports_table.wgpu_command_encoder_release = wgpuCommandEncoderRelease;
+			// CommandEncoder
+			.wgpu_command_encoder_begin_compute_pass = wgpuCommandEncoderBeginComputePass,
+			.wgpu_command_encoder_begin_render_pass = wgpuCommandEncoderBeginRenderPass,
+			.wgpu_command_encoder_clear_buffer = wgpuCommandEncoderClearBuffer,
+			.wgpu_command_encoder_copy_buffer_to_buffer = wgpuCommandEncoderCopyBufferToBuffer,
+			.wgpu_command_encoder_copy_buffer_to_texture = wgpuCommandEncoderCopyBufferToTexture,
+			.wgpu_command_encoder_copy_texture_to_buffer = wgpuCommandEncoderCopyTextureToBuffer,
+			.wgpu_command_encoder_copy_texture_to_texture = wgpuCommandEncoderCopyTextureToTexture,
+			.wgpu_command_encoder_finish = wgpuCommandEncoderFinish,
+			.wgpu_command_encoder_insert_debug_marker = wgpuCommandEncoderInsertDebugMarker,
+			.wgpu_command_encoder_pop_debug_group = wgpuCommandEncoderPopDebugGroup,
+			.wgpu_command_encoder_push_debug_group = wgpuCommandEncoderPushDebugGroup,
+			.wgpu_command_encoder_resolve_query_set = wgpuCommandEncoderResolveQuerySet,
+			.wgpu_command_encoder_set_label = wgpuCommandEncoderSetLabel,
+			.wgpu_command_encoder_write_timestamp = wgpuCommandEncoderWriteTimestamp,
+			.wgpu_command_encoder_reference = wgpuCommandEncoderReference,
+			.wgpu_command_encoder_release = wgpuCommandEncoderRelease,
 
-		// ComputePassEncoder
-		wgpu_exports_table.wgpu_compute_pass_encoder_dispatch_workgroups = wgpuComputePassEncoderDispatchWorkgroups;
-		wgpu_exports_table.wgpu_compute_pass_encoder_dispatch_workgroups_indirect = wgpuComputePassEncoderDispatchWorkgroupsIndirect;
-		wgpu_exports_table.wgpu_compute_pass_encoder_end = wgpuComputePassEncoderEnd;
-		wgpu_exports_table.wgpu_compute_pass_encoder_insert_debug_marker = wgpuComputePassEncoderInsertDebugMarker;
-		wgpu_exports_table.wgpu_compute_pass_encoder_pop_debug_group = wgpuComputePassEncoderPopDebugGroup;
-		wgpu_exports_table.wgpu_compute_pass_encoder_push_debug_group = wgpuComputePassEncoderPushDebugGroup;
-		wgpu_exports_table.wgpu_compute_pass_encoder_set_bind_group = wgpuComputePassEncoderSetBindGroup;
-		wgpu_exports_table.wgpu_compute_pass_encoder_set_label = wgpuComputePassEncoderSetLabel;
-		wgpu_exports_table.wgpu_compute_pass_encoder_set_pipeline = wgpuComputePassEncoderSetPipeline;
-		wgpu_exports_table.wgpu_compute_pass_encoder_reference = wgpuComputePassEncoderReference;
-		wgpu_exports_table.wgpu_compute_pass_encoder_release = wgpuComputePassEncoderRelease;
+			// ComputePassEncoder
+			.wgpu_compute_pass_encoder_dispatch_workgroups = wgpuComputePassEncoderDispatchWorkgroups,
+			.wgpu_compute_pass_encoder_dispatch_workgroups_indirect = wgpuComputePassEncoderDispatchWorkgroupsIndirect,
+			.wgpu_compute_pass_encoder_end = wgpuComputePassEncoderEnd,
+			.wgpu_compute_pass_encoder_insert_debug_marker = wgpuComputePassEncoderInsertDebugMarker,
+			.wgpu_compute_pass_encoder_pop_debug_group = wgpuComputePassEncoderPopDebugGroup,
+			.wgpu_compute_pass_encoder_push_debug_group = wgpuComputePassEncoderPushDebugGroup,
+			.wgpu_compute_pass_encoder_set_bind_group = wgpuComputePassEncoderSetBindGroup,
+			.wgpu_compute_pass_encoder_set_label = wgpuComputePassEncoderSetLabel,
+			.wgpu_compute_pass_encoder_set_pipeline = wgpuComputePassEncoderSetPipeline,
+			.wgpu_compute_pass_encoder_reference = wgpuComputePassEncoderReference,
+			.wgpu_compute_pass_encoder_release = wgpuComputePassEncoderRelease,
 
-		// ComputePipeline
-		wgpu_exports_table.wgpu_compute_pipeline_get_bind_group_layout = wgpuComputePipelineGetBindGroupLayout;
-		wgpu_exports_table.wgpu_compute_pipeline_set_label = wgpuComputePipelineSetLabel;
-		wgpu_exports_table.wgpu_compute_pipeline_reference = wgpuComputePipelineReference;
-		wgpu_exports_table.wgpu_compute_pipeline_release = wgpuComputePipelineRelease;
+			// ComputePipeline
+			.wgpu_compute_pipeline_get_bind_group_layout = wgpuComputePipelineGetBindGroupLayout,
+			.wgpu_compute_pipeline_set_label = wgpuComputePipelineSetLabel,
+			.wgpu_compute_pipeline_reference = wgpuComputePipelineReference,
+			.wgpu_compute_pipeline_release = wgpuComputePipelineRelease,
 
-		// Device
-		wgpu_exports_table.wgpu_device_create_bind_group = wgpuDeviceCreateBindGroup;
-		wgpu_exports_table.wgpu_device_create_bind_group_layout = wgpuDeviceCreateBindGroupLayout;
-		wgpu_exports_table.wgpu_device_create_buffer = wgpuDeviceCreateBuffer;
-		wgpu_exports_table.wgpu_device_create_command_encoder = wgpuDeviceCreateCommandEncoder;
-		wgpu_exports_table.wgpu_device_create_compute_pipeline = wgpuDeviceCreateComputePipeline;
-		wgpu_exports_table.wgpu_device_create_compute_pipeline_async = wgpuDeviceCreateComputePipelineAsync;
-		wgpu_exports_table.wgpu_device_create_pipeline_layout = wgpuDeviceCreatePipelineLayout;
-		wgpu_exports_table.wgpu_device_create_query_set = wgpuDeviceCreateQuerySet;
-		wgpu_exports_table.wgpu_device_create_render_bundle_encoder = wgpuDeviceCreateRenderBundleEncoder;
-		wgpu_exports_table.wgpu_device_create_render_pipeline = wgpuDeviceCreateRenderPipeline;
-		wgpu_exports_table.wgpu_device_create_render_pipeline_async = wgpuDeviceCreateRenderPipelineAsync;
-		wgpu_exports_table.wgpu_device_create_sampler = wgpuDeviceCreateSampler;
-		wgpu_exports_table.wgpu_device_create_shader_module = wgpuDeviceCreateShaderModule;
-		wgpu_exports_table.wgpu_device_create_texture = wgpuDeviceCreateTexture;
-		wgpu_exports_table.wgpu_device_destroy = wgpuDeviceDestroy;
-		wgpu_exports_table.wgpu_device_enumerate_features = wgpuDeviceEnumerateFeatures;
-		wgpu_exports_table.wgpu_device_get_limits = wgpuDeviceGetLimits;
-		wgpu_exports_table.wgpu_device_get_queue = wgpuDeviceGetQueue;
-		wgpu_exports_table.wgpu_device_has_feature = wgpuDeviceHasFeature;
-		wgpu_exports_table.wgpu_device_pop_error_scope = wgpuDevicePopErrorScope;
-		wgpu_exports_table.wgpu_device_push_error_scope = wgpuDevicePushErrorScope;
-		wgpu_exports_table.wgpu_device_set_label = wgpuDeviceSetLabel;
-		wgpu_exports_table.wgpu_device_set_uncaptured_error_callback = wgpuDeviceSetUncapturedErrorCallback;
-		wgpu_exports_table.wgpu_device_reference = wgpuDeviceReference;
-		wgpu_exports_table.wgpu_device_release = wgpuDeviceRelease;
+			// Device
+			.wgpu_device_create_bind_group = wgpuDeviceCreateBindGroup,
+			.wgpu_device_create_bind_group_layout = wgpuDeviceCreateBindGroupLayout,
+			.wgpu_device_create_buffer = wgpuDeviceCreateBuffer,
+			.wgpu_device_create_command_encoder = wgpuDeviceCreateCommandEncoder,
+			.wgpu_device_create_compute_pipeline = wgpuDeviceCreateComputePipeline,
+			.wgpu_device_create_compute_pipeline_async = wgpuDeviceCreateComputePipelineAsync,
+			.wgpu_device_create_pipeline_layout = wgpuDeviceCreatePipelineLayout,
+			.wgpu_device_create_query_set = wgpuDeviceCreateQuerySet,
+			.wgpu_device_create_render_bundle_encoder = wgpuDeviceCreateRenderBundleEncoder,
+			.wgpu_device_create_render_pipeline = wgpuDeviceCreateRenderPipeline,
+			.wgpu_device_create_render_pipeline_async = wgpuDeviceCreateRenderPipelineAsync,
+			.wgpu_device_create_sampler = wgpuDeviceCreateSampler,
+			.wgpu_device_create_shader_module = wgpuDeviceCreateShaderModule,
+			.wgpu_device_create_texture = wgpuDeviceCreateTexture,
+			.wgpu_device_destroy = wgpuDeviceDestroy,
+			.wgpu_device_enumerate_features = wgpuDeviceEnumerateFeatures,
+			.wgpu_device_get_limits = wgpuDeviceGetLimits,
+			.wgpu_device_get_queue = wgpuDeviceGetQueue,
+			.wgpu_device_has_feature = wgpuDeviceHasFeature,
+			.wgpu_device_pop_error_scope = wgpuDevicePopErrorScope,
+			.wgpu_device_push_error_scope = wgpuDevicePushErrorScope,
+			.wgpu_device_set_label = wgpuDeviceSetLabel,
+			.wgpu_device_set_uncaptured_error_callback = wgpuDeviceSetUncapturedErrorCallback,
+			.wgpu_device_reference = wgpuDeviceReference,
+			.wgpu_device_release = wgpuDeviceRelease,
 
-		// Instance
-		wgpu_exports_table.wgpu_instance_create_surface = wgpuInstanceCreateSurface;
-		wgpu_exports_table.wgpu_instance_process_events = wgpuInstanceProcessEvents;
-		wgpu_exports_table.wgpu_instance_request_adapter = wgpuInstanceRequestAdapter;
-		wgpu_exports_table.wgpu_instance_reference = wgpuInstanceReference;
-		wgpu_exports_table.wgpu_instance_release = wgpuInstanceRelease;
+			// Instance
+			.wgpu_instance_create_surface = wgpuInstanceCreateSurface,
+			.wgpu_instance_process_events = wgpuInstanceProcessEvents,
+			.wgpu_instance_request_adapter = wgpuInstanceRequestAdapter,
+			.wgpu_instance_reference = wgpuInstanceReference,
+			.wgpu_instance_release = wgpuInstanceRelease,
 
-		// PipelineLayout
-		wgpu_exports_table.wgpu_pipeline_layout_set_label = wgpuPipelineLayoutSetLabel;
-		wgpu_exports_table.wgpu_pipeline_layout_reference = wgpuPipelineLayoutReference;
-		wgpu_exports_table.wgpu_pipeline_layout_release = wgpuPipelineLayoutRelease;
+			// PipelineLayout
+			.wgpu_pipeline_layout_set_label = wgpuPipelineLayoutSetLabel,
+			.wgpu_pipeline_layout_reference = wgpuPipelineLayoutReference,
+			.wgpu_pipeline_layout_release = wgpuPipelineLayoutRelease,
 
-		// QuerySet
-		wgpu_exports_table.wgpu_query_set_destroy = wgpuQuerySetDestroy;
-		wgpu_exports_table.wgpu_query_set_get_count = wgpuQuerySetGetCount;
-		wgpu_exports_table.wgpu_query_set_get_type = wgpuQuerySetGetType;
-		wgpu_exports_table.wgpu_query_set_set_label = wgpuQuerySetSetLabel;
-		wgpu_exports_table.wgpu_query_set_reference = wgpuQuerySetReference;
-		wgpu_exports_table.wgpu_query_set_release = wgpuQuerySetRelease;
+			// QuerySet
+			.wgpu_query_set_destroy = wgpuQuerySetDestroy,
+			.wgpu_query_set_get_count = wgpuQuerySetGetCount,
+			.wgpu_query_set_get_type = wgpuQuerySetGetType,
+			.wgpu_query_set_set_label = wgpuQuerySetSetLabel,
+			.wgpu_query_set_reference = wgpuQuerySetReference,
+			.wgpu_query_set_release = wgpuQuerySetRelease,
 
-		// Queue
-		wgpu_exports_table.wgpu_queue_on_submitted_work_done = wgpuQueueOnSubmittedWorkDone;
-		wgpu_exports_table.wgpu_queue_set_label = wgpuQueueSetLabel;
-		wgpu_exports_table.wgpu_queue_submit = wgpuQueueSubmit;
-		wgpu_exports_table.wgpu_queue_write_buffer = wgpuQueueWriteBuffer;
-		wgpu_exports_table.wgpu_queue_write_texture = wgpuQueueWriteTexture;
-		wgpu_exports_table.wgpu_queue_reference = wgpuQueueReference;
-		wgpu_exports_table.wgpu_queue_release = wgpuQueueRelease;
+			// Queue
+			.wgpu_queue_on_submitted_work_done = wgpuQueueOnSubmittedWorkDone,
+			.wgpu_queue_set_label = wgpuQueueSetLabel,
+			.wgpu_queue_submit = wgpuQueueSubmit,
+			.wgpu_queue_write_buffer = wgpuQueueWriteBuffer,
+			.wgpu_queue_write_texture = wgpuQueueWriteTexture,
+			.wgpu_queue_reference = wgpuQueueReference,
+			.wgpu_queue_release = wgpuQueueRelease,
 
-		// RenderBundle
-		wgpu_exports_table.wgpu_render_bundle_set_label = wgpuRenderBundleSetLabel;
-		wgpu_exports_table.wgpu_render_bundle_reference = wgpuRenderBundleReference;
-		wgpu_exports_table.wgpu_render_bundle_release = wgpuRenderBundleRelease;
+			// RenderBundle
+			.wgpu_render_bundle_set_label = wgpuRenderBundleSetLabel,
+			.wgpu_render_bundle_reference = wgpuRenderBundleReference,
+			.wgpu_render_bundle_release = wgpuRenderBundleRelease,
 
-		// RenderBundleEncoder
-		wgpu_exports_table.wgpu_render_bundle_encoder_draw = wgpuRenderBundleEncoderDraw;
-		wgpu_exports_table.wgpu_render_bundle_encoder_draw_indexed = wgpuRenderBundleEncoderDrawIndexed;
-		wgpu_exports_table.wgpu_render_bundle_encoder_draw_indexed_indirect = wgpuRenderBundleEncoderDrawIndexedIndirect;
-		wgpu_exports_table.wgpu_render_bundle_encoder_draw_indirect = wgpuRenderBundleEncoderDrawIndirect;
-		wgpu_exports_table.wgpu_render_bundle_encoder_finish = wgpuRenderBundleEncoderFinish;
-		wgpu_exports_table.wgpu_render_bundle_encoder_insert_debug_marker = wgpuRenderBundleEncoderInsertDebugMarker;
-		wgpu_exports_table.wgpu_render_bundle_encoder_pop_debug_group = wgpuRenderBundleEncoderPopDebugGroup;
-		wgpu_exports_table.wgpu_render_bundle_encoder_push_debug_group = wgpuRenderBundleEncoderPushDebugGroup;
-		wgpu_exports_table.wgpu_render_bundle_encoder_set_bind_group = wgpuRenderBundleEncoderSetBindGroup;
-		wgpu_exports_table.wgpu_render_bundle_encoder_set_index_buffer = wgpuRenderBundleEncoderSetIndexBuffer;
-		wgpu_exports_table.wgpu_render_bundle_encoder_set_label = wgpuRenderBundleEncoderSetLabel;
-		wgpu_exports_table.wgpu_render_bundle_encoder_set_pipeline = wgpuRenderBundleEncoderSetPipeline;
-		wgpu_exports_table.wgpu_render_bundle_encoder_set_vertex_buffer = wgpuRenderBundleEncoderSetVertexBuffer;
-		wgpu_exports_table.wgpu_render_bundle_encoder_reference = wgpuRenderBundleEncoderReference;
-		wgpu_exports_table.wgpu_render_bundle_encoder_release = wgpuRenderBundleEncoderRelease;
+			// RenderBundleEncoder
+			.wgpu_render_bundle_encoder_draw = wgpuRenderBundleEncoderDraw,
+			.wgpu_render_bundle_encoder_draw_indexed = wgpuRenderBundleEncoderDrawIndexed,
+			.wgpu_render_bundle_encoder_draw_indexed_indirect = wgpuRenderBundleEncoderDrawIndexedIndirect,
+			.wgpu_render_bundle_encoder_draw_indirect = wgpuRenderBundleEncoderDrawIndirect,
+			.wgpu_render_bundle_encoder_finish = wgpuRenderBundleEncoderFinish,
+			.wgpu_render_bundle_encoder_insert_debug_marker = wgpuRenderBundleEncoderInsertDebugMarker,
+			.wgpu_render_bundle_encoder_pop_debug_group = wgpuRenderBundleEncoderPopDebugGroup,
+			.wgpu_render_bundle_encoder_push_debug_group = wgpuRenderBundleEncoderPushDebugGroup,
+			.wgpu_render_bundle_encoder_set_bind_group = wgpuRenderBundleEncoderSetBindGroup,
+			.wgpu_render_bundle_encoder_set_index_buffer = wgpuRenderBundleEncoderSetIndexBuffer,
+			.wgpu_render_bundle_encoder_set_label = wgpuRenderBundleEncoderSetLabel,
+			.wgpu_render_bundle_encoder_set_pipeline = wgpuRenderBundleEncoderSetPipeline,
+			.wgpu_render_bundle_encoder_set_vertex_buffer = wgpuRenderBundleEncoderSetVertexBuffer,
+			.wgpu_render_bundle_encoder_reference = wgpuRenderBundleEncoderReference,
+			.wgpu_render_bundle_encoder_release = wgpuRenderBundleEncoderRelease,
 
-		// RenderPassEncoder
-		wgpu_exports_table.wgpu_render_pass_encoder_begin_occlusion_query = wgpuRenderPassEncoderBeginOcclusionQuery;
-		wgpu_exports_table.wgpu_render_pass_encoder_draw = wgpuRenderPassEncoderDraw;
-		wgpu_exports_table.wgpu_render_pass_encoder_draw_indexed = wgpuRenderPassEncoderDrawIndexed;
-		wgpu_exports_table.wgpu_render_pass_encoder_draw_indexed_indirect = wgpuRenderPassEncoderDrawIndexedIndirect;
-		wgpu_exports_table.wgpu_render_pass_encoder_draw_indirect = wgpuRenderPassEncoderDrawIndirect;
-		wgpu_exports_table.wgpu_render_pass_encoder_end = wgpuRenderPassEncoderEnd;
-		wgpu_exports_table.wgpu_render_pass_encoder_end_occlusion_query = wgpuRenderPassEncoderEndOcclusionQuery;
-		wgpu_exports_table.wgpu_render_pass_encoder_execute_bundles = wgpuRenderPassEncoderExecuteBundles;
-		wgpu_exports_table.wgpu_render_pass_encoder_insert_debug_marker = wgpuRenderPassEncoderInsertDebugMarker;
-		wgpu_exports_table.wgpu_render_pass_encoder_pop_debug_group = wgpuRenderPassEncoderPopDebugGroup;
-		wgpu_exports_table.wgpu_render_pass_encoder_push_debug_group = wgpuRenderPassEncoderPushDebugGroup;
-		wgpu_exports_table.wgpu_render_pass_encoder_set_bind_group = wgpuRenderPassEncoderSetBindGroup;
-		wgpu_exports_table.wgpu_render_pass_encoder_set_blend_constant = wgpuRenderPassEncoderSetBlendConstant;
-		wgpu_exports_table.wgpu_render_pass_encoder_set_index_buffer = wgpuRenderPassEncoderSetIndexBuffer;
-		wgpu_exports_table.wgpu_render_pass_encoder_set_label = wgpuRenderPassEncoderSetLabel;
-		wgpu_exports_table.wgpu_render_pass_encoder_set_pipeline = wgpuRenderPassEncoderSetPipeline;
-		wgpu_exports_table.wgpu_render_pass_encoder_set_scissor_rect = wgpuRenderPassEncoderSetScissorRect;
-		wgpu_exports_table.wgpu_render_pass_encoder_set_stencil_reference = wgpuRenderPassEncoderSetStencilReference;
-		wgpu_exports_table.wgpu_render_pass_encoder_set_vertex_buffer = wgpuRenderPassEncoderSetVertexBuffer;
-		wgpu_exports_table.wgpu_render_pass_encoder_set_viewport = wgpuRenderPassEncoderSetViewport;
-		wgpu_exports_table.wgpu_render_pass_encoder_reference = wgpuRenderPassEncoderReference;
-		wgpu_exports_table.wgpu_render_pass_encoder_release = wgpuRenderPassEncoderRelease;
+			// RenderPassEncoder
+			.wgpu_render_pass_encoder_begin_occlusion_query = wgpuRenderPassEncoderBeginOcclusionQuery,
+			.wgpu_render_pass_encoder_draw = wgpuRenderPassEncoderDraw,
+			.wgpu_render_pass_encoder_draw_indexed = wgpuRenderPassEncoderDrawIndexed,
+			.wgpu_render_pass_encoder_draw_indexed_indirect = wgpuRenderPassEncoderDrawIndexedIndirect,
+			.wgpu_render_pass_encoder_draw_indirect = wgpuRenderPassEncoderDrawIndirect,
+			.wgpu_render_pass_encoder_end = wgpuRenderPassEncoderEnd,
+			.wgpu_render_pass_encoder_end_occlusion_query = wgpuRenderPassEncoderEndOcclusionQuery,
+			.wgpu_render_pass_encoder_execute_bundles = wgpuRenderPassEncoderExecuteBundles,
+			.wgpu_render_pass_encoder_insert_debug_marker = wgpuRenderPassEncoderInsertDebugMarker,
+			.wgpu_render_pass_encoder_pop_debug_group = wgpuRenderPassEncoderPopDebugGroup,
+			.wgpu_render_pass_encoder_push_debug_group = wgpuRenderPassEncoderPushDebugGroup,
+			.wgpu_render_pass_encoder_set_bind_group = wgpuRenderPassEncoderSetBindGroup,
+			.wgpu_render_pass_encoder_set_blend_constant = wgpuRenderPassEncoderSetBlendConstant,
+			.wgpu_render_pass_encoder_set_index_buffer = wgpuRenderPassEncoderSetIndexBuffer,
+			.wgpu_render_pass_encoder_set_label = wgpuRenderPassEncoderSetLabel,
+			.wgpu_render_pass_encoder_set_pipeline = wgpuRenderPassEncoderSetPipeline,
+			.wgpu_render_pass_encoder_set_scissor_rect = wgpuRenderPassEncoderSetScissorRect,
+			.wgpu_render_pass_encoder_set_stencil_reference = wgpuRenderPassEncoderSetStencilReference,
+			.wgpu_render_pass_encoder_set_vertex_buffer = wgpuRenderPassEncoderSetVertexBuffer,
+			.wgpu_render_pass_encoder_set_viewport = wgpuRenderPassEncoderSetViewport,
+			.wgpu_render_pass_encoder_reference = wgpuRenderPassEncoderReference,
+			.wgpu_render_pass_encoder_release = wgpuRenderPassEncoderRelease,
 
-		// RenderPipeline
-		wgpu_exports_table.wgpu_render_pipeline_get_bind_group_layout = wgpuRenderPipelineGetBindGroupLayout;
-		wgpu_exports_table.wgpu_render_pipeline_set_label = wgpuRenderPipelineSetLabel;
-		wgpu_exports_table.wgpu_render_pipeline_reference = wgpuRenderPipelineReference;
-		wgpu_exports_table.wgpu_render_pipeline_release = wgpuRenderPipelineRelease;
+			// RenderPipeline
+			.wgpu_render_pipeline_get_bind_group_layout = wgpuRenderPipelineGetBindGroupLayout,
+			.wgpu_render_pipeline_set_label = wgpuRenderPipelineSetLabel,
+			.wgpu_render_pipeline_reference = wgpuRenderPipelineReference,
+			.wgpu_render_pipeline_release = wgpuRenderPipelineRelease,
 
-		// Sampler
-		wgpu_exports_table.wgpu_sampler_set_label = wgpuSamplerSetLabel;
-		wgpu_exports_table.wgpu_sampler_reference = wgpuSamplerReference;
-		wgpu_exports_table.wgpu_sampler_release = wgpuSamplerRelease;
+			// Sampler
+			.wgpu_sampler_set_label = wgpuSamplerSetLabel,
+			.wgpu_sampler_reference = wgpuSamplerReference,
+			.wgpu_sampler_release = wgpuSamplerRelease,
 
-		// ShaderModule
-		wgpu_exports_table.wgpu_shader_module_get_compilation_info = wgpuShaderModuleGetCompilationInfo;
-		wgpu_exports_table.wgpu_shader_module_set_label = wgpuShaderModuleSetLabel;
-		wgpu_exports_table.wgpu_shader_module_reference = wgpuShaderModuleReference;
-		wgpu_exports_table.wgpu_shader_module_release = wgpuShaderModuleRelease;
+			// ShaderModule
+			.wgpu_shader_module_get_compilation_info = wgpuShaderModuleGetCompilationInfo,
+			.wgpu_shader_module_set_label = wgpuShaderModuleSetLabel,
+			.wgpu_shader_module_reference = wgpuShaderModuleReference,
+			.wgpu_shader_module_release = wgpuShaderModuleRelease,
 
-		// Surface
-		wgpu_exports_table.wgpu_surface_configure = wgpuSurfaceConfigure;
-		wgpu_exports_table.wgpu_surface_get_capabilities = wgpuSurfaceGetCapabilities;
-		wgpu_exports_table.wgpu_surface_get_current_texture = wgpuSurfaceGetCurrentTexture;
-		wgpu_exports_table.wgpu_surface_get_preferred_format = wgpuSurfaceGetPreferredFormat;
-		wgpu_exports_table.wgpu_surface_present = wgpuSurfacePresent;
-		wgpu_exports_table.wgpu_surface_unconfigure = wgpuSurfaceUnconfigure;
-		wgpu_exports_table.wgpu_surface_reference = wgpuSurfaceReference;
-		wgpu_exports_table.wgpu_surface_release = wgpuSurfaceRelease;
+			// Surface
+			.wgpu_surface_configure = wgpuSurfaceConfigure,
+			.wgpu_surface_get_capabilities = wgpuSurfaceGetCapabilities,
+			.wgpu_surface_get_current_texture = wgpuSurfaceGetCurrentTexture,
+			.wgpu_surface_get_preferred_format = wgpuSurfaceGetPreferredFormat,
+			.wgpu_surface_present = wgpuSurfacePresent,
+			.wgpu_surface_unconfigure = wgpuSurfaceUnconfigure,
+			.wgpu_surface_reference = wgpuSurfaceReference,
+			.wgpu_surface_release = wgpuSurfaceRelease,
 
-		// SurfaceCapabilities
-		wgpu_exports_table.wgpu_surface_capabilities_free_members = wgpuSurfaceCapabilitiesFreeMembers;
+			// SurfaceCapabilities
+			.wgpu_surface_capabilities_free_members = wgpuSurfaceCapabilitiesFreeMembers,
 
-		// Texture
-		wgpu_exports_table.wgpu_texture_create_view = wgpuTextureCreateView;
-		wgpu_exports_table.wgpu_texture_destroy = wgpuTextureDestroy;
-		wgpu_exports_table.wgpu_texture_get_depth_or_array_layers = wgpuTextureGetDepthOrArrayLayers;
-		wgpu_exports_table.wgpu_texture_get_dimension = wgpuTextureGetDimension;
-		wgpu_exports_table.wgpu_texture_get_format = wgpuTextureGetFormat;
-		wgpu_exports_table.wgpu_texture_get_height = wgpuTextureGetHeight;
-		wgpu_exports_table.wgpu_texture_get_mip_level_count = wgpuTextureGetMipLevelCount;
-		wgpu_exports_table.wgpu_texture_get_sample_count = wgpuTextureGetSampleCount;
-		wgpu_exports_table.wgpu_texture_get_usage = wgpuTextureGetUsage;
-		wgpu_exports_table.wgpu_texture_get_width = wgpuTextureGetWidth;
-		wgpu_exports_table.wgpu_texture_set_label = wgpuTextureSetLabel;
-		wgpu_exports_table.wgpu_texture_reference = wgpuTextureReference;
-		wgpu_exports_table.wgpu_texture_release = wgpuTextureRelease;
+			// Texture
+			.wgpu_texture_create_view = wgpuTextureCreateView,
+			.wgpu_texture_destroy = wgpuTextureDestroy,
+			.wgpu_texture_get_depth_or_array_layers = wgpuTextureGetDepthOrArrayLayers,
+			.wgpu_texture_get_dimension = wgpuTextureGetDimension,
+			.wgpu_texture_get_format = wgpuTextureGetFormat,
+			.wgpu_texture_get_height = wgpuTextureGetHeight,
+			.wgpu_texture_get_mip_level_count = wgpuTextureGetMipLevelCount,
+			.wgpu_texture_get_sample_count = wgpuTextureGetSampleCount,
+			.wgpu_texture_get_usage = wgpuTextureGetUsage,
+			.wgpu_texture_get_width = wgpuTextureGetWidth,
+			.wgpu_texture_set_label = wgpuTextureSetLabel,
+			.wgpu_texture_reference = wgpuTextureReference,
+			.wgpu_texture_release = wgpuTextureRelease,
 
-		// TextureView
-		wgpu_exports_table.wgpu_texture_view_set_label = wgpuTextureViewSetLabel;
-		wgpu_exports_table.wgpu_texture_view_reference = wgpuTextureViewReference;
-		wgpu_exports_table.wgpu_texture_view_release = wgpuTextureViewRelease;
+			// TextureView
+			.wgpu_texture_view_set_label = wgpuTextureViewSetLabel,
+			.wgpu_texture_view_reference = wgpuTextureViewReference,
+			.wgpu_texture_view_release = wgpuTextureViewRelease,
 
-		// Native wgpu extensions (from wgpu.h)
-		wgpu_exports_table.wgpu_generate_report = wgpuGenerateReport;
-		wgpu_exports_table.wgpu_instance_enumerate_adapters = wgpuInstanceEnumerateAdapters;
-		wgpu_exports_table.wgpu_queue_submit_for_index = wgpuQueueSubmitForIndex;
-		wgpu_exports_table.wgpu_device_poll = wgpuDevicePoll;
-		wgpu_exports_table.wgpu_set_log_callback = wgpuSetLogCallback;
-		wgpu_exports_table.wgpu_set_log_level = wgpuSetLogLevel;
-		wgpu_exports_table.wgpu_get_version = wgpuGetVersion;
-		wgpu_exports_table.wgpu_render_pass_encoder_set_push_constants = wgpuRenderPassEncoderSetPushConstants;
-		wgpu_exports_table.wgpu_render_pass_encoder_multi_draw_indirect = wgpuRenderPassEncoderMultiDrawIndirect;
-		wgpu_exports_table.wgpu_render_pass_encoder_multi_draw_indexed_indirect = wgpuRenderPassEncoderMultiDrawIndexedIndirect;
-		wgpu_exports_table.wgpu_render_pass_encoder_multi_draw_indirect_count = wgpuRenderPassEncoderMultiDrawIndirectCount;
-		wgpu_exports_table.wgpu_render_pass_encoder_multi_draw_indexed_indirect_count = wgpuRenderPassEncoderMultiDrawIndexedIndirectCount;
-		wgpu_exports_table.wgpu_compute_pass_encoder_begin_pipeline_statistics_query = wgpuComputePassEncoderBeginPipelineStatisticsQuery;
-		wgpu_exports_table.wgpu_compute_pass_encoder_end_pipeline_statistics_query = wgpuComputePassEncoderEndPipelineStatisticsQuery;
-		wgpu_exports_table.wgpu_render_pass_encoder_begin_pipeline_statistics_query = wgpuRenderPassEncoderBeginPipelineStatisticsQuery;
-		wgpu_exports_table.wgpu_render_pass_encoder_end_pipeline_statistics_query = wgpuRenderPassEncoderEndPipelineStatisticsQuery;
+			// Native wgpu extensions (from wgpu.h)
+			.wgpu_generate_report = wgpuGenerateReport,
+			.wgpu_instance_enumerate_adapters = wgpuInstanceEnumerateAdapters,
+			.wgpu_queue_submit_for_index = wgpuQueueSubmitForIndex,
+			.wgpu_device_poll = wgpuDevicePoll,
+			.wgpu_set_log_callback = wgpuSetLogCallback,
+			.wgpu_set_log_level = wgpuSetLogLevel,
+			.wgpu_get_version = wgpuGetVersion,
+			.wgpu_render_pass_encoder_set_push_constants = wgpuRenderPassEncoderSetPushConstants,
+			.wgpu_render_pass_encoder_multi_draw_indirect = wgpuRenderPassEncoderMultiDrawIndirect,
+			.wgpu_render_pass_encoder_multi_draw_indexed_indirect = wgpuRenderPassEncoderMultiDrawIndexedIndirect,
+			.wgpu_render_pass_encoder_multi_draw_indirect_count = wgpuRenderPassEncoderMultiDrawIndirectCount,
+			.wgpu_render_pass_encoder_multi_draw_indexed_indirect_count = wgpuRenderPassEncoderMultiDrawIndexedIndirectCount,
+			.wgpu_compute_pass_encoder_begin_pipeline_statistics_query = wgpuComputePassEncoderBeginPipelineStatisticsQuery,
+			.wgpu_compute_pass_encoder_end_pipeline_statistics_query = wgpuComputePassEncoderEndPipelineStatisticsQuery,
+			.wgpu_render_pass_encoder_begin_pipeline_statistics_query = wgpuRenderPassEncoderBeginPipelineStatisticsQuery,
+			.wgpu_render_pass_encoder_end_pipeline_statistics_query = wgpuRenderPassEncoderEndPipelineStatisticsQuery,
 
-		return &wgpu_exports_table;
+		};
+
+		return &exports;
 	}
 }


### PR DESCRIPTION
This should help with missing pointer assignments and excessive verbosity of the initialization code.