### PR TITLE
Replace a hardcoded error message for async reads

### DIFF
--- a/Runtime/API/FileSystem/AsyncFileReader.lua
+++ b/Runtime/API/FileSystem/AsyncFileReader.lua
@@ -62,7 +62,7 @@ function AsyncFileReader:FILE_STATUS_AVAILABLE(event, payload)
 	if payload.stat.type == "directory" then
 		-- On Windows, read requests on directories succeed without returning any data
 		-- Simulating the error returned on other platforms here allows providing a consistent interface
-		payload.errorMessage = "EISDIR: illegal operation on a directory" -- Should use uv_strerror but it isn't currently bound
+		payload.errorMessage = uv.translate_sys_error(uv.errno.EISDIR)
 		EVENT("FILE_REQUEST_FAILED", payload)
 		return
 	end


### PR DESCRIPTION
I was under the impression that `uv.strerror` isn't part of the bindings, which is technically correct.

However, there is a function to look up the error string already, so hard-coding the value isn't necessary here.