### PR TITLE
Exclude .ninja_lock from VCS tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,5 @@ build.ninja
 CHANGELOG.MD
 .DS_Store
 .n2_db
+.ninja_lock
 deps/versions.lua


### PR DESCRIPTION
It's usually deleted before git will even see it, but removing any potential for this to be committed seems better.