### PR TITLE
Enable caching for build artifacts in the Windows release workflow

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up MSYS2 environment
         uses: msys2/setup-msys2@v2
         with:
-          install: git make mingw-w64-x86_64-gcc ninja mingw-w64-x86_64-cmake mingw-w64-x86_64-rust
+          install: git make mingw-w64-x86_64-gcc ninja mingw-w64-x86_64-cmake
 
       - name: Disable autocrlf # Messes up everything on Windows since the formatter applies \n
         run: |
@@ -64,6 +64,51 @@ jobs:
           echo "CC=${SCCACHE_UNIX_PATH} gcc" >> $GITHUB_ENV
           echo "CXX=${SCCACHE_UNIX_PATH} g++" >> $GITHUB_ENV
 
+      - name: Get submodule versions
+        id: revparse
+        run: |
+          echo "openssl=$(git rev-parse HEAD:deps/openssl/openssl)" >> $GITHUB_OUTPUT
+          echo "wgpu=$(git rev-parse HEAD:deps/gfx-rs/wgpu-native)" >> $GITHUB_OUTPUT
+          echo "rml=$(git rev-parse HEAD:deps/mikke89/RmlUi)" >> $GITHUB_OUTPUT
+          echo "labsound=$(git rev-parse HEAD:deps/LabSound/LabSound)" >> $GITHUB_OUTPUT
+          echo "luajit=$(git rev-parse HEAD:deps/LuaJIT/LuaJIT)" >> $GITHUB_OUTPUT
+
+      - name: Cache OpenSSL
+        id: cache-openssl
+        uses: actions/cache@v4
+        with:
+          path: |
+            ninjabuild-windows/libcrypto.a
+            ninjabuild-windows/libssl.a
+          key: openssl-${{ steps.revparse.outputs.openssl }}-${{ hashFiles('deps/openssl-windowsbuild.sh') }}-${{ runner.os }}
+
+      - name: Cache wgpu-native
+        id: cache-wgpu
+        uses: actions/cache@v4
+        with:
+          path: ninjabuild-windows/libwgpu_native.a
+          key: wgpu-${{ steps.revparse.outputs.wgpu }}-${{ hashFiles('deps/wgpu-windowsbuild.sh') }}-${{ runner.os }}
+
+      - name: Cache RML and FreeType
+        id: cache-rml
+        uses: actions/cache@v4
+        with:
+          path: |
+            ninjabuild-windows/libfreetype.a
+            ninjabuild-windows/librmlui.a
+            ninjabuild-windows/librmlui_lua.a
+          key: rml-${{ steps.revparse.outputs.rml }}-freetype-${{ steps.revparse.outputs.freetype }}-${{ steps.revparse.outputs.luajit }}-${{ hashFiles('deps/rml-windowsbuild.sh', 'deps/luajit-windowsbuild.sh') }}-${{ runner.os }}
+
+      - name: Cache LabSound
+        id: cache-labsound
+        uses: actions/cache@v4
+        with:
+          path: |
+            ninjabuild-windows/libLabSound.a
+            ninjabuild-windows/libLabSoundRtAudio.a
+            ninjabuild-windows/libnyquist.a
+          key: labsound-${{ steps.revparse.outputs.labsound }}-${{ hashFiles('deps/labsound-windowsbuild.sh') }}-${{ runner.os }}
+
       - name: Start Windows Audio engine # Required for LabSound tests
         run: net start audiosrv
 
@@ -77,7 +122,11 @@ jobs:
         run: deps/luajit-windowsbuild.sh && ls ninjabuild-windows
 
       - name: Build wgpu
-        run: deps/wgpu-windowsbuild.sh && ls ninjabuild-windows
+        if: steps.cache-wgpu.outputs.cache-hit != 'true'
+        run: |
+          pacman -S mingw-w64-x86_64-rust --noconfirm
+          deps/wgpu-windowsbuild.sh
+          ls ninjabuild-windows
 
       - name: Build luv and libuv
         run: deps/luv-windowsbuild.sh && ls ninjabuild-windows
@@ -92,6 +141,7 @@ jobs:
         run: deps/rapidjson-windowsbuild.sh && ls ninjabuild-windows
 
       - name: Build openssl
