### PR TITLE
Fix clang-format inconsistencies for different SpaceInEmptyBlock settings

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -115,7 +115,7 @@ SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: false
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyBlock: true
+SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles:  false

--- a/Runtime/Bindings/FFI/WebServer.hpp
+++ b/Runtime/Bindings/FFI/WebServer.hpp
@@ -43,7 +43,7 @@ struct DeferredEvent {
 	DeferredEvent(Type type, std::string clientID, std::string payload)
 		: type(type)
 		, clientID(std::move(clientID))
-		, payload(std::move(payload)) { }
+		, payload(std::move(payload)) {}
 };
 
 // Template parameters: isUsingSSL

--- a/Runtime/Bindings/rapidjson.hpp
+++ b/Runtime/Bindings/rapidjson.hpp
@@ -37,7 +37,7 @@ using namespace rapidjson;
 struct Key {
 	Key(const char* k, SizeType l)
 		: key(k)
-		, size(l) { }
+		, size(l) {}
 	bool operator<(const Key& rhs) const {
 		return strcmp(key, rhs.key) < 0;
 	}


### PR DESCRIPTION
It seems that this is applied differently in the latest Homebrew release, which is one major version ahead of the MSYS2 release.

Regardless of why the inconsistency exists in the first place, adding spaces isn't desirable so this setting should always be disabled.