### PR TITLE
Move redundant submodule properties to the .gitmodules file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,114 +1,114 @@
-[submodule "deps/LuaJIT/LuaJIT"]
+[submodule "LuaJIT"]
 	path = deps/LuaJIT/LuaJIT
 	url = https://github.com/LuaJIT/LuaJIT
 	ignore = dirty
 	branch = v2.1
-[submodule "deps/madler/zlib"]
+[submodule "zlib"]
 	path = deps/madler/zlib
 	url = https://github.com/madler/zlib
 	ignore = dirty
 	branch = master
-[submodule "deps/PCRE2Project/pcre2"]
+[submodule "pcre2"]
 	path = deps/PCRE2Project/pcre2
 	url = https://github.com/PCRE2Project/pcre2
 	ignore = dirty
 	branch = master
-[submodule "deps/openssl/openssl"]
+[submodule "openssl"]
 	path = deps/openssl/openssl
 	url = https://github.com/openssl/openssl
 	ignore = dirty
 	branch = master
-[submodule "deps/richgel999/miniz"]
+[submodule "miniz"]
 	path = deps/richgel999/miniz
 	url = https://github.com/richgel999/miniz
 	ignore = dirty
 	branch = master
-[submodule "deps/luvit/luv"]
+[submodule "luv"]
 	path = deps/luvit/luv
 	url = https://github.com/luvit/luv
 	ignore = dirty
 	branch = master
-[submodule "deps/kikito/inspect.lua"]
+[submodule "inspect.lua"]
 	path = deps/kikito/inspect.lua
 	url = https://github.com/kikito/inspect.lua.git
 	ignore = dirty
 	branch = master
-[submodule "deps/webview/webview"]
+[submodule "webview"]
 	path = deps/webview/webview
 	url = https://github.com/webview/webview
 	ignore = dirty
 	branch = master
-[submodule "deps/uNetworking/uWebSockets"]
+[submodule "uWebSockets"]
 	path = deps/uNetworking/uWebSockets
 	url = https://github.com/uNetworking/uWebSockets.git
 	ignore = dirty
 	branch = master
-[submodule "deps/zhaog/lua-openssl"]
+[submodule "lua-openssl"]
 	path = deps/zhaog/lua-openssl
 	url = https://github.com/zhaozg/lua-openssl
 	ignore = dirty
 	branch = master
-[submodule "deps/mariusbancila/stduuid"]
+[submodule "stduuid"]
 	path = deps/mariusbancila/stduuid
 	url = https://github.com/mariusbancila/stduuid
 	ignore = dirty
 	branch = master
-[submodule "deps/brimworks/lua-zlib"]
+[submodule "lua-zlib"]
 	path = deps/brimworks/lua-zlib
 	url = https://github.com/brimworks/lua-zlib
 	ignore = dirty
 	branch = master
-[submodule "deps/xpol/lua-rapidjson"]
+[submodule "lua-rapidjson"]
 	path = deps/xpol/lua-rapidjson
 	url = https://github.com/xpol/lua-rapidjson.git
 	ignore = dirty
 	branch = master
-[submodule "deps/nothings/stb"]
+[submodule "stb"]
 	path = deps/nothings/stb
 	url = https://github.com/nothings/stb.git
 	ignore = dirty
 	branch = master
-[submodule "deps/rrthomas/lrexlib"]
+[submodule "lrexlib"]
 	path = deps/rrthomas/lrexlib
 	url = https://github.com/rrthomas/lrexlib
 	ignore = dirty
 	branch = master
-[submodule "deps/glfw/glfw"]
+[submodule "glfw"]
 	path = deps/glfw/glfw
 	url = https://github.com/glfw/glfw/
 	ignore = dirty
 	branch = master
-[submodule "deps/gfx-rs/wgpu-native"]
+[submodule "wgpu-native"]
 	path = deps/gfx-rs/wgpu-native
 	url = https://github.com/gfx-rs/wgpu-native.git
 	ignore = dirty
 	branch = trunk
-[submodule "deps/mikke89/RmlUi"]
+[submodule "RmlUi"]
 	path = deps/mikke89/RmlUi
 	url = https://github.com/mikke89/RmlUi.git
 	ignore = dirty
 	branch = master
-[submodule "deps/freetype/freetype"]
+[submodule "freetype"]
 	path = deps/freetype/freetype
 	url = https://github.com/freetype/freetype.git
 	ignore = dirty
 	branch = master
-[submodule "deps/LabSound/LabSound"]
+[submodule "LabSound"]
 	path = deps/LabSound/LabSound
 	url = https://github.com/LabSound/LabSound.git
 	ignore = dirty
 	branch = main
-[submodule "deps/roberto-ieru/LPeg"]
+[submodule "LPeg"]
 	path = deps/roberto-ieru/LPeg
 	url = https://github.com/roberto-ieru/LPeg
 	ignore = dirty
 	branch = master