+        if: steps.cache-openssl.outputs.cache-hit != 'true'
         run: deps/openssl-windowsbuild.sh && ls ninjabuild-windows
 
       - name: Build lua-openssl
@@ -107,9 +157,11 @@ jobs:
         run: deps/uws-windowsbuild.sh && ls ninjabuild-windows
 
       - name: Build RmlUI with FreeType
+        if: steps.cache-rml.outputs.cache-hit != 'true'
         run: deps/rml-windowsbuild.sh && ls ninjabuild-windows
 
       - name: Build LabSound
+        if: steps.cache-labsound.outputs.cache-hit != 'true'
         run: deps/labsound-windowsbuild.sh && ls ninjabuild-windows
 
       - name: Build runtime

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -122,7 +122,7 @@ jobs:
         run: deps/luajit-windowsbuild.sh && ls ninjabuild-windows
 
       - name: Build wgpu
-        if: steps.cache-wgpu.outputs.cache-hit != 'true'
+        if: steps.cache-wgpu.outputs.cache-hit != 'true' || startsWith(github.ref, 'refs/tags/')
         run: |
           pacman -S mingw-w64-x86_64-rust --noconfirm
           deps/wgpu-windowsbuild.sh
@@ -141,7 +141,7 @@ jobs:
         run: deps/rapidjson-windowsbuild.sh && ls ninjabuild-windows
 
       - name: Build openssl
-        if: steps.cache-openssl.outputs.cache-hit != 'true'
+        if: steps.cache-openssl.outputs.cache-hit != 'true' || startsWith(github.ref, 'refs/tags/')
         run: deps/openssl-windowsbuild.sh && ls ninjabuild-windows
 
       - name: Build lua-openssl
@@ -157,11 +157,11 @@ jobs:
         run: deps/uws-windowsbuild.sh && ls ninjabuild-windows
 
       - name: Build RmlUI with FreeType
-        if: steps.cache-rml.outputs.cache-hit != 'true'
+        if: steps.cache-rml.outputs.cache-hit != 'true' || startsWith(github.ref, 'refs/tags/')
         run: deps/rml-windowsbuild.sh && ls ninjabuild-windows
 
       - name: Build LabSound
-        if: steps.cache-labsound.outputs.cache-hit != 'true'
+        if: steps.cache-labsound.outputs.cache-hit != 'true' || startsWith(github.ref, 'refs/tags/')
         run: deps/labsound-windowsbuild.sh && ls ninjabuild-windows
 
       - name: Build runtime


### PR DESCRIPTION
This brings down the time for (cached) Windows to about the same level as uncached macOS and Linux builds.

Before: 17 to 20 minutes for a full rebuild - macOS and Linux may take between 6 and 8 minutes in comparison
After: Full rebuild unchanged, but subsequent CI runs should no longer be bottle-necked by the Windows build time

The `sccache` setup is complimentary; it didn't seem to have much of an effect but there's no reason to disable it either.

*(For more info on the rationale for individual changes, see the design notes below)*

---

Invalidation strategy: Submodule versions, build scripts, and where applicable, build-time dependencies (mostly LuaJIT).

Potential issues:

1. Desync between deps and build tools: Not a problem as build scripts have no side effects/build config is independent
2. Caching artifacts could cause issues if the invalidation strategy isn't sound: That's why I kept it as simple as possible
3. Cache size is limited, eviction strategy may be less than ideal: Unlikely to matter, can look into it later if needed?
4. Changing the build system significantly means updating all the cache steps as well: Not planned anytime soon, whatever?
5. If there's an issue and a tagged Windows release is borked, that'd be VERY bad: Disable caching for tags to be safe?

The time savings appear to be significant when caching the largest bottlenecks (times are for Windows runners):

* OpenSSL: Up to 5 minutes saved (!!)
* WebGPU: Up to 3 minutes saved (!); can also defer installing the MSYS2 Rust toolchain to save
* RML/FreeType and LabSound: Saves about 30-45 seconds for each - still worth it
* LuaJIT/libuv/luv: Might save another minute or so by caching them, but there are too many moving pieces

Didn't bother with the rest, nor with caching macOS/Linux runs at this time (Amdahl's law). Maybe later?