### PR TITLE
Fix the default checksum for miniz.adler32

### DIFF
--- a/Runtime/Bindings/lminiz.cpp
+++ b/Runtime/Bindings/lminiz.cpp
@@ -367,7 +367,9 @@ static int ltdefl(lua_State* L) {
 }
 
 static int lmz_adler32(lua_State* L) {
-	mz_ulong adler = luaL_optinteger(L, 2, 0);
+	constexpr auto DEFAULT_ADLER32_CHECKSUM = 1; // A is the sum of all bytes in the stream (here: zero) plus one
+	mz_ulong adler = luaL_optinteger(L, 2, DEFAULT_ADLER32_CHECKSUM);
+
 	size_t buf_len = 0;
 	const unsigned char* ptr = reinterpret_cast<const unsigned char*>(luaL_optlstring(L, 1, NULL, &buf_len));
 	adler = mz_adler32(adler, ptr, buf_len);

--- a/Tests/BDD/miniz-library.spec.lua
+++ b/Tests/BDD/miniz-library.spec.lua
@@ -65,6 +65,12 @@ describe("miniz", function()
 
 			assertEquals(checksum1, checksum2)
 		end)
+
+		it("should initialize the checksum with one if none was passed", function()
+			-- See https://github.com/luvit/luvi/pull/294)
+			local checksum = miniz.adler32("Wikipedia", nil)
+			assertEquals(checksum, 300286872) -- 0x11E60398
+		end)
 	end)
 
 	describe("crc32", function()


### PR DESCRIPTION
Reported and fixed in the upstream bindings by Bilal Bassam.