### PR TITLE
Upgrade the cppcheck version used in CI runs to v2.16.0

### DIFF
--- a/.cppcheck
+++ b/.cppcheck
@@ -1,13 +1,15 @@
 // The performance impact is irrelevant where deliberately used, but it affects readability
 passedByValue
 
+// Includes are neither found nor required
+missingIncludeSystem
+missingInclude
+
 // cppcheck can't find the headers, but it's whatever since GCC checks macros anyway
 unknownMacro:Runtime/luajit_repl.c
 
 // Debug functions left in on purpose
 unusedFunction:Runtime/LuaVirtualMachine.cpp
-// Callback-based interface (hooks that will be called by RML)
-unusedFunction:Runtime/Bindings/FFI/RmlUi_Renderer_WebGPU.cpp
 
 // FFI exports used from Lua, which cppcheck can't see
 unusedStructMember:Runtime/Bindings/FFI/cpp/cpp_exports.hpp

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -20,7 +20,7 @@ jobs:
     name: Lint codebase
     runs-on: ubuntu-22.04
     env:
-        CPPCHECK_VERSION: 2.10.3
+        CPPCHECK_VERSION: 2.16.0
     steps:
 
       # LuaRocks needs the 5.1 headers to compile LuaCheck later, so we download them, too

--- a/Runtime/Bindings/FFI/RmlUi_Renderer_WebGPU.cpp
+++ b/Runtime/Bindings/FFI/RmlUi_Renderer_WebGPU.cpp
@@ -203,7 +203,7 @@ Rml::TextureHandle RenderInterface_WebGPU::LoadTexture(Rml::Vector2i& textureDim
 
 	// Should probably defer this for async/background loading (later)
 	int inputChannels;
-	unsigned char* rgbaImageBytes = stbi_load(source.c_str(), &textureDimensions.x, &textureDimensions.y, &inputChannels, CONVERT_TO_RGB_WITH_ALPHA);
+	unsigned const char* rgbaImageBytes = stbi_load(source.c_str(), &textureDimensions.x, &textureDimensions.y, &inputChannels, CONVERT_TO_RGB_WITH_ALPHA);
 	if(!rgbaImageBytes) return false;
 
 	WGPUTexture wgpuTexture = CreateTexture(rgbaImageBytes, textureDimensions.x, textureDimensions.y);

--- a/Runtime/Bindings/FFI/WebServer.cpp
+++ b/Runtime/Bindings/FFI/WebServer.cpp
@@ -165,7 +165,7 @@ void WebServer::OnWebSocketOpen(auto* websocket) {
 
 	m_deferredEventsQueue.emplace(DeferredEvent::Type::OPEN, clientID, "");
 
-	PerSocketData* perSocketData = websocket->getUserData();
+	const PerSocketData* perSocketData = websocket->getUserData();
 	m_websocketClientsMap[perSocketData->clientID] = websocket;
 }
 

--- a/Runtime/Bindings/FFI/interop/interop_ffi.cpp
+++ b/Runtime/Bindings/FFI/interop/interop_ffi.cpp
@@ -2,17 +2,17 @@
 
 #include <queue>
 
-std::queue<deferred_event_t>* queue_create() {
+deferred_event_queue_t queue_create() {
 	return new std::queue<deferred_event_t>();
 }
 
-size_t queue_size(const std::queue<deferred_event_t>* queue) {
+size_t queue_size(const deferred_event_queue_t queue) {
 	if(!queue) return 0;
 
 	return queue->size();
 }
 
-bool queue_push_event(std::queue<deferred_event_t>* queue, deferred_event_t event) {
+bool queue_push_event(deferred_event_queue_t queue, deferred_event_t event) {
 	if(!queue) return false;
 
 	queue->push(event);
@@ -20,7 +20,7 @@ bool queue_push_event(std::queue<deferred_event_t>* queue, deferred_event_t even
 	return true;
 }
 
-deferred_event_t queue_pop_event(std::queue<deferred_event_t>* queue) {
+deferred_event_t queue_pop_event(deferred_event_queue_t queue) {
 	if(queue->empty()) {
 		error_event_t error_details;
 		error_details.type = ERROR_EVENT;
@@ -36,7 +36,7 @@ deferred_event_t queue_pop_event(std::queue<deferred_event_t>* queue) {
 	return event;
 }
 
-void queue_destroy(std::queue<deferred_event_t>* queue) {
+void queue_destroy(deferred_event_queue_t queue) {
 	delete queue;
 }
 

--- a/Runtime/Bindings/FFI/interop/interop_ffi.cpp
+++ b/Runtime/Bindings/FFI/interop/interop_ffi.cpp
@@ -6,7 +6,7 @@ std::queue<deferred_event_t>* queue_create() {
 	return new std::queue<deferred_event_t>();
 }
 
-size_t queue_size(std::queue<deferred_event_t>* queue) {
+size_t queue_size(const std::queue<deferred_event_t>* queue) {
 	if(!queue) return 0;
 
 	return queue->size();

--- a/Runtime/Bindings/FFI/stbi/stbi.lua
+++ b/Runtime/Bindings/FFI/stbi/stbi.lua
@@ -49,6 +49,8 @@ typedef struct {
 	size_t num_bytes_used;
 } luajit_stringbuffer_t;
 
+typedef void (*stbi_write_callback_t)(void*, void*, int);
+
 struct static_stbi_exports_table {
 	const char* (*stbi_version)(void);
 

--- a/Runtime/Bindings/FFI/stbi/stbi_exports.h
+++ b/Runtime/Bindings/FFI/stbi/stbi_exports.h
@@ -30,6 +30,8 @@ typedef struct {
 	size_t num_bytes_used;
 } luajit_stringbuffer_t;
 
+typedef void (*stbi_write_callback_t)(void*, void*, int);
+
 struct static_stbi_exports_table {
 	const char* (*stbi_version)(void);
 

--- a/Runtime/Bindings/FFI/stbi/stbi_ffi.cpp
+++ b/Runtime/Bindings/FFI/stbi/stbi_ffi.cpp
@@ -69,7 +69,7 @@ bool stbi_image_free(stbi_image_t* image) {
 	return true;
 }
 
-static void append_to_buffer(void* context, void* chunk, int chunk_size) {
+static void append_to_buffer(void* context, const void* chunk, int chunk_size) {
 	luajit_stringbuffer_t* result = static_cast<luajit_stringbuffer_t*>(context);
 
 	bool hasBufferEnoughSpace = result->num_bytes_used + chunk_size <= result->capacity;
@@ -89,7 +89,8 @@ size_t stbi_encode_bmp(stbi_image_t* image, uint8_t* buffer, const size_t buffer
 	if(!image->data) return 0;
 
 	luajit_stringbuffer_t result = { buffer, buffer_size, 0 };
-	stbi_write_bmp_to_func(append_to_buffer, &result, image->width, image->height, image->channels, image->data);
+	auto write_callback = reinterpret_cast<stbi_write_callback_t>(append_to_buffer);
+	stbi_write_bmp_to_func(write_callback, &result, image->width, image->height, image->channels, image->data);
 
 	return result.num_bytes_used;
 }
@@ -100,7 +101,8 @@ size_t stbi_encode_png(stbi_image_t* image, uint8_t* buffer, const size_t buffer
 	if(!image->data) return 0;
 
 	luajit_stringbuffer_t result = { buffer, buffer_size, 0 };
-	stbi_write_png_to_func(append_to_buffer, &result, image->width, image->height, image->channels, image->data, stride);
+	auto write_callback = reinterpret_cast<stbi_write_callback_t>(append_to_buffer);
+	stbi_write_png_to_func(write_callback, &result, image->width, image->height, image->channels, image->data, stride);
 
 	return result.num_bytes_used;
 }
@@ -113,7 +115,8 @@ size_t stbi_encode_jpg(stbi_image_t* image, uint8_t* buffer, const size_t buffer
 	if(quality < 0 || quality > 100) quality = 100;
 
 	luajit_stringbuffer_t result = { buffer, buffer_size, 0 };
-	stbi_write_jpg_to_func(append_to_buffer, &result, image->width, image->height, image->channels, image->data, quality);
+	auto write_callback = reinterpret_cast<stbi_write_callback_t>(append_to_buffer);
+	stbi_write_jpg_to_func(write_callback, &result, image->width, image->height, image->channels, image->data, quality);
 
 	return result.num_bytes_used;
 }
@@ -124,7 +127,8 @@ size_t stbi_encode_tga(stbi_image_t* image, uint8_t* buffer, const size_t buffer
 	if(!image->data) return 0;
 
 	luajit_stringbuffer_t result = { buffer, buffer_size, 0 };
-	stbi_write_tga_to_func(append_to_buffer, &result, image->width, image->height, image->channels, image->data);
+	auto write_callback = reinterpret_cast<stbi_write_callback_t>(append_to_buffer);
+	stbi_write_tga_to_func(write_callback, &result, image->width, image->height, image->channels, image->data);
 
 	return result.num_bytes_used;
 }

--- a/deps/cppcheck.sh
+++ b/deps/cppcheck.sh
@@ -7,6 +7,6 @@ INCLUDE_DIRS="-I Runtime -I Runtime/Bindings"
 SRC_DIRS="Runtime/*"
 IGNORE_LIST=".cppcheck"
 
-RELEVANT_FILES=$(find $SRC_DIRS -type f \( -name '*.c' -o -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \))
+RELEVANT_FILES=$(find $SRC_DIRS -type f \( -name '*.c' -o -name '*.cpp' \))
 
 cppcheck --enable=all --error-exitcode=127 --suppressions-list=$IGNORE_LIST $INCLUDE_DIRS $RELEVANT_FILES

--- a/deps/cppcheck.sh
+++ b/deps/cppcheck.sh
@@ -9,4 +9,4 @@ IGNORE_LIST=".cppcheck"
 
 RELEVANT_FILES=$(find $SRC_DIRS -type f \( -name '*.c' -o -name '*.cpp' \))
 
-cppcheck --enable=all --error-exitcode=127 --suppressions-list=$IGNORE_LIST $INCLUDE_DIRS $RELEVANT_FILES
+cppcheck --enable=all --check-level=exhaustive --error-exitcode=127 --suppressions-list=$IGNORE_LIST $INCLUDE_DIRS $RELEVANT_FILES


### PR DESCRIPTION
Should probably remove the ignore list entirely to reduce the maintenance overhead, but I'll save that for later.