### PR TITLE
Enable parallel submodule clones for all build workflows

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -28,10 +28,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: "0" # Required so that git describe actually works (and we can embed the version tag)
+        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recursive --jobs=$(nproc)
 
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -35,21 +35,18 @@ jobs:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1 # Prevent brew updates in the ccache setup step (~2GB download ...)
 
     steps:
+        # nproc is used to determine the number of parallel jobs
+      - name: Install GNU coreutils
+        run: brew install coreutils
+
       - name: Check out Git repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: "0" # Required so that git describe actually works (and we can embed the version tag)
+        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recursive --jobs=$(nproc)
 
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2
 
       - name: Install Ninja
         run: brew install ninja
-
-        # nproc is used by build scripts to determine the number of parallel jobs
-      - name: Install GNU coreutils
-        run: brew install coreutils
 
       - name: Configure environment
         run: |

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -45,10 +45,7 @@ jobs:
           git config --global core.eol lf
 
       - name: Check out Git repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: "0" # Required so that git describe actually works (and we can embed the version tag)
+        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recursive --jobs=$(nproc)
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,11 +39,7 @@ jobs:
 
     steps:
       - name: Checkout Git repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          # Required so that git describe actually works (and we can discover version tags)
-          fetch-depth: "0"
+        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recursive --jobs=$(nproc)
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL scan


### PR DESCRIPTION
This action doesn't currently support the `--jobs` command. Unfortunately, cloning a lot of submodules is rather slow.

Parallel clones seem to reduce the time by a minute or so, but there's obviously no difference in workflows that don't require a recursive checkout.
