### PR TITLE
Disable some unnecessary zlib build options

### DIFF
--- a/deps/zlib-unixbuild.sh
+++ b/deps/zlib-unixbuild.sh
@@ -6,7 +6,8 @@ OUT_DIR=ninjabuild-unix
 SRC_DIR=deps/madler/zlib
 BUILD_DIR=$SRC_DIR/cmakebuild-unix
 
-cmake -S $SRC_DIR -B $BUILD_DIR -G Ninja -DBUILD_SHARED_LIBS=ON -DCMAKE_C_COMPILER=gcc
+ZLIB_BUILD_FLAGS="-DZLIB_BUILD_EXAMPLES=OFF -DSKIP_INSTALL_ALL=ON"
+cmake -S $SRC_DIR -B $BUILD_DIR -G Ninja -DBUILD_SHARED_LIBS=ON -DCMAKE_C_COMPILER=gcc $ZLIB_BUILD_FLAGS
 cmake --build $BUILD_DIR --clean-first
 
 cp $BUILD_DIR/libz.a $OUT_DIR/zlibstatic.a

--- a/deps/zlib-windowsbuild.sh
+++ b/deps/zlib-windowsbuild.sh
@@ -6,7 +6,8 @@ OUT_DIR=ninjabuild-windows
 SRC_DIR=deps/madler/zlib
 BUILD_DIR=$SRC_DIR/cmakebuild-windows
 
-cmake -S $SRC_DIR -B $BUILD_DIR -G Ninja -DBUILD_SHARED_LIBS=ON -DCMAKE_C_COMPILER=gcc
+ZLIB_BUILD_FLAGS="-DZLIB_BUILD_EXAMPLES=OFF -DSKIP_INSTALL_ALL=ON"
+cmake -S $SRC_DIR -B $BUILD_DIR -G Ninja -DBUILD_SHARED_LIBS=ON -DCMAKE_C_COMPILER=gcc $ZLIB_BUILD_FLAGS
 cmake --build $BUILD_DIR --clean-first
 
 cp $BUILD_DIR/libzlibstatic.a $OUT_DIR/zlibstatic.a


### PR DESCRIPTION
None of these are particularly useful here, but they are wasting a little bit of time and other resources.

TODOs:

- [x] Enable the same flags on macOS/Linux
- [x] Rebase after merging the `vfs.dlopen` PR (options may conflict)