### PR TITLE
Fix bcsave-related deprecation warnings on macOS

### DIFF
--- a/BuildTools/BuildTarget.lua
+++ b/BuildTools/BuildTarget.lua
@@ -175,7 +175,8 @@ function BuildTarget:ProcessLuaSources()
 	local objectFiles = self.objectFiles
 
 	for index, luaSourceFilePath in ipairs(self.luaSources) do
-		local outputFile = string.format("%s/%s.%s", self.BUILD_DIR, luaSourceFilePath, "c")
+		local outputFile =
+			string.format("%s/%s.%s", self.BUILD_DIR, luaSourceFilePath, NinjaBuildTools.OBJECT_FILE_EXTENSION)
 		ninjaFile:AddBuildEdge(outputFile, "bcsave " .. luaSourceFilePath)
 		table.insert(objectFiles, outputFile)
 	end


### PR DESCRIPTION
Currently the runtime is compiled in Objective C compatibility mode because of glfw3webgpu, which unfortunately still hasn't been merged upstream yet (see 43dbf1e for context). LuaJIT bytecode objects are passed as C files to the linker, but the runtime is of course a C++ executable - hence the warning.

This was previously changed in 8e0af2e when adding support for M1 builds, because the generated bytecode objects were misaligned. I don't know if the alignment issues are still present, but there's only one way to find out...