### PR TITLE
Set up a shared event loop instead of re-using luv's default loop

### DIFF
--- a/Tests/BDD/uv-library.spec.lua
+++ b/Tests/BDD/uv-library.spec.lua
@@ -8,4 +8,12 @@ describe("uv", function()
 			assertNil(libuvErrorMessage) -- Will be ENOBUFFS if the argv memory wasn't set up
 		end)
 	end)
+
+	describe("walk", function()
+		it("should not crash when encountering foreign handles", function()
+			uv.walk(function(handle)
+				print(handle) -- Will crash before getting here if luv tries to process a foreign handle
+			end)
+		end)
+	end)
 end)


### PR DESCRIPTION
~~Resolves #573~~.

No longer necessary to fix the crashes, but still based on the research/work done while troubleshooting them.