### PR TITLE
Enable use of the preinstalled MSYS2 version for Windows builds (and autoformat runs)

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -27,6 +27,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           install: git mingw-w64-x86_64-clang
+          release: false # Use version from runner images to reduce build times
 
       - name: Disable autocrlf # Messes up everything on Windows since the formatter applies \n
         run: |

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -38,6 +38,7 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           install: git make mingw-w64-x86_64-gcc ninja mingw-w64-x86_64-cmake mingw-w64-x86_64-rust
+          release: false # Use version from runner images to reduce build times
 
       - name: Disable autocrlf # Messes up everything on Windows since the formatter applies \n
         run: |


### PR DESCRIPTION
Not sure how much of a difference it will make. Presumably, don't really need to install MSYS from scratch every time?