### PR TITLE
Always apply +x to self-contained executables after they've been built

### DIFF
--- a/Runtime/evo.lua
+++ b/Runtime/evo.lua
@@ -394,6 +394,7 @@ function evo.buildZipApp(commandName, argv)
 		.. zipFileContents
 		.. ffi.string(signature, ffi.sizeof(signature))
 	C_FileSystem.WriteFile(outputFileName, standaloneExecutableBytes)
+	uv.fs_chmod(outputFileName, tonumber("775", 8)) -- No-op on Windows, but that's OK
 	printf("Created self-contained executable: %s", transform.brightYellow(outputFileName))
 end
 

--- a/Tests/snapshot-test.lua
+++ b/Tests/snapshot-test.lua
@@ -400,8 +400,7 @@ testCases = {
 	-- This relies on the hello-world-app being built first, but the order is not guaranteed
 	["cli-hello-world-app"] = {
 		humanReadableDescription = "Invoking the hello world app should execute the bundled app instead of the runtime CLI with the provided args",
-		programToRun = ffi.os ~= "Windows" and "chmod +x hello-world-app && ./hello-world-app hi"
-			or "hello-world-app.exe hi",
+		programToRun = ffi.os ~= "Windows" and "./hello-world-app hi" or "hello-world-app.exe hi",
 		onExit = function(observedOutput, status, terminationReason, exitCodeOrSignalID)
 			assertEquals(observedOutput, "Hello world!\n")
 			assertExitSuccess(observedOutput, status, terminationReason, exitCodeOrSignalID)


### PR DESCRIPTION
It's not difficult to do this by hand, but rather annoying (especially when testing).