### PR TITLE
Update uWebSockets to the latest HEAD

### DIFF
--- a/Runtime/Bindings/FFI/WebServer.hpp
+++ b/Runtime/Bindings/FFI/WebServer.hpp
@@ -148,7 +148,7 @@ private:
 	void SetCallbackHandlers(std::string requestID, auto* response, auto* request);
 
 	// Internal references (used to make us and uws API calls)
-	uWS::TemplatedApp<false> m_uwsAppHandle; // Set isUsingSSL=true once SSL support is in
+	uWS::App m_uwsAppHandle; // Should use uWS::SSLApp once SSL support is in
 	struct us_listen_socket_t* m_usListenSocket = nullptr;
 
 	// Auxiliary state (needed because uws doesn't provide APIs for these)


### PR DESCRIPTION
This won't compile due to a new parameter for `uWS::TemplatedApp`. Draft PR serves as a reminder to review the diff.

Relevant changelog: https://github.com/uNetworking/uWebSockets/releases/tag/v20.65.0 (second parameter is for caching)

```
Template refactors needed for coming HTTP cache; it should be entirely backwards compatible for your app
```

It is not in fact backwards-compatible, at least when used as the WebServer does? Might be user error, should be easy to fix.

Caching changes were introduced by [this commit](https://github.com/uNetworking/uWebSockets/commit/88b15f3b2c4caa815b71a643a0803423e8f1797d). Maybe the `TemplatedApp` isn't supposed to be used directly? Yup, that's it.