### PR TITLE
Remove the hardcoded CPPCHECK_VERSION

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,8 +19,6 @@ jobs:
   luacheck:
     name: Lint codebase
     runs-on: ubuntu-24.04
-    env:
-        CPPCHECK_VERSION: 2.16.0
     steps:
 
       # LuaRocks needs the 5.1 headers to compile LuaCheck later, so we download them, too
@@ -56,13 +54,10 @@ jobs:
       - name: Run selene
         run: selene .
 
-      # apt only has an ancient version, which behaves inconsistently
       - name: Install cppcheck
         run: |
           git clone --depth 1 https://github.com/danmar/cppcheck.git
           cd cppcheck
-          git fetch --tags
-          git checkout $CPPCHECK_VERSION
           mkdir build
           cd build
           cmake ..


### PR DESCRIPTION
Since cppcheck is built from source anyway, there's no good reason to not just use the latest version.