### PR TITLE
Enable fail-fast for the CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       security-events: write
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         language: ['cpp']
 


### PR DESCRIPTION
Unlike the other build workflows, this one didn't stop executing when one of the other runners has already failed.