### PR TITLE
Add a new CI step for running the benchmark scripts to all build workflows

### DIFF
--- a/.github/run-all-benchmarks.lua
+++ b/.github/run-all-benchmarks.lua
@@ -1,0 +1,8 @@
+local transform = require("transform")
+
+local availableBenchmarks = C_FileSystem.ReadDirectoryTree("Benchmarks")
+for fileSystemPath, _ in pairs(availableBenchmarks) do
+	printf("Running benchmark: %s", transform.brightMagenta(fileSystemPath))
+	dofile(fileSystemPath)
+	print()
+end

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -121,6 +121,9 @@ jobs:
       - name: Run integration tests
         run: xvfb-run evo Tests/integration-test.lua
 
+      - name: Run benchmarks
+        run: evo .github/run-all-benchmarks.lua
+
       - name: Prepare artifacts
         run: cp evo evo-linux-x64
 

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Run integration tests
         run: evo Tests/integration-test.lua
 
+      - name: Run benchmarks
+        run: evo .github/run-all-benchmarks.lua
+
       - name: Prepare artifacts
         run: cp evo evo-macos-${{ matrix.arch }}
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Run integration tests
         run: evo Tests/integration-test.lua
 
+      - name: Run benchmarks
+        run: evo .github/run-all-benchmarks.lua
+
       # GitHub adds a heading of their own, so remove the duplicate
       - name: Generate CHANGELOG.MD
         run: evo create-changelog.lua && tail -n +3 CHANGELOG.MD > CHANGELOG-GITHUB.MD && mv CHANGELOG-GITHUB.MD CHANGELOG.MD


### PR DESCRIPTION
This doesn't actually check the benchmark results, which would be neat, but even so they can serve as another layer of tests.