### PR TITLE
Pin GitHub runner image versions for all CI workflows

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-15, windows-2025]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             stylua: stylua-linux-x86_64.zip
             exe: ""
-          - os: macos-latest
+          - os: macos-15
             stylua: stylua-macos-x86_64.zip
             exe: ""
-          - os: windows-latest
+          - os: windows-2025
             stylua: stylua-windows-x86_64.zip
             exe: ".exe"
     defaults:

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     if: github.event.pull_request.draft == false
     name: Build for Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -27,12 +27,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, macos-14]
         include:
-          - os: macos-latest
-            arch: x64
-          - os: macos-14
-            arch: M1
+          - os: macos-15
+            arch: [x64, M1]
     env:
         MACOSX_DEPLOYMENT_TARGET: 10.13
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1 # Prevent brew updates in the ccache setup step (~2GB download ...)

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -109,9 +109,6 @@ jobs:
             ninjabuild-windows/libnyquist.a
           key: labsound-${{ steps.revparse.outputs.labsound }}-${{ hashFiles('deps/labsound-windowsbuild.sh') }}-${{ runner.os }}
 
-      - name: Start Windows Audio engine # Required for LabSound tests
-        run: net start audiosrv
-
       - name: Set up virtual audio device # Required for LabSound tests
         uses: LABSN/sound-ci-helpers@v1
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     if: github.event.pull_request.draft == false
     name: Build for Windows
-    runs-on: windows-latest
+    runs-on: windows-2025
     env:
       SCCACHE_GHA_ENABLED: "true"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   analyze:
     name: Scan with CodeQL
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-22.04'
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   luacheck:
     name: Lint codebase
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
         CPPCHECK_VERSION: 2.10.3
     steps:


### PR DESCRIPTION
Upgrading to the latest Ubuntu version will require fixing a bunch of problems. Until there's time to tackle all that, the CI workflows won't succeed if using the `latest` tag. See upgrade notes in [actions/runner-images](https://github.com/actions/runner-images) for details.

There's many software and toolchain differences, as well as some redundant steps to be pruned that I've noticed while checking the runner-images repository. Those should be resolved individually; for now, the highest priority is to just restore the capability of CI workflows to detect breaking changes (that aren't caused by third parties).

I'm also pinning macOS and Windows since the same problem could in theory affect those runners, even if it doesn't appear to be the case right now. I do eventually want to upgrade the toolchains used on macOS (latest clang instead of Apple's default), which will also be much easier if the exact image version is known.