### PR TITLE
Update wgpu-native to the latest HEAD

### DIFF
--- a/BuildTools/Targets/EvoBuildTarget.lua
+++ b/BuildTools/Targets/EvoBuildTarget.lua
@@ -180,6 +180,7 @@ local EvoBuildTarget = {
 			"wmcodecdspuuid",
 			"mfuuid",
 			"ksuser",
+			"oleaut32",
 		},
 		OSX = {
 			"m",

--- a/Runtime/Bindings/FFI/wgpu/wgpu_aliases.h
+++ b/Runtime/Bindings/FFI/wgpu/wgpu_aliases.h
@@ -1446,8 +1446,6 @@ typedef enum WGPUNativeFeature {
 	WGPUNativeFeature_PartiallyBoundBindingArray = 0x0003000A,
 	WGPUNativeFeature_TextureFormat16bitNorm = 0x0003000B,
 	WGPUNativeFeature_TextureCompressionAstcHdr = 0x0003000C,
-	// NYI (breaking API change required)
-	// WGPUNativeFeature_TimestampQueryInsidePasses = 0x0003000D,
 	WGPUNativeFeature_MappablePrimaryBuffers = 0x0003000E,
 	WGPUNativeFeature_BufferBindingArray = 0x0003000F,
 	WGPUNativeFeature_UniformBufferAndStorageTextureArrayNonUniformIndexing = 0x00030010,
@@ -1458,17 +1456,21 @@ typedef enum WGPUNativeFeature {
 	// WGPUNativeFeature_PolygonModePoint = 0x00030014,
 	// WGPUNativeFeature_ConservativeRasterization = 0x00030015,
 	// WGPUNativeFeature_ClearTexture = 0x00030016,
-	// WGPUNativeFeature_SpirvShaderPassthrough = 0x00030017,
+	WGPUNativeFeature_SpirvShaderPassthrough = 0x00030017,
 	// WGPUNativeFeature_Multiview = 0x00030018,
 	WGPUNativeFeature_VertexAttribute64bit = 0x00030019,
-	WGPUNativeFeature_ShaderUnusedVertexOutput = 0x0003001A,
-	WGPUNativeFeature_TextureFormatNv12 = 0x0003001B,
-	WGPUNativeFeature_RayTracingAccelerationStructure = 0x0003001C,
-	WGPUNativeFeature_RayQuery = 0x0003001D,
-	WGPUNativeFeature_ShaderF64 = 0x0003001E,
-	WGPUNativeFeature_ShaderI16 = 0x0003001F,
-	WGPUNativeFeature_ShaderPrimitiveIndex = 0x00030020,
-	WGPUNativeFeature_ShaderEarlyDepthTest = 0x00030021,
+	WGPUNativeFeature_TextureFormatNv12 = 0x0003001A,
+	WGPUNativeFeature_RayTracingAccelerationStructure = 0x0003001B,
+	WGPUNativeFeature_RayQuery = 0x0003001C,
+	WGPUNativeFeature_ShaderF64 = 0x0003001D,
+	WGPUNativeFeature_ShaderI16 = 0x0003001E,
+	WGPUNativeFeature_ShaderPrimitiveIndex = 0x0003001F,
+	WGPUNativeFeature_ShaderEarlyDepthTest = 0x00030020,
+	WGPUNativeFeature_Subgroup = 0x00030021,
+	WGPUNativeFeature_SubgroupVertex = 0x00030022,
+	WGPUNativeFeature_SubgroupBarrier = 0x00030023,
+	WGPUNativeFeature_TimestampQueryInsideEncoders = 0x00030024,
+	WGPUNativeFeature_TimestampQueryInsidePasses = 0x00030025,
 	WGPUNativeFeature_Force32 = 0x7FFFFFFF
 } WGPUNativeFeature;
 
@@ -1573,7 +1575,7 @@ typedef struct WGPUPushConstantRange {
 typedef struct WGPUPipelineLayoutExtras {
 	WGPUChainedStruct chain;
 	size_t pushConstantRangeCount;
-	WGPUPushConstantRange* pushConstantRanges;
+	WGPUPushConstantRange const* pushConstantRanges;
 } WGPUPipelineLayoutExtras;
 
 typedef uint64_t WGPUSubmissionIndex;
@@ -1596,11 +1598,16 @@ typedef struct WGPUShaderModuleGLSLDescriptor {
 	WGPUShaderDefine* defines;
 } WGPUShaderModuleGLSLDescriptor;
 
+typedef struct WGPUShaderModuleDescriptorSpirV {
+	char const* label;
+	uint32_t sourceSize;
+	uint32_t const* source;
+} WGPUShaderModuleDescriptorSpirV;
+
 typedef struct WGPURegistryReport {
 	size_t numAllocated;
 	size_t numKeptFromUser;
 	size_t numReleasedFromUser;
-	size_t numDestroyedFromUser;
 	size_t numError;
 	size_t elementSize;
 } WGPURegistryReport;
@@ -1661,7 +1668,19 @@ typedef struct WGPUQuerySetDescriptorExtras {
 
 typedef struct WGPUSurfaceConfigurationExtras {
 	WGPUChainedStruct chain;
-	WGPUBool desiredMaximumFrameLatency;
+	uint32_t desiredMaximumFrameLatency;
 } WGPUSurfaceConfigurationExtras;
 
 typedef void (*WGPULogCallback)(WGPULogLevel level, char const* message, void* userdata);
+
+typedef enum WGPUNativeTextureFormat {
+	// From Features::TEXTURE_FORMAT_16BIT_NORM
+	WGPUNativeTextureFormat_R16Unorm = 0x00030001,
+	WGPUNativeTextureFormat_R16Snorm = 0x00030002,
+	WGPUNativeTextureFormat_Rg16Unorm = 0x00030003,
+	WGPUNativeTextureFormat_Rg16Snorm = 0x00030004,
+	WGPUNativeTextureFormat_Rgba16Unorm = 0x00030005,
+	WGPUNativeTextureFormat_Rgba16Snorm = 0x00030006,
+	// From Features::TEXTURE_FORMAT_NV12
+	WGPUNativeTextureFormat_NV12 = 0x00030007,
+} WGPUNativeTextureFormat;

--- a/Runtime/Bindings/FFI/wgpu/wgpu_exports.h
+++ b/Runtime/Bindings/FFI/wgpu/wgpu_exports.h
@@ -9,13 +9,15 @@ struct static_wgpu_exports_table {
 
 	// Methods of Adapter
 	size_t (*wgpu_adapter_enumerate_features)(WGPUAdapter adapter, WGPUFeatureName* features);
+	void (*wgpu_adapter_get_info)(WGPUAdapter adapter, WGPUAdapterInfo* info);
 	WGPUBool (*wgpu_adapter_get_limits)(WGPUAdapter adapter, WGPUSupportedLimits* limits);
-	void (*wgpu_adapter_get_properties)(WGPUAdapter adapter, WGPUAdapterProperties* properties);
 	WGPUBool (*wgpu_adapter_has_feature)(WGPUAdapter adapter, WGPUFeatureName feature);
-	void (*wgpu_adapter_request_adapter_info)(WGPUAdapter adapter, WGPUAdapterRequestAdapterInfoCallback callback, void* userdata);
 	void (*wgpu_adapter_request_device)(WGPUAdapter adapter, WGPUDeviceDescriptor const* descriptor /* nullable */, WGPUAdapterRequestDeviceCallback callback, void* userdata);
 	void (*wgpu_adapter_reference)(WGPUAdapter adapter);
 	void (*wgpu_adapter_release)(WGPUAdapter adapter);
+
+	// Methods of AdapterInfo
+	void (*wgpu_adapter_info_free_members)(WGPUAdapterInfo adapterInfo);
 
 	// Methods of BindGroup
 	void (*wgpu_bind_group_set_label)(WGPUBindGroup bindGroup, char const* label);
@@ -105,7 +107,6 @@ struct static_wgpu_exports_table {
 	void (*wgpu_device_pop_error_scope)(WGPUDevice device, WGPUErrorCallback callback, void* userdata);
 	void (*wgpu_device_push_error_scope)(WGPUDevice device, WGPUErrorFilter filter);
 	void (*wgpu_device_set_label)(WGPUDevice device, char const* label);
-	void (*wgpu_device_set_uncaptured_error_callback)(WGPUDevice device, WGPUErrorCallback callback, void* userdata);
 	void (*wgpu_device_reference)(WGPUDevice device);
 	void (*wgpu_device_release)(WGPUDevice device);
 
@@ -206,7 +207,6 @@ struct static_wgpu_exports_table {
 	void (*wgpu_surface_configure)(WGPUSurface surface, WGPUSurfaceConfiguration const* config);
 	void (*wgpu_surface_get_capabilities)(WGPUSurface surface, WGPUAdapter adapter, WGPUSurfaceCapabilities* surfaceCapabilities);
 	void (*wgpu_surface_get_current_texture)(WGPUSurface surface, WGPUSurfaceTexture* surfaceTexture);
-	WGPUTextureFormat (*wgpu_surface_get_preferred_format)(WGPUSurface surface, WGPUAdapter adapter);
 	void (*wgpu_surface_present)(WGPUSurface surface);
 	void (*wgpu_surface_set_label)(WGPUSurface surface, char const* label);
 	void (*wgpu_surface_unconfigure)(WGPUSurface surface);

--- a/Runtime/Bindings/FFI/wgpu/wgpu_exports.h
+++ b/Runtime/Bindings/FFI/wgpu/wgpu_exports.h
@@ -241,7 +241,7 @@ struct static_wgpu_exports_table {
 	size_t (*wgpu_instance_enumerate_adapters)(WGPUInstance instance, WGPUInstanceEnumerateAdapterOptions const* options, WGPUAdapter* adapters);
 
 	WGPUSubmissionIndex (*wgpu_queue_submit_for_index)(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const* commands);
-
+	WGPUShaderModule (*wgpu_device_create_shader_module_spirv)(WGPUDevice device, WGPUShaderModuleDescriptorSpirV const* descriptor);
 	WGPUBool (*wgpu_device_poll)(WGPUDevice device, WGPUBool wait, WGPUWrappedSubmissionIndex const* wrappedSubmissionIndex);
 
 	void (*wgpu_set_log_callback)(WGPULogCallback callback, void* userdata);
@@ -250,8 +250,9 @@ struct static_wgpu_exports_table {
 
 	uint32_t (*wgpu_get_version)(void);
 
+	void (*wgpu_compute_pass_encoder_set_push_constants)(WGPUComputePassEncoder encoder, uint32_t offset, uint32_t sizeBytes, void const* data);
 	void (*wgpu_render_pass_encoder_set_push_constants)(WGPURenderPassEncoder encoder, WGPUShaderStageFlags stages, uint32_t offset, uint32_t sizeBytes, void const* data);
-
+	void (*wgpu_render_bundle_encoder_set_push_constants)(WGPURenderBundleEncoder encoder, WGPUShaderStageFlags stages, uint32_t offset, uint32_t sizeBytes, void const* data);
 	void (*wgpu_render_pass_encoder_multi_draw_indirect)(WGPURenderPassEncoder encoder, WGPUBuffer buffer, uint64_t offset, uint32_t count);
 	void (*wgpu_render_pass_encoder_multi_draw_indexed_indirect)(WGPURenderPassEncoder encoder, WGPUBuffer buffer, uint64_t offset, uint32_t count);
 
@@ -262,4 +263,6 @@ struct static_wgpu_exports_table {
 	void (*wgpu_compute_pass_encoder_end_pipeline_statistics_query)(WGPUComputePassEncoder computePassEncoder);
 	void (*wgpu_render_pass_encoder_begin_pipeline_statistics_query)(WGPURenderPassEncoder renderPassEncoder, WGPUQuerySet querySet, uint32_t queryIndex);
 	void (*wgpu_render_pass_encoder_end_pipeline_statistics_query)(WGPURenderPassEncoder renderPassEncoder);
+	void (*wgpu_compute_pass_encoder_write_timestamp)(WGPUComputePassEncoder computePassEncoder, WGPUQuerySet querySet, uint32_t queryIndex);
+	void (*wgpu_render_pass_encoder_write_timestamp)(WGPURenderPassEncoder renderPassEncoder, WGPUQuerySet querySet, uint32_t queryIndex);
 };

--- a/Runtime/Bindings/FFI/wgpu/wgpu_ffi.cpp
+++ b/Runtime/Bindings/FFI/wgpu/wgpu_ffi.cpp
@@ -18,13 +18,15 @@ namespace wgpu_ffi {
 
 			// Adapter
 			.wgpu_adapter_enumerate_features = wgpuAdapterEnumerateFeatures,
+			.wgpu_adapter_get_info = wgpuAdapterGetInfo,
 			.wgpu_adapter_get_limits = wgpuAdapterGetLimits,
-			.wgpu_adapter_get_properties = wgpuAdapterGetProperties,
 			.wgpu_adapter_has_feature = wgpuAdapterHasFeature,
-			.wgpu_adapter_request_adapter_info = wgpuAdapterRequestAdapterInfo,
 			.wgpu_adapter_request_device = wgpuAdapterRequestDevice,
 			.wgpu_adapter_reference = wgpuAdapterReference,
 			.wgpu_adapter_release = wgpuAdapterRelease,
+
+			// AdapterInfo
+			.wgpu_adapter_info_free_members = wgpuAdapterInfoFreeMembers,
 
 			// BindGroup
 			.wgpu_bind_group_set_label = wgpuBindGroupSetLabel,
@@ -114,7 +116,6 @@ namespace wgpu_ffi {
 			.wgpu_device_pop_error_scope = wgpuDevicePopErrorScope,
 			.wgpu_device_push_error_scope = wgpuDevicePushErrorScope,
 			.wgpu_device_set_label = wgpuDeviceSetLabel,
-			.wgpu_device_set_uncaptured_error_callback = wgpuDeviceSetUncapturedErrorCallback,
 			.wgpu_device_reference = wgpuDeviceReference,
 			.wgpu_device_release = wgpuDeviceRelease,
 
@@ -215,7 +216,6 @@ namespace wgpu_ffi {
 			.wgpu_surface_configure = wgpuSurfaceConfigure,
 			.wgpu_surface_get_capabilities = wgpuSurfaceGetCapabilities,
 			.wgpu_surface_get_current_texture = wgpuSurfaceGetCurrentTexture,
-			.wgpu_surface_get_preferred_format = wgpuSurfaceGetPreferredFormat,
 			.wgpu_surface_present = wgpuSurfacePresent,
 			.wgpu_surface_set_label = wgpuSurfaceSetLabel,
 			.wgpu_surface_unconfigure = wgpuSurfaceUnconfigure,

--- a/Runtime/Bindings/FFI/wgpu/wgpu_ffi.cpp
+++ b/Runtime/Bindings/FFI/wgpu/wgpu_ffi.cpp
@@ -249,11 +249,14 @@ namespace wgpu_ffi {
 			.wgpu_generate_report = wgpuGenerateReport,
 			.wgpu_instance_enumerate_adapters = wgpuInstanceEnumerateAdapters,
 			.wgpu_queue_submit_for_index = wgpuQueueSubmitForIndex,
+			.wgpu_device_create_shader_module_spirv = wgpuDeviceCreateShaderModuleSpirV,
 			.wgpu_device_poll = wgpuDevicePoll,
 			.wgpu_set_log_callback = wgpuSetLogCallback,
 			.wgpu_set_log_level = wgpuSetLogLevel,
 			.wgpu_get_version = wgpuGetVersion,
+			.wgpu_compute_pass_encoder_set_push_constants = wgpuComputePassEncoderSetPushConstants,
 			.wgpu_render_pass_encoder_set_push_constants = wgpuRenderPassEncoderSetPushConstants,
+			.wgpu_render_bundle_encoder_set_push_constants = wgpuRenderBundleEncoderSetPushConstants,
 			.wgpu_render_pass_encoder_multi_draw_indirect = wgpuRenderPassEncoderMultiDrawIndirect,
 			.wgpu_render_pass_encoder_multi_draw_indexed_indirect = wgpuRenderPassEncoderMultiDrawIndexedIndirect,
 			.wgpu_render_pass_encoder_multi_draw_indirect_count = wgpuRenderPassEncoderMultiDrawIndirectCount,
@@ -262,7 +265,8 @@ namespace wgpu_ffi {
 			.wgpu_compute_pass_encoder_end_pipeline_statistics_query = wgpuComputePassEncoderEndPipelineStatisticsQuery,
 			.wgpu_render_pass_encoder_begin_pipeline_statistics_query = wgpuRenderPassEncoderBeginPipelineStatisticsQuery,
 			.wgpu_render_pass_encoder_end_pipeline_statistics_query = wgpuRenderPassEncoderEndPipelineStatisticsQuery,
-
+			.wgpu_compute_pass_encoder_write_timestamp = wgpuComputePassEncoderWriteTimestamp,
+			.wgpu_render_pass_encoder_write_timestamp = wgpuRenderPassEncoderWriteTimestamp,
 		};
 
 		return &exports;

--- a/Tests/Integration/glfw-webgpu-surface.lua
+++ b/Tests/Integration/glfw-webgpu-surface.lua
@@ -84,18 +84,18 @@ local function inspectAdapter(adapter)
 	print("\tmaxComputeWorkgroupSizeZ: ", limits.limits.maxComputeWorkgroupSizeZ)
 	print("\tmaxComputeWorkgroupsPerDimension: ", limits.limits.maxComputeWorkgroupsPerDimension)
 
-	local properties = ffi.new("WGPUAdapterProperties")
-	wgpu.bindings.wgpu_adapter_get_properties(adapter, properties)
+	local adapterInfo = ffi.new("WGPUAdapterInfo")
+	wgpu.bindings.wgpu_adapter_get_info(adapter, adapterInfo)
 
-	print("Adapter properties:")
-	print("\tvendorID: ", properties.vendorID)
-	print("\tdeviceID: ", properties.deviceID)
-	print("\tname: ", ffi.string(properties.name))
-	if properties.driverDescription then
-		print("\tdriverDescription: ", ffi.string(properties.driverDescription))
-	end
-	print("\tadapterType: ", properties.adapterType)
-	print("\tbackendType: ", properties.backendType)
+	print("Adapter info:")
+	print("\tvendorID: ", adapterInfo.vendorID)
+	print("\tdeviceID: ", adapterInfo.deviceID)
+	print("\tdescription: ", ffi.string(adapterInfo.description))
+	print("\tadapterType: ", adapterInfo.adapterType)
+	print("\tbackendType: ", adapterInfo.backendType)
+	print("\tarchitecture: ", ffi.string(adapterInfo.architecture))
+	print("\tdevice: ", ffi.string(adapterInfo.device))
+	print("\tvendor: ", ffi.string(adapterInfo.vendor))
 end
 
 inspectAdapter(requestedAdapter)


### PR DESCRIPTION
There's no way this doesn't break at least *something*, but it won't help to fall behind even further.

TODOs:

- [x] Update the GLFW/WebGPU integration test - the surface info API has changed slightly
- [x] Link `oleaut32` on Windows (CI failure - needs research, why was it added? -> `WGPUDx12Compiler`) 
- [x] Update the wgpu-native extension headers - discrepancies misleading (`TODO` comments turned into `NYI`?)