### PR TITLE
Enable parallel builds for LuaJIT

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -50,6 +50,10 @@ jobs:
       - name: Install Ninja
         run: brew install ninja
 
+        # nproc is used by build scripts to determine the number of parallel jobs
+      - name: Install GNU coreutils
+        run: brew install coreutils
+
       - name: Configure environment
         run: |
           echo "CC=ccache gcc" >> $GITHUB_ENV
@@ -71,10 +75,6 @@ jobs:
 
       - name: Build miniz
         run: deps/miniz-unixbuild.sh && ls ninjabuild-unix
-
-      # Building OpenSSL is extremely slow, so nproc is used to determine the number of parallel jobs
-      - name: Install GNU coreutils
-        run: brew install coreutils
 
       - name: Build openssl
         run: deps/openssl-unixbuild.sh && ls ninjabuild-unix

--- a/deps/luajit-unixbuild.sh
+++ b/deps/luajit-unixbuild.sh
@@ -1,6 +1,8 @@
 set -e
 
-echo Building target luajit
+NUM_PARALLEL_JOBS=$(nproc)
+
+echo "Building target luajit with $NUM_PARALLEL_JOBS jobs"
 
 LUAJIT_DIR=deps/LuaJIT/LuaJIT
 LUAJIT_SOURCE_DIR=$LUAJIT_DIR/src
@@ -11,7 +13,7 @@ mkdir -p $BUILD_DIR/jit
 cd $LUAJIT_DIR
 
 make clean
-make BUILDMODE=static XCFLAGS=-DLUAJIT_ENABLE_LUA52COMPAT
+make  -j $NUM_PARALLEL_JOBS BUILDMODE=static XCFLAGS=-DLUAJIT_ENABLE_LUA52COMPAT
 
 cd -
 

--- a/deps/luajit-windowsbuild.sh
+++ b/deps/luajit-windowsbuild.sh
@@ -1,6 +1,8 @@
 set -e
 
-echo Building target luajit
+# Beware, the magic Windows globals... This should work on all relevant systems, though?
+NUM_PARALLEL_JOBS=$NUMBER_OF_PROCESSORS
+echo "Building target luajit with $NUM_PARALLEL_JOBS jobs"
 
 LUAJIT_DIR=deps/LuaJIT/LuaJIT
 LUAJIT_SOURCE_DIR=$LUAJIT_DIR/src
@@ -11,7 +13,7 @@ mkdir -p $BUILD_DIR/jit
 cd $LUAJIT_DIR
 
 make clean
-make BUILDMODE=static XCFLAGS=-DLUAJIT_ENABLE_LUA52COMPAT
+make  -j $NUM_PARALLEL_JOBS BUILDMODE=static XCFLAGS=-DLUAJIT_ENABLE_LUA52COMPAT
 
 cd -
 


### PR DESCRIPTION
Pretty silly oversight. Using 8 jobs saves 16 seconds on my system.