### PR TITLE
Fix the CodeQL workflow's git checkout step

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,8 +38,14 @@ jobs:
         language: ['cpp']
 
     steps:
-      - name: Checkout Git repository
-        run: cd .. && git clone https://github.com/evo-lua/evo-runtime --recursive --jobs=$(nproc)
+      - name: Update git config
+        run: git config --global submodule.fetchJobs $(nproc) && git config --global --list
+
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: recursive
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL scan


### PR DESCRIPTION
Forgot that one when modifying the other build workflows. Obviously, this should be checking out the actual branch as well. Using a shallow clone seems OK here since the scan doesn't have to be running any tests.