### PR TITLE
Enable auto-generated build summaries for CI workflow runs

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -210,8 +210,8 @@ jobs:
           echo "**Build Time:** ${BUILD_TIME} seconds" >> $GITHUB_STEP_SUMMARY
           echo "**Build Date:** $(date)" >> $GITHUB_STEP_SUMMARY
           echo "**Branch:** ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
-          echo "## Changelog" >> $GITHUB_STEP_SUMMARY
-          tail -n +3 CHANGELOG.MD >> $GITHUB_STEP_SUMMARY
+          echo "## Changelog\n\n" >> $GITHUB_STEP_SUMMARY
+          cat CHANGELOG.MD >> $GITHUB_STEP_SUMMARY
           BUILD_TIME=$(($(date +%s) - ${{ github.event.workflow_run.created_at }}))
 
 # TODO publish artifacts (changelog/build summary/logs?)

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -204,6 +204,17 @@ jobs:
           name: CHANGELOG-PREVIEW-LINUX.MD
           path: CHANGELOG.MD
         
+      - name: Generate build summary
+        run: |
+          echo "## Build Stats" >> $GITHUB_STEP_SUMMARY
+          echo "**Build Time:** ${BUILD_TIME} seconds" >> $GITHUB_STEP_SUMMARY
+          echo "**Build Date:** $(date)" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:** ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "## Changelog" >> $GITHUB_STEP_SUMMARY
+          tail -n +3 CHANGELOG.MD >> $GITHUB_STEP_SUMMARY
+          BUILD_TIME=$(($(date +%s) - ${{ github.event.workflow_run.created_at }}))
+
+# TODO publish artifacts (changelog/build summary/logs?)
 
       - name: Publish new release
         # Truly "continuous" releases may be overkill here, so better only release tagged versions

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -198,16 +198,16 @@ jobs:
         # TBD upload as artifact? same as the executable, and possibly libs (DLL only)
 
 # TBD upload binary as well? review storage quotas first...
-      - name: Upload CHANGELOG.MD preview
-        uses: actions/upload-artifact@v4
-        with:
-          name: CHANGELOG-PREVIEW-LINUX.MD
-          path: CHANGELOG.MD
+      # - name: Upload CHANGELOG.MD preview
+        # uses: actions/upload-artifact@v4
+        # with:
+          # name: CHANGELOG-PREVIEW-LINUX.MD
+          # path: CHANGELOG.MD
         
       - name: Generate build summary
         run: |
           echo "## Context" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** ${{ github.ref_name }} (${{ github.ref }})" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:**  $(git branch --show-current) (${{ github.ref }})" >> $GITHUB_STEP_SUMMARY
           echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
           BUILD_TIME=$(($(date +%s) - ${{ github.event.workflow_run.created_at }}))
           echo "**Build Time:** ${BUILD_TIME} seconds" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -207,12 +207,12 @@ jobs:
       - name: Generate build summary
         run: |
           echo "## Build Stats" >> $GITHUB_STEP_SUMMARY
+          BUILD_TIME=$(($(date +%s) - ${{ github.event.workflow_run.created_at }}))
           echo "**Build Time:** ${BUILD_TIME} seconds" >> $GITHUB_STEP_SUMMARY
           echo "**Build Date:** $(date)" >> $GITHUB_STEP_SUMMARY
           echo "**Branch:** ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
           echo "## Changelog\n\n" >> $GITHUB_STEP_SUMMARY
           cat CHANGELOG.MD >> $GITHUB_STEP_SUMMARY
-          BUILD_TIME=$(($(date +%s) - ${{ github.event.workflow_run.created_at }}))
 
 # TODO publish artifacts (changelog/build summary/logs?)
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -211,6 +211,18 @@ jobs:
           echo "**Build Time:** ${BUILD_TIME} seconds" >> $GITHUB_STEP_SUMMARY
           echo "**Build Date:** $(date)" >> $GITHUB_STEP_SUMMARY
           echo "**Branch:** ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.cache-openssl.outputs.cache-hit }}" == 'true' ]; then