-[submodule "deps/starwing/luautf8"]
+[submodule "luautf8"]
 	path = deps/starwing/luautf8
 	url = https://github.com/starwing/luautf8
 	ignore = dirty
 	branch = master
-[submodule "deps/Tencent/rapidjson"]
+[submodule "rapidjson"]
 	path = deps/Tencent/rapidjson
 	url = https://github.com/Tencent/rapidjson
 	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,90 +2,114 @@
 	path = deps/LuaJIT/LuaJIT
 	url = https://github.com/LuaJIT/LuaJIT
 	ignore = dirty
+	branch = v2.1
 [submodule "deps/madler/zlib"]
 	path = deps/madler/zlib
 	url = https://github.com/madler/zlib
 	ignore = dirty
+	branch = master
 [submodule "deps/PCRE2Project/pcre2"]
 	path = deps/PCRE2Project/pcre2
 	url = https://github.com/PCRE2Project/pcre2
 	ignore = dirty
+	branch = master
 [submodule "deps/openssl/openssl"]
 	path = deps/openssl/openssl
 	url = https://github.com/openssl/openssl
 	ignore = dirty
+	branch = master
 [submodule "deps/richgel999/miniz"]
 	path = deps/richgel999/miniz
 	url = https://github.com/richgel999/miniz
 	ignore = dirty
+	branch = master
 [submodule "deps/luvit/luv"]
 	path = deps/luvit/luv
 	url = https://github.com/luvit/luv
 	ignore = dirty
+	branch = master
 [submodule "deps/kikito/inspect.lua"]
 	path = deps/kikito/inspect.lua
 	url = https://github.com/kikito/inspect.lua.git
 	ignore = dirty
+	branch = master
 [submodule "deps/webview/webview"]
 	path = deps/webview/webview
 	url = https://github.com/webview/webview
 	ignore = dirty
+	branch = master
 [submodule "deps/uNetworking/uWebSockets"]
 	path = deps/uNetworking/uWebSockets
 	url = https://github.com/uNetworking/uWebSockets.git
 	ignore = dirty
+	branch = master
 [submodule "deps/zhaog/lua-openssl"]
 	path = deps/zhaog/lua-openssl
 	url = https://github.com/zhaozg/lua-openssl
 	ignore = dirty
+	branch = master
 [submodule "deps/mariusbancila/stduuid"]
 	path = deps/mariusbancila/stduuid
 	url = https://github.com/mariusbancila/stduuid
 	ignore = dirty
+	branch = master
 [submodule "deps/brimworks/lua-zlib"]
 	path = deps/brimworks/lua-zlib
 	url = https://github.com/brimworks/lua-zlib
 	ignore = dirty
+	branch = master
 [submodule "deps/xpol/lua-rapidjson"]
 	path = deps/xpol/lua-rapidjson
 	url = https://github.com/xpol/lua-rapidjson.git
 	ignore = dirty
+	branch = master
 [submodule "deps/nothings/stb"]
 	path = deps/nothings/stb
 	url = https://github.com/nothings/stb.git
 	ignore = dirty
+	branch = master
 [submodule "deps/rrthomas/lrexlib"]
 	path = deps/rrthomas/lrexlib
 	url = https://github.com/rrthomas/lrexlib
 	ignore = dirty
+	branch = master
 [submodule "deps/glfw/glfw"]
 	path = deps/glfw/glfw
 	url = https://github.com/glfw/glfw/
 	ignore = dirty
+	branch = master
 [submodule "deps/gfx-rs/wgpu-native"]
 	path = deps/gfx-rs/wgpu-native
 	url = https://github.com/gfx-rs/wgpu-native.git
 	ignore = dirty
+	branch = trunk
 [submodule "deps/mikke89/RmlUi"]
 	path = deps/mikke89/RmlUi
 	url = https://github.com/mikke89/RmlUi.git
 	ignore = dirty
+	branch = master
 [submodule "deps/freetype/freetype"]
 	path = deps/freetype/freetype
 	url = https://github.com/freetype/freetype.git
 	ignore = dirty
+	branch = master
 [submodule "deps/LabSound/LabSound"]
 	path = deps/LabSound/LabSound
 	url = https://github.com/LabSound/LabSound.git
 	ignore = dirty
+	branch = main
 [submodule "deps/roberto-ieru/LPeg"]
 	path = deps/roberto-ieru/LPeg
 	url = https://github.com/roberto-ieru/LPeg
 	ignore = dirty
+	branch = master
 [submodule "deps/starwing/luautf8"]
 	path = deps/starwing/luautf8
 	url = https://github.com/starwing/luautf8
 	ignore = dirty
+	branch = master
 [submodule "deps/Tencent/rapidjson"]
 	path = deps/Tencent/rapidjson
 	url = https://github.com/Tencent/rapidjson
+	ignore = dirty
+	branch = master

--- a/BuildTools/Targets/EvoBuildTarget.lua
+++ b/BuildTools/Targets/EvoBuildTarget.lua
@@ -53,6 +53,7 @@ local EvoBuildTarget = {
 		"Runtime/Libraries/bdd.lua",
 		"Runtime/Libraries/console.lua",
 		"Runtime/Libraries/etrace.lua",
+		"Runtime/Libraries/git.lua",
 		"Runtime/Libraries/oop.lua",
 		"Runtime/Libraries/path.lua",
 		"Runtime/Libraries/profiler.lua",

--- a/Runtime/Libraries/git.lua
+++ b/Runtime/Libraries/git.lua
@@ -1,0 +1,45 @@
+local git = {}
+
+local currentSubmoduleName
+local function parseNextLine(submodules, line)
+	local submoduleName = line:match('%[submodule%s"(.*)%"]')
+	if submoduleName then
+		currentSubmoduleName = submoduleName
+		submodules[submoduleName] = {}
+		return
+	end
+
+	local recognizedFields = {
+		-- Mandatory fields
+		["path"] = tostring,
+		["url"] = tostring,
+		-- Optional fields
+		["ignore"] = tostring,
+		["update"] = tostring,
+		["branch"] = tostring,
+		["fetchRecurseSubmodules"] = tostring,
+		["shallow"] = tostring,
+	}
+
+	for fieldName, _ in pairs(recognizedFields) do
+		local matchedValue = line:match("%s?" .. fieldName .. "%s?=%s?(.*)")
+		if matchedValue then
+			submodules[currentSubmoduleName][fieldName] = matchedValue
+			return
+		end
+	end
+end
+
+function git.modules(fileContents)
+	fileContents = fileContents:gsub("\r\n", "\n")
+	local lines = string.explode(fileContents, "\n")
+	local submodules = {}
+
+	for _, line in ipairs(lines) do
+		parseNextLine(submodules, line)
+	end
+
+	return submodules
+end
+
+return git

--- a/Tests/BDD/git-library.spec.lua
+++ b/Tests/BDD/git-library.spec.lua
@@ -1,0 +1,43 @@
+local git = require("git")
+
+describe("git", function()
+	describe("modules", function()
+		local fileContents = [[
+[submodule "deps/LuaJIT/LuaJIT"]
+path = deps/LuaJIT/LuaJIT
+url = https://github.com/LuaJIT/LuaJIT
+ignore = dirty
+branch = v2.1
+[submodule "deps/openssl/openssl"]
+	path = deps/openssl/openssl
+	url = https://github.com/openssl/openssl
+	ignore = dirty
+	branch = master
+	fetchRecurseSubmodules = false
+	shallow = true
+	update = checkout
+]]
+
+		it("should return a table representing the .gitmodule file contents", function()
+			local submodules = git.modules(fileContents)
+			assertEquals(table.count(submodules), 2)
+
+			assertEquals(submodules["deps/LuaJIT/LuaJIT"].path, "deps/LuaJIT/LuaJIT")
+			assertEquals(submodules["deps/LuaJIT/LuaJIT"].url, "https://github.com/LuaJIT/LuaJIT")
+			assertEquals(submodules["deps/LuaJIT/LuaJIT"].ignore, "dirty")
+
+			assertEquals(submodules["deps/openssl/openssl"].path, "deps/openssl/openssl")
+			assertEquals(submodules["deps/openssl/openssl"].url, "https://github.com/openssl/openssl")
+			assertEquals(submodules["deps/openssl/openssl"].ignore, "dirty")
+			assertEquals(submodules["deps/openssl/openssl"].branch, "master")
+			assertEquals(submodules["deps/openssl/openssl"].fetchRecurseSubmodules, "false")
+			assertEquals(submodules["deps/openssl/openssl"].shallow, "true")
+			assertEquals(submodules["deps/openssl/openssl"].update, "checkout")
+		end)
+
+		it("should normalize iine endings to avoid crossplatform issues", function()
+			local fileContentsWithCRLF = fileContents:gsub("\n", "\r\n")
+			assertEquals(git.modules(fileContents), git.modules(fileContentsWithCRLF))
+		end)
+	end)
+end)

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -7,6 +7,7 @@ local specFiles = {
 	"Tests/BDD/debug-library.spec.lua",
 	"Tests/BDD/etrace-library.spec.lua",
 	"Tests/BDD/evo-library.spec.lua",
+	"Tests/BDD/git-library.spec.lua",
 	"Tests/BDD/glfw-library.spec.lua",
 	"Tests/BDD/iconv-library.spec.lua",
 	"Tests/BDD/interop-library.spec.lua",


### PR DESCRIPTION
Instead of having to manually update several locations whenever submodules are added or removed, it may be a little easier to store the relevant information in the gitmodules file itself. Scripts can then simply read it from there. Parsing the file itself isn't a big deal, as long as robustness is largely irrelevant... which it is, at least for now.