### PR TITLE
Bump the macOS deployment target to 13.3

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -31,7 +31,7 @@ jobs:
           - os: macos-15
             arch: [x64, M1]
     env:
-        MACOSX_DEPLOYMENT_TARGET: 10.13
+        MACOSX_DEPLOYMENT_TARGET: 13.3
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1 # Prevent brew updates in the ccache setup step (~2GB download ...)
 
     steps:


### PR DESCRIPTION
Without this, a number of desirable (modern) features aren't available. Both Apple and Homebrew support only the last three major releases, so there's not much sense in trying to support older versions - at least for now.