### PR TITLE
Enable shallow submodule clones for all build workflows

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recursive --jobs=$(nproc)
+        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recurse-submodules --shallow-submodules --depth=1 --tags --jobs=$(nproc)
 
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -40,7 +40,7 @@ jobs:
         run: brew install coreutils
 
       - name: Check out Git repository
-        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recursive --jobs=$(nproc)
+        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recurse-submodules --shallow-submodules --depth=1 --tags --jobs=$(nproc)
 
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -45,7 +45,7 @@ jobs:
           git config --global core.eol lf
 
       - name: Check out Git repository
-        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recursive --jobs=$(nproc)
+        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recurse-submodules --shallow-submodules --depth=1 --tags --jobs=$(nproc)
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout Git repository
-        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recursive --jobs=$(nproc)
+        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recurse-submodules --shallow-submodules --depth=1 --tags --jobs=$(nproc)
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL scan


### PR DESCRIPTION
This should further reduce the time of the CI workflows.

Tags have to be fetched manually since versions are determined using `git describe`.