### PR TITLE
Remove the paths-ignore filter from all CI workflows

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -2,15 +2,10 @@ name: Autoformat
 
 on:
   pull_request:
-    paths-ignore:
-      - "README.MD"
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
-    paths-ignore:
-      - "README.MD"
-      - '.gitignore'
 
 jobs:
   check-format:

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -6,8 +6,6 @@ on:
       - main
     tags:
       - '*'
-    paths-ignore:
-      - '**.md'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -6,8 +6,6 @@ on:
       - main
     tags:
       - '*'
-    paths-ignore:
-      - '**.md'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -6,8 +6,6 @@ on:
       - main
     tags:
       - '*'
-    paths-ignore:
-      - '**.md'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,16 +6,10 @@ on:
       - main
     tags:
       - '*'
-    paths-ignore:
-      - '**.md'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'changelog.lua'
-      - '.gitignore'
   schedule:
     - cron: '00 00 * * 6'
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -2,18 +2,10 @@ name: Static Analysis
 
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'changelog.lua'
-      - '.gitignore'
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - 'changelog.lua'
-      - '.gitignore'
 
 jobs:
   luacheck:


### PR DESCRIPTION
Follow-up to #638. This is still blocking and it doesn't seem very useful. Perhaps there's a more reliable way?