### PR TITLE
Update all third-party actions to their latest version

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Publish new release
         # Truly "continuous" releases may be overkill here, so better only release tagged versions
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: evo-linux-x64
           body_path: CHANGELOG.MD

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Publish new release
         # Truly "continuous" releases may be overkill here, so better only release tagged versions
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: evo-macos-${{ matrix.arch }}
           body_path: CHANGELOG.MD

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: "0" # Required so that git describe actually works (and we can embed the version tag)
 
       - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Download Webview2 SDK
         run: deps/fetch-mswebview2.sh && ls ninjabuild-windows
@@ -195,7 +195,7 @@ jobs:
       - name: Publish new release
         # Truly "continuous" releases may be overkill here, so better only release tagged versions
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: evo.exe
           body_path: CHANGELOG.MD

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -101,13 +101,13 @@ jobs:
           output: sarif-results/${{ matrix.language }}.sarif
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: sarif-results/${{ matrix.language }}.sarif
           category: "/language:${{matrix.language}}"
 
       - name: Upload analysis results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sarif-results
           path: sarif-results


### PR DESCRIPTION
Finding uses of third-party actions:

```sh
clear && grep -r "uses:" -i .github | sort  
```

Results:

```sh
.github/workflows/autoformat.yml:        uses: actions/cache@v4
.github/workflows/autoformat.yml:        uses: actions/checkout@v4
.github/workflows/ci-linux.yml:        uses: actions/checkout@v4
.github/workflows/ci-linux.yml:        uses: hendrikmuhs/ccache-action@v1.2
.github/workflows/ci-linux.yml:        uses: softprops/action-gh-release@v1
.github/workflows/ci-mac.yml:        uses: actions/checkout@v4
.github/workflows/ci-mac.yml:        uses: hendrikmuhs/ccache-action@v1.2
.github/workflows/ci-mac.yml:        uses: softprops/action-gh-release@v1
.github/workflows/ci-windows.yml:        uses: actions/cache@v4
.github/workflows/ci-windows.yml:        uses: actions/cache@v4
.github/workflows/ci-windows.yml:        uses: actions/cache@v4
.github/workflows/ci-windows.yml:        uses: actions/cache@v4
.github/workflows/ci-windows.yml:        uses: actions/checkout@v4
.github/workflows/ci-windows.yml:        uses: LABSN/sound-ci-helpers@v1
.github/workflows/ci-windows.yml:        uses: mozilla-actions/sccache-action@v0.0.6
.github/workflows/ci-windows.yml:        uses: msys2/setup-msys2@v2
.github/workflows/ci-windows.yml:        uses: softprops/action-gh-release@v1
.github/workflows/codeql.yml:        uses: actions/checkout@v4
.github/workflows/codeql.yml:        uses: actions/upload-artifact@v3
.github/workflows/codeql.yml:        uses: advanced-security/filter-sarif@v1
.github/workflows/codeql.yml:        uses: github/codeql-action/analyze@v3
.github/workflows/codeql.yml:        uses: github/codeql-action/init@v3
.github/workflows/codeql.yml:        uses: github/codeql-action/upload-sarif@v2
.github/workflows/codeql.yml:        uses: hendrikmuhs/ccache-action@v1.2
.github/workflows/static-analysis.yml:        uses: actions/checkout@v4
```

No breaking changes, AFACT.