### PR TITLE
Remove the paths-ignore option from all build workflows

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -12,10 +12,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'changelog.lua'
-      - '.gitignore'
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -12,10 +12,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'changelog.lua'
-      - '.gitignore'
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -12,10 +12,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'changelog.lua'
-      - '.gitignore'
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
The idea here was probably to avoid wasting CI time... but it prevents minor changes, like #637, from being merged because all build workflows are required checks. GitHub's branch protection feature is clearly half-baked. Luckily minor changes like these virtually never happen, so for the time being it shouldn't be a big problem to remove this setting.

Edit: I'd also prefer for the CI to be less wasteful by means of being faster, but that's a future concern.