### PR TITLE
Strip GDB debug symbols from generated object files

### DIFF
--- a/BuildTools/NinjaBuildTools.lua
+++ b/BuildTools/NinjaBuildTools.lua
@@ -6,7 +6,7 @@ local isWindows = (ffi.os == "Windows")
 local isMacOS = (ffi.os == "OSX")
 
 local GCC_RELEASE_FLAGS = "-O3 -DNDEBUG"
-local GCC_DEBUG_FLAGS = "-g" -- For better stack traces
+local GCC_DEBUG_FLAGS = "" -- None, for now (add -g -ggdb here as needed)
 local GCC_DIAGNOSTICS_FLAGS =
 	"-Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -fvisibility=hidden -fno-strict-aliasing -fdiagnostics-color -Wfatal-errors"
 local DEFAULT_COMPILER_FLAGS = format("%s %s %s", GCC_RELEASE_FLAGS, GCC_DEBUG_FLAGS, GCC_DIAGNOSTICS_FLAGS)


### PR DESCRIPTION
I don't know why this is here, but it doesn't make much sense. If a SEGFAULT in the runtime layer needs to be debugged, developers can add it manually. And if there's a crash in LuaJIT itself, then the symbols aren't going to help anyway. Setting the -g flag for bcsave should be sufficient and takes up much less space in comparison, while enabling readable stack traces.

The GDB symbols increase the binary size by a whopping 10 MB, which certainly doesn't seem desirable. Time for a diet!