+            echo "- **OpenSSL:** Cache hit" >> $GITHUB_STEP_SUMMARY
+            echo "  Cache key: openssl-${{ steps.revparse.outputs.openssl }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- **OpenSSL:** Cache miss, rebuilt" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ steps.cache-wgpu.outputs.cache-hit }}" == 'true' ]; then
+            echo "- **WGPU:** Cache hit" >> $GITHUB_STEP_SUMMARY
+            echo "  Cache key: wgpu-${{ steps.revparse.outputs.wgpu }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- **WGPU:** Cache miss, rebuilt" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "## Changelog\n\n" >> $GITHUB_STEP_SUMMARY
           cat CHANGELOG.MD >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -206,24 +206,28 @@ jobs:
         
       - name: Generate build summary
         run: |
-          echo "## Build Stats" >> $GITHUB_STEP_SUMMARY
+          echo "## Context" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:** ${{ github.ref_name }} (${{ github.ref }})" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
           BUILD_TIME=$(($(date +%s) - ${{ github.event.workflow_run.created_at }}))
           echo "**Build Time:** ${BUILD_TIME} seconds" >> $GITHUB_STEP_SUMMARY
           echo "**Build Date:** $(date)" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Created at:** ${{ github.event.workflow_run.created_at }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Triggered by:** ${{ github.github.triggering_actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Status:** ${{ github.github.action_status }}" >> $GITHUB_STEP_SUMMARY
+          echo "## Caching" >> $GITHUB_STEP_SUMMARY
           if [ "${{ steps.cache-openssl.outputs.cache-hit }}" == 'true' ]; then
-            echo "- **OpenSSL:** Cache hit" >> $GITHUB_STEP_SUMMARY
-            echo "  Cache key: openssl-${{ steps.revparse.outputs.openssl }}" >> $GITHUB_STEP_SUMMARY
+            echo "- **OpenSSL:** Cache HIT (key: ${{ steps.cache-openssl.key }})" >> $GITHUB_STEP_SUMMARY
           else
-            echo "- **OpenSSL:** Cache miss, rebuilt" >> $GITHUB_STEP_SUMMARY
+            echo "- **OpenSSL:** Cache MISS (full rebuild)" >> $GITHUB_STEP_SUMMARY
           fi
           if [ "${{ steps.cache-wgpu.outputs.cache-hit }}" == 'true' ]; then
             echo "- **WGPU:** Cache hit" >> $GITHUB_STEP_SUMMARY
-            echo "  Cache key: wgpu-${{ steps.revparse.outputs.wgpu }}" >> $GITHUB_STEP_SUMMARY
+            echo "  Cache key: ${{ steps.cache-wgpu.key }}" >> $GITHUB_STEP_SUMMARY
           else
             echo "- **WGPU:** Cache miss, rebuilt" >> $GITHUB_STEP_SUMMARY
           fi
-          echo "## Changelog\n\n" >> $GITHUB_STEP_SUMMARY
+          echo "## Changelog" >> $GITHUB_STEP_SUMMARY
           cat CHANGELOG.MD >> $GITHUB_STEP_SUMMARY
 
 # TODO publish artifacts (changelog/build summary/logs?)

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -190,7 +190,12 @@ jobs:
 
       # GitHub adds a heading of their own, so remove the duplicate
       - name: Generate CHANGELOG.MD
-        run: evo create-changelog.lua && tail -n +3 CHANGELOG.MD > CHANGELOG-GITHUB.MD && mv CHANGELOG-GITHUB.MD CHANGELOG.MD
+        run: |
+          evo create-changelog.lua
+          tail -n +3 CHANGELOG.MD > CHANGELOG-GITHUB.MD
+          mv CHANGELOG-GITHUB.MD CHANGELOG.MD
+          cat CHANGELOG.MD
+        # TBD upload as artifact? same as the executable, and possibly libs (DLL only)
 
       - name: Publish new release
         # Truly "continuous" releases may be overkill here, so better only release tagged versions

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -197,6 +197,14 @@ jobs:
           cat CHANGELOG.MD
         # TBD upload as artifact? same as the executable, and possibly libs (DLL only)
 
+# TBD upload binary as well? review storage quotas first...
+      - name: Upload CHANGELOG.MD preview
+        uses: actions/upload-artifact@v4
+        with:
+          name: CHANGELOG-PREVIEW-LINUX.MD
+          path: CHANGELOG.MD
+        
+
       - name: Publish new release
         # Truly "continuous" releases may be overkill here, so better only release tagged versions
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
TODO: Also for macOS/Linux (once the format is final). Probably not useful to do this for the check runs, so skip those for now.