### PR TITLE
Enable the classic linker for macOS builds

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -33,8 +33,7 @@ jobs:
           - os: macos-15
             arch: M1
     env:
-        MACOSX_DEPLOYMENT_TARGET: 13.3
-        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1 # Prevent brew updates in the ccache setup step (~2GB download ...)
+        MACOSX_DEPLOYMENT_TARGET: 15.3
 
     steps:
         # nproc is used to determine the number of parallel jobs
@@ -44,16 +43,12 @@ jobs:
       - name: Check out Git repository
         run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recursive --jobs=$(nproc)
 
-      - name: Set up ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-
       - name: Install Ninja
         run: brew install ninja
 
       - name: Configure environment
         run: |
-          echo "CC=ccache gcc" >> $GITHUB_ENV
-          echo "CXX=ccache g++" >> $GITHUB_ENV
+          echo | clang -dM -E - | grep __apple_build_version__
       - name: Build luajit
         run: deps/luajit-unixbuild.sh && ls ninjabuild-unix
 

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -33,7 +33,8 @@ jobs:
           - os: macos-15
             arch: M1
     env:
-        MACOSX_DEPLOYMENT_TARGET: 15.3
+        MACOSX_DEPLOYMENT_TARGET: 13.3
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1 # Prevent brew updates in the ccache setup step (~2GB download ...)
 
     steps:
         # nproc is used to determine the number of parallel jobs
@@ -43,12 +44,16 @@ jobs:
       - name: Check out Git repository
         run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recursive --jobs=$(nproc)
 
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+
       - name: Install Ninja
         run: brew install ninja
 
       - name: Configure environment
         run: |
-          echo | clang -dM -E - | grep __apple_build_version__
+          echo "CC=ccache gcc" >> $GITHUB_ENV
+          echo "CXX=ccache g++" >> $GITHUB_ENV
       - name: Build luajit
         run: deps/luajit-unixbuild.sh && ls ninjabuild-unix
 

--- a/BuildTools/BuildTarget.lua
+++ b/BuildTools/BuildTarget.lua
@@ -175,8 +175,7 @@ function BuildTarget:ProcessLuaSources()
 	local objectFiles = self.objectFiles
 
 	for index, luaSourceFilePath in ipairs(self.luaSources) do
-		local outputFile =
-			string.format("%s/%s.%s", self.BUILD_DIR, luaSourceFilePath, NinjaBuildTools.OBJECT_FILE_EXTENSION)
+		local outputFile = string.format("%s/%s.%s", self.BUILD_DIR, luaSourceFilePath, "c")
 		ninjaFile:AddBuildEdge(outputFile, "bcsave " .. luaSourceFilePath)
 		table.insert(objectFiles, outputFile)
 	end

--- a/BuildTools/BuildTarget.lua
+++ b/BuildTools/BuildTarget.lua
@@ -175,8 +175,7 @@ function BuildTarget:ProcessLuaSources()
 	local objectFiles = self.objectFiles
 
 	for index, luaSourceFilePath in ipairs(self.luaSources) do
-		local outputFile =
-			string.format("%s/%s.%s", self.BUILD_DIR, luaSourceFilePath, ".cpp")
+		local outputFile = string.format("%s/%s.%s", self.BUILD_DIR, luaSourceFilePath, "c")
 		ninjaFile:AddBuildEdge(outputFile, "bcsave " .. luaSourceFilePath)
 		table.insert(objectFiles, outputFile)
 	end

--- a/BuildTools/BuildTarget.lua
+++ b/BuildTools/BuildTarget.lua
@@ -175,7 +175,8 @@ function BuildTarget:ProcessLuaSources()
 	local objectFiles = self.objectFiles
 
 	for index, luaSourceFilePath in ipairs(self.luaSources) do
-		local outputFile = string.format("%s/%s.%s", self.BUILD_DIR, luaSourceFilePath, "c")
+		local outputFile =
+			string.format("%s/%s.%s", self.BUILD_DIR, luaSourceFilePath, ".cpp")
 		ninjaFile:AddBuildEdge(outputFile, "bcsave " .. luaSourceFilePath)
 		table.insert(objectFiles, outputFile)
 	end

--- a/BuildTools/BuildTarget.lua
+++ b/BuildTools/BuildTarget.lua
@@ -176,7 +176,7 @@ function BuildTarget:ProcessLuaSources()
 
 	for index, luaSourceFilePath in ipairs(self.luaSources) do
 		local outputFile =
-			string.format("%s/%s.%s", self.BUILD_DIR, luaSourceFilePath, ".cpp")
+			string.format("%s/%s.%s", self.BUILD_DIR, luaSourceFilePath, NinjaBuildTools.OBJECT_FILE_EXTENSION)
 		ninjaFile:AddBuildEdge(outputFile, "bcsave " .. luaSourceFilePath)
 		table.insert(objectFiles, outputFile)
 	end

--- a/BuildTools/BuildTarget.lua
+++ b/BuildTools/BuildTarget.lua
@@ -176,7 +176,7 @@ function BuildTarget:ProcessLuaSources()
 
 	for index, luaSourceFilePath in ipairs(self.luaSources) do
 		local outputFile =
-			string.format("%s/%s.%s", self.BUILD_DIR, luaSourceFilePath, NinjaBuildTools.OBJECT_FILE_EXTENSION)
+			string.format("%s/%s.%s", self.BUILD_DIR, luaSourceFilePath, ".cpp")
 		ninjaFile:AddBuildEdge(outputFile, "bcsave " .. luaSourceFilePath)
 		table.insert(objectFiles, outputFile)
 	end

--- a/BuildTools/NinjaBuildTools.lua
+++ b/BuildTools/NinjaBuildTools.lua
@@ -21,17 +21,13 @@ local C_BuildTools = {
 		displayName = "GNU Compiler Collection",
 		C_COMPILER = "gcc",
 		CPP_COMPILER = "g++",
-		COMPILER_FLAGS_CPP = DEFAULT_COMPILER_FLAGS
-			.. " -std=c++20"
-			.. (isMacOS and " -Wl,-ld64 -Wl,-no_deduplicate" or ""),
+		COMPILER_FLAGS_CPP = DEFAULT_COMPILER_FLAGS .. " -std=c++20",
 		-- Forced ObjC compilation should be removed once glfw3webgpu is merged into the GLFW core library
-		COMPILER_FLAGS_C = DEFAULT_COMPILER_FLAGS
-			.. " -std=c11"
-			.. (isMacOS and " -ObjC -Wl,-ld64 -Wl,-no_deduplicate" or ""),
+		COMPILER_FLAGS_C = DEFAULT_COMPILER_FLAGS .. " -std=c11" .. (isMacOS and " -ObjC" or ""),
 		C_LINKER = "gcc",
 		CPP_LINKER = "g++",
 		-- Must export the entry point of bytecode objects so that LuaJIT can load them via require()
-		LINKER_FLAGS = isWindows and "-Wl,--export-all-symbols" or "-rdynamic -no_deduplicate -ld64",
+		LINKER_FLAGS = isWindows and "-Wl,--export-all-symbols" or "-rdynamic",
 		C_ARCHIVER = "ar",
 		CPP_ARCHIVER = "ar",
 		ARCHIVER_FLAGS = "-rcs",

--- a/BuildTools/NinjaBuildTools.lua
+++ b/BuildTools/NinjaBuildTools.lua
@@ -23,15 +23,15 @@ local C_BuildTools = {
 		CPP_COMPILER = "g++",
 		COMPILER_FLAGS_CPP = DEFAULT_COMPILER_FLAGS
 			.. " -std=c++20"
-			.. (isMacOS and " -Wl,-ld64 -Wl,-no_deduplicate" or ""),
+			.. (isMacOS and " -Wl,-ld_classic -Wl,-no_deduplicate" or ""),
 		-- Forced ObjC compilation should be removed once glfw3webgpu is merged into the GLFW core library
 		COMPILER_FLAGS_C = DEFAULT_COMPILER_FLAGS
 			.. " -std=c11"
-			.. (isMacOS and " -ObjC -Wl,-ld64 -Wl,-no_deduplicate" or ""),
+			.. (isMacOS and " -ObjC -Wl,-ld_classic -Wl,-no_deduplicate" or ""),
 		C_LINKER = "gcc",
 		CPP_LINKER = "g++",
 		-- Must export the entry point of bytecode objects so that LuaJIT can load them via require()
-		LINKER_FLAGS = isWindows and "-Wl,--export-all-symbols" or "-rdynamic -no_deduplicate -ld64",
+		LINKER_FLAGS = isWindows and "-Wl,--export-all-symbols" or "-rdynamic -no_deduplicate -Wl,-ld_classic",
 		C_ARCHIVER = "ar",
 		CPP_ARCHIVER = "ar",
 		ARCHIVER_FLAGS = "-rcs",

--- a/BuildTools/NinjaBuildTools.lua
+++ b/BuildTools/NinjaBuildTools.lua
@@ -21,13 +21,17 @@ local C_BuildTools = {
 		displayName = "GNU Compiler Collection",
 		C_COMPILER = "gcc",
 		CPP_COMPILER = "g++",
-		COMPILER_FLAGS_CPP = DEFAULT_COMPILER_FLAGS .. " -std=c++20",
+		COMPILER_FLAGS_CPP = DEFAULT_COMPILER_FLAGS
+			.. " -std=c++20"
+			.. (isMacOS and " -Wl,-ld64 -Wl,-no_deduplicate" or ""),
 		-- Forced ObjC compilation should be removed once glfw3webgpu is merged into the GLFW core library
-		COMPILER_FLAGS_C = DEFAULT_COMPILER_FLAGS .. " -std=c11" .. (isMacOS and " -ObjC" or ""),
+		COMPILER_FLAGS_C = DEFAULT_COMPILER_FLAGS
+			.. " -std=c11"
+			.. (isMacOS and " -ObjC -Wl,-ld64 -Wl,-no_deduplicate" or ""),
 		C_LINKER = "gcc",
 		CPP_LINKER = "g++",
 		-- Must export the entry point of bytecode objects so that LuaJIT can load them via require()
-		LINKER_FLAGS = isWindows and "-Wl,--export-all-symbols" or "-rdynamic",
+		LINKER_FLAGS = isWindows and "-Wl,--export-all-symbols" or "-rdynamic -no_deduplicate -ld64",
 		C_ARCHIVER = "ar",
 		CPP_ARCHIVER = "ar",
 		ARCHIVER_FLAGS = "-rcs",

--- a/BuildTools/NinjaBuildTools.lua
+++ b/BuildTools/NinjaBuildTools.lua
@@ -23,15 +23,15 @@ local C_BuildTools = {
 		CPP_COMPILER = "g++",
 		COMPILER_FLAGS_CPP = DEFAULT_COMPILER_FLAGS
 			.. " -std=c++20"
-			.. (isMacOS and " -Wl,-ld_classic -Wl,-no_deduplicate" or ""),
+			.. (isMacOS and " -Wl,-ld64 -Wl,-no_deduplicate" or ""),
 		-- Forced ObjC compilation should be removed once glfw3webgpu is merged into the GLFW core library
 		COMPILER_FLAGS_C = DEFAULT_COMPILER_FLAGS
 			.. " -std=c11"
-			.. (isMacOS and " -ObjC -Wl,-ld_classic -Wl,-no_deduplicate" or ""),
+			.. (isMacOS and " -ObjC -Wl,-ld64 -Wl,-no_deduplicate" or ""),
 		C_LINKER = "gcc",
 		CPP_LINKER = "g++",
 		-- Must export the entry point of bytecode objects so that LuaJIT can load them via require()
-		LINKER_FLAGS = isWindows and "-Wl,--export-all-symbols" or "-rdynamic -no_deduplicate -Wl,-ld_classic",
+		LINKER_FLAGS = isWindows and "-Wl,--export-all-symbols" or "-rdynamic -no_deduplicate -ld64",
 		C_ARCHIVER = "ar",
 		CPP_ARCHIVER = "ar",
 		ARCHIVER_FLAGS = "-rcs",


### PR DESCRIPTION
The rewritten one seems to mess up the generated object files (see LuaJIT issues, there's several recent ones related to M1). Since I've no way of testing this, let's just see if it fixes the build failures or if reverting is in order.