### PR TITLE
Streamline the shared event loop code in preparation for future changes

### DIFF
--- a/Runtime/LuaVirtualMachine.cpp
+++ b/Runtime/LuaVirtualMachine.cpp
@@ -140,16 +140,6 @@ void LuaVirtualMachine::CreateGlobalNamespace(std::string name) {
 	lua_setglobal(m_luaState, name.c_str());
 }
 
-void LuaVirtualMachine::AssignGlobalVariable(std::string key, std::string value) {
-	lua_pushstring(m_luaState, value.c_str());
-	lua_setglobal(m_luaState, key.c_str());
-}
-
-void LuaVirtualMachine::AssignGlobalVariable(std::string key, void* lightUserdataPointer) {
-	lua_pushlightuserdata(m_luaState, lightUserdataPointer);
-	lua_setglobal(m_luaState, key.c_str());
-}
-
 bool LuaVirtualMachine::CheckStack() {
 	// The most basic of checks, to make sure all symmetrical PUSH/POP operations are in alignment...
 	if(m_relativeStackOffset != 0) {

--- a/Runtime/LuaVirtualMachine.hpp
+++ b/Runtime/LuaVirtualMachine.hpp
@@ -18,8 +18,6 @@ public:
 	bool SetGlobalArgs(int argc, char* argv[]);
 	void BindStaticLibraryExports(std::string fieldName, void* staticExportsTable);
 	void CreateGlobalNamespace(std::string name);
-	void AssignGlobalVariable(std::string key, std::string value);
-	void AssignGlobalVariable(std::string key, void* lightUserdataPointer);
 	bool CheckStack();
 	lua_State* GetState();
 

--- a/Runtime/SharedEventLoop.hpp
+++ b/Runtime/SharedEventLoop.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "LuaVirtualMachine.hpp"
+#include "uws_ffi.hpp"
+
+#include <cassert>
+#include <format>
+#include <memory>
+#include <stdexcept>
+
+using namespace std;
+using uws_loop_t = uWS::Loop*;
+
+extern "C" {
+#include "luv.h"
+#include "uv.h"
+}
+
+class SharedEventLoop {
+private:
+	shared_ptr<LuaVirtualMachine> m_mainThreadVM;
+
+	uv_loop_t m_uvMainLoop;
+	uws_loop_t m_uwsMainLoop;
+
+public:
+	explicit SharedEventLoop(auto L) {
+		assert(L != nullptr);
+		m_mainThreadVM = L;
+
+		int errorCode = uv_loop_init(&m_uvMainLoop);
+		if(errorCode != 0) {
+			auto message = format("Failed to initialize shared event loop ({}: {})",
+				uv_err_name(errorCode), uv_strerror(errorCode));
+			throw runtime_error(message);
+		}
+
+		luv_set_loop(m_mainThreadVM->GetState(), &m_uvMainLoop);
+
+		auto uwsEventLoop = uws_ffi::assignEventLoop(&m_uvMainLoop);
+		assert(uwsEventLoop != nullptr);
+		m_mainThreadVM->AssignGlobalVariable("UWS_EVENT_LOOP", static_cast<void*>(uwsEventLoop));
+		m_uwsMainLoop = uwsEventLoop;
+	}
+
+	~SharedEventLoop() {
+		luv_set_loop(m_mainThreadVM->GetState(), nullptr);
+		uws_ffi::unassignEventLoop(m_uwsMainLoop);
+	}
+
+	void RunMainLoopUntilDone() {
+		// There's just a single main loop right now, but that'll probably need to change
+		int refCount = uv_run(&m_uvMainLoop, UV_RUN_DEFAULT);
+		if(refCount != 0) {
+			auto message = format("Main loop finished running, but there's {} active references", refCount);
+			throw runtime_error(message);
+		}
+	}
+};

--- a/Runtime/SharedEventLoop.hpp
+++ b/Runtime/SharedEventLoop.hpp
@@ -39,7 +39,6 @@ public:
 
 		auto uwsEventLoop = uws_ffi::assignEventLoop(&m_uvMainLoop);
 		assert(uwsEventLoop != nullptr);
-		m_mainThreadVM->AssignGlobalVariable("UWS_EVENT_LOOP", static_cast<void*>(uwsEventLoop));
 		m_uwsMainLoop = uwsEventLoop;
 	}
 


### PR DESCRIPTION
Also allows getting rid of some technical debt (UWS global, hacky `os.exit` override, multiple exit routes).