### PR TITLE
Prevent sporadic dbus errors in the Linux build workflow

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -63,6 +63,7 @@ jobs:
             echo $DISPLAY
             export DISPLAY=:99.0
             echo $DISPLAY
+            sudo apt-get install at-spi2-core
 
       - name: Generate versions.lua # Required for those libraries that don't export versioning information
         run: deps/discover-submodule-versions.sh && cat deps/versions.lua


### PR DESCRIPTION
Apparently this is supposed to fix the crashes. Time will tell?

---

From a recent run that happened to fail randomly:

```sh
(evo:25117): dbind-WARNING **: 08:10:11.199: AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: The name org.a11y.Bus was not provided by any .service files
Aborted (core dumped)
```