### PR TITLE
Fix a perpetually-running timer in the webview tests

### DIFF
--- a/Tests/BDD/webview-library.spec.lua
+++ b/Tests/BDD/webview-library.spec.lua
@@ -57,6 +57,7 @@ describe("webview", function()
 					if numUpdates == 6 then
 						uv.stop()
 						-- Should destroy view here, but it's shared
+						guiUpdateTimer:stop()
 					end
 				end)
 


### PR DESCRIPTION
Yet another oversight that's only been uncovered now (same problem as #534).