### PR TITLE
Fix a capitalization issue in the submodule updater

### DIFF
--- a/BuildTools/update-submodules.lua
+++ b/BuildTools/update-submodules.lua
@@ -84,7 +84,7 @@ function SubmoduleUpdater:GetHelpText(submodules)
 	local indent = "  "
 	local readableList = indent .. table.concat(sortedKeys, "\n" .. indent)
 
-	return "Valid submodule IDs:\n\n" .. readableList:lower()
+	return "Valid submodule IDs:\n\n" .. readableList
 end
 
 local gitmodulesFileContents = C_FileSystem.ReadFile(".gitmodules")
@@ -97,7 +97,7 @@ if not submoduleID then
 	os.exit(1)
 end
 
-local submoduleToUpdate = submodules[submoduleID] or submodules[submoduleID:lower()]
+local submoduleToUpdate = submodules[submoduleID]
 if not submoduleToUpdate then
 	printf(red("Cannot upgrade submodule %s (invalid submodule ID)\n"), submoduleID)
 	print(SubmoduleUpdater:GetHelpText(submodules))


### PR DESCRIPTION
This doesn't look right. If the submodule name is case-sensitive, then it can't be selected by converting to lower-case.

It would be possible to look up the keys and ignore capitalization to find a match, but that seems a tad excessive.