### PR TITLE
Add a missing nil test case for validateString

### DIFF
--- a/Tests/SmokeTests/validation-library/test-validate-string.lua
+++ b/Tests/SmokeTests/validation-library/test-validate-string.lua
@@ -3,6 +3,13 @@ local ffi = require("ffi")
 local validation = require("validation")
 local validateString = validation.validateString
 
+local function testNilValueCase()
+	local nothing = nil
+	assertThrows(function()
+		validateString(nothing, "nothing")
+	end, "Expected argument nothing to be a string value, but received a nil value instead")
+end
+
 local function testStringValueCase()
 	local str = "hello"
 	assertDoesNotThrow(function()
@@ -53,6 +60,7 @@ local function testStructCase()
 end
 
 local function testValidateString()
+	testNilValueCase()
 	testStringValueCase()
 	testNumberValueCase()
 	testBooleanValueCase()


### PR DESCRIPTION
Not that it matters much, but I did run into a silly bug recently that had me question my sanity for a bit...

I then created this test case, only to find out I swapped a parameter, so the validation always worked. Can't hurt to keep the test, though, given that not having one left open the possibility of a bug in the validation - however unlikely.