### PR TITLE
Add a vfs.extract function to more easily load asset files from within LUAZIP apps

### DIFF
--- a/Runtime/Libraries/vfs.lua
+++ b/Runtime/Libraries/vfs.lua
@@ -78,6 +78,21 @@ function vfs.dofile(zipApp, filePath)
 	return nil, "Failed to load file " .. filePath .. " (no such entry exists)"
 end
 
+function vfs.extract(zipApp, filePath)
+	validation.validateTable(zipApp, "zipApp")
+	validation.validateString(filePath, "filePath")
+
+	local reader = zipApp.reader
+	for index = 1, reader:get_num_files() do
+		if reader:get_filename(index) == filePath then
+			local fileContents = reader:extract(index)
+			return fileContents
+		end
+	end
+
+	return nil, "Failed to extract file " .. filePath .. " (no such entry exists)"
+end
+
 -- VFS searcher: Allow require to find files stored in the VFS of LUAZIP apps
 -- See https://www.lua.org/manual/5.2/manual.html#pdf-package.searchers
 function vfs.searcher(zipApp, moduleName)


### PR DESCRIPTION
It's handy for non-executable files, such as shader programs (my use case) or shared libraries which need to be FFI-loaded. The latter should ideally be loaded from the VFS directly, but that's still a bit off in the future. This is a first step in the general direction.