### PR TITLE
Combine actions/checkout with parallel clones

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -27,8 +27,14 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      - name: Update git config
+        run: git config --global submodule.fetchJobs $(nproc) && git config --global --list
+
       - name: Check out Git repository
-        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recursive --jobs=$(nproc)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -41,8 +41,14 @@ jobs:
       - name: Install GNU coreutils
         run: brew install coreutils
 
+      - name: Update git config
+        run: git config --global submodule.fetchJobs $(nproc) && git config --global --list
+
       - name: Check out Git repository
-        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recursive --jobs=$(nproc)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
       - name: Set up ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -44,8 +44,14 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
 
+      - name: Update git config
+        run: git config --global submodule.fetchJobs $(nproc) && git config --global --list
+
       - name: Check out Git repository
-        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recursive --jobs=$(nproc)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.6

--- a/BuildTools/BuildTarget.lua
+++ b/BuildTools/BuildTarget.lua
@@ -175,8 +175,7 @@ function BuildTarget:ProcessLuaSources()
 	local objectFiles = self.objectFiles
 
 	for index, luaSourceFilePath in ipairs(self.luaSources) do
-		local outputFile =
-			string.format("%s/%s.%s", self.BUILD_DIR, luaSourceFilePath, NinjaBuildTools.OBJECT_FILE_EXTENSION)
+		local outputFile = string.format("%s/%s.%s", self.BUILD_DIR, luaSourceFilePath, "c")
 		ninjaFile:AddBuildEdge(outputFile, "bcsave " .. luaSourceFilePath)
 		table.insert(objectFiles, outputFile)
 	end


### PR DESCRIPTION
That was a terrible idea, but in theory it should be possible to get parallel clones without having to handle checkouts.

Also reverting the Objective C "fix" since it still seems to break on M1. Simply saving C++ files should also work.