### PR TITLE
Rework the interface for the iconv.convert FFI bindings

### DIFF
--- a/Benchmarks/iconv-charset-conversion.lua
+++ b/Benchmarks/iconv-charset-conversion.lua
@@ -1,11 +1,14 @@
 local console = require("console")
 local iconv = require("iconv")
 local ffi = require("ffi")
+local jit = require("jit")
 
 local SAMPLE_SIZE = 500000
 
-local function iconv_lowlevel()
-	local input = "\192\175\192\250\192\206\197\205\198\228\192\204\189\186"
+local UTF_MAX_BYTES_PER_CODEPOINT = 4
+local CP949_INPUT_STRING = "\192\175\192\250\192\206\197\205\198\228\192\204\189\186"
+local UTF8_OUTPUT_STRING = "유저인터페이스"
+local function iconv_lowlevel(input)
 	local descriptor = iconv.bindings.iconv_open("UTF-8", "CP949")
 
 	local inputSize = ffi.new("size_t[1]", #input)
@@ -22,46 +25,70 @@ local function iconv_lowlevel()
 	local converted = ffi.string(outputBuffer, numConversionsPerformed)
 
 	iconv.bindings.iconv_close(descriptor)
-	return converted, result
+	return result, converted
 end
 
-local function iconv_lua()
-	local input = "\192\175\192\250\192\206\197\205\198\228\192\204\189\186"
+local function iconv_lua(input)
 	local output, message = iconv.convert(input, "CP949", "UTF-8")
 	return output, message
 end
 
-local function iconv_cpp()
-	local inputBuffer = buffer.new()
-	local outputBuffer = buffer.new(1024)
-	local ptr, len = outputBuffer:reserve(1024)
-	local result = iconv.bindings.iconv_convert(inputBuffer, #inputBuffer, "CP949", "UTF-8", ptr, len)
-	return result
+-- This should more or less match what iconv.convert is doing, minus validation/error handling
+local readBuffer = buffer.new()
+local writeBuffer = buffer.new()
+local request = ffi.new("iconv_request_t")
+local function iconv_cpp(input)
+	readBuffer:put(input)
+	local readCursor = readBuffer:ref()
+
+	writeBuffer:reset()
+	local writeCursor, writeBufferSize = writeBuffer:reserve(#input * UTF_MAX_BYTES_PER_CODEPOINT)
+
+	request.input.charset = "CP949"
+	request.input.buffer = readCursor
+	request.input.length = #input
+	request.input.remaining = #input
+
+	request.output.charset = "UTF-8"
+	request.output.buffer = writeCursor
+	request.output.length = writeBufferSize
+	request.output.remaining = writeBufferSize
+
+	local result = iconv.bindings.iconv_convert(request)
+	local numBytesWritten = tonumber(request.output.length - request.output.remaining)
+	writeBuffer:commit(numBytesWritten)
+
+	return result, tostring(writeBuffer)
 end
 
 math.randomseed(os.clock())
 local availableBenchmarks = {
 	function()
-		local label = "[FFI] Low-level API (tedious and slow, but the most flexible)"
+		local label = "[FFI] Multi-step conversions using the libiconv API directly (manual descriptor management)"
 		console.startTimer(label)
 		for i = 1, SAMPLE_SIZE, 1 do
-			iconv_lowlevel()
+			local result, output = iconv_lowlevel(CP949_INPUT_STRING)
+			assert(result == ffi.C.ICONV_RESULT_OK, iconv.strerror(result))
+			assert(output == UTF8_OUTPUT_STRING, output)
 		end
 		console.stopTimer(label)
 	end,
 	function()
-		local label = "[FFI] One-shot C++ conversion (fast but less flexible)"
+		local label = "[FFI] Immediate conversion using iconv.bindings.iconv_convert (manual buffer management)"
 		console.startTimer(label)
 		for i = 1, SAMPLE_SIZE, 1 do
-			iconv_cpp()
+			local result, output = iconv_cpp(CP949_INPUT_STRING)
+			assert(result == ffi.C.ICONV_RESULT_OK, iconv.strerror(result))
+			assert(output == UTF8_OUTPUT_STRING, output)
 		end
 		console.stopTimer(label)
 	end,
 	function()
-		local label = "[FFI] Lua-friendly wrapper (safer, but slower)"
+		local label = "[FFI] Immediate conversion using iconv.convert (idiomatic Lua wrapper, with preallocation)"
 		console.startTimer(label)
 		for i = 1, SAMPLE_SIZE, 1 do
-			iconv_lua()
+			local output, message = iconv_lua(CP949_INPUT_STRING)
+			assert(output == UTF8_OUTPUT_STRING, message)
 		end
 		console.stopTimer(label)
 	end,

--- a/Benchmarks/iconv-charset-conversion.lua
+++ b/Benchmarks/iconv-charset-conversion.lua
@@ -68,7 +68,15 @@ local availableBenchmarks = {
 }
 
 table.shuffle(availableBenchmarks)
+jit.off()
+print("Running benchmarks with JIT=OFF")
+for _, benchmark in ipairs(availableBenchmarks) do
+	benchmark()
+end
 
+table.shuffle(availableBenchmarks)
+print("Running benchmarks with JIT=ON")
+jit.on()
 for _, benchmark in ipairs(availableBenchmarks) do
 	benchmark()
 end

--- a/Runtime/Bindings/FFI/iconv/iconv.lua
+++ b/Runtime/Bindings/FFI/iconv/iconv.lua
@@ -3,87 +3,106 @@ local validation = require("validation")
 
 local validateString = validation.validateString
 
-local ffi_string = ffi.string
 local tonumber = tonumber
 local tostring = tostring
 
-local iconv = {
-	errorMessages = {
-		INVALID_CONVERSION_HANDLE = "Cannot close an invalid iconv_t descriptor",
-	},
-}
+local UTF_MAX_BYTES_PER_CODEPOINT = 4
+
+local iconv = {}
 
 iconv.cdefs = [[
 typedef void* iconv_t;
-typedef struct iconv_result_t {
-	uint8_t status_code;
-	size_t num_bytes_written;
-	const char* message;
+typedef enum iconv_result_t {
+	ICONV_RESULT_OK,
+	ICONV_INVALID_REQUEST,
+	ICONV_INVALID_DESCRIPTOR,
+	ICONV_INVALID_INPUT,
+	ICONV_INVALID_OUTPUT,
+	ICONV_CONVERSION_FAILED,
+	ICONV_INCOMPLETE_INPUT,
+	ICONV_WRITEBUFFER_FULL,
+	ICONV_RESULT_LAST,
 } iconv_result_t;
 
+typedef char* iconv_cursor_t;
+typedef const char* iconv_encoding_t; // Aliased for now, replace with enum later
+
+typedef struct iconv_memory_t {
+	iconv_encoding_t charset;
+	iconv_cursor_t buffer;
+	size_t length;
+	size_t remaining;
+} iconv_memory_t;
+
+typedef struct iconv_request_t {
+	iconv_memory_t input;
+	iconv_memory_t output;
+	iconv_t handle;
+} iconv_request_t;
+
 struct static_iconv_exports_table {
-	iconv_result_t (*iconv_convert)(char* input, size_t input_size, const char* input_encoding, const char* output_encoding, char* output, size_t output_size);
+
+	// Exports from iconv.h
 	iconv_t (*iconv_open)(const char* input_encoding, const char* output_encoding);
 	int (*iconv_close)(iconv_t conversion_descriptor);
 	size_t (*iconv)(iconv_t conversion_descriptor, char** input, size_t* input_size, char** output, size_t* output_size);
 
-	// Shared constants
-	size_t CHARSET_CONVERSION_FAILED;
+	// Charset conversion API
+	iconv_result_t (*iconv_convert)(iconv_request_t* conversion_details);
+	iconv_result_t (*iconv_try_close)(iconv_request_t* request);
+
+	// Utility methods
+	const char* (*iconv_strerror)(iconv_result_t status);
+	bool (*iconv_check_result)(iconv_t handle);
 };
 
 ]]
 
--- Should probably move this elsewhere?
-local function ffi_strerror(errno)
-	return ffi.string(ffi.C.strerror(errno))
-end
-
 function iconv.initialize()
-	ffi.cdef([[
-		// Should probably move this elsewhere?
-		char *strerror(int errnum);
-	]])
-
 	ffi.cdef(iconv.cdefs)
 end
 
-local UTF_BYTES_PER_CODEPOINT = 4
-
+local request, readBuffer, writeBuffer
 function iconv.convert(input, inputEncoding, outputEncoding)
 	validateString(input, "input")
 	validateString(inputEncoding, "inputEncoding")
 	validateString(outputEncoding, "outputEncoding")
 
-	if #input == 0 then
-		-- Prevents LuaJIT from trying to collect a NULL buffer (= crash)
-		return nil, ffi_strerror(22) -- EINVAL
+	-- Preallocate resources only when needed; it's somewhat costly otherwise
+	request = request or ffi.new("iconv_request_t")
+	readBuffer = readBuffer or buffer.new(256)
+	writeBuffer = writeBuffer or buffer.new(256)
+
+	readBuffer:put(input)
+	local readCursor = readBuffer:ref()
+	request.input.charset = "CP949"
+	request.input.buffer = readCursor
+	request.input.length = #input
+	request.input.remaining = #input
+
+	-- If the input is empty, reserving a zero-length write buffer may lead to misleading errors
+	local maxRequiredWriteBufferSize = math.max(1, #input * UTF_MAX_BYTES_PER_CODEPOINT)
+
+	writeBuffer:reset()
+	local writeCursor, writeBufferCapacity = writeBuffer:reserve(maxRequiredWriteBufferSize)
+	request.output.charset = "UTF-8"
+	request.output.buffer = writeCursor
+	request.output.length = writeBufferCapacity
+	request.output.remaining = writeBufferCapacity
+
+	local result = iconv.bindings.iconv_convert(request)
+	local numBytesWritten = tonumber(request.output.length - request.output.remaining)
+	writeBuffer:commit(numBytesWritten)
+
+	if result ~= ffi.C.ICONV_RESULT_OK then
+		return nil, iconv.strerror(result)
 	end
 
-	local inputBuffer = ffi.new("char[?]", #input + 1, input) -- Wasteful, but iconv modifies the input buffer
-	local maxOutputBufferSize = #input * UTF_BYTES_PER_CODEPOINT -- Worst case scenario (also wasteful)
-	local outputBuffer = buffer.new(maxOutputBufferSize)
-	local ptr, len = outputBuffer:reserve(maxOutputBufferSize)
-
-	local result = iconv.bindings.iconv_convert(inputBuffer, #input, inputEncoding, outputEncoding, ptr, len)
-
-	local numBytesWritten = tonumber(result.num_bytes_written)
-	outputBuffer:commit(numBytesWritten)
-
-	if tonumber(result.status_code) ~= 0 then
-		local errorMessage = ffi_string(result.message)
-		return nil, errorMessage
-	end
-
-	return tostring(outputBuffer), ffi_strerror(0)
+	return tostring(writeBuffer), iconv.strerror(result)
 end
 
-function iconv.try_close(descriptor)
-	if ffi.cast("size_t", descriptor) ~= iconv.bindings.CHARSET_CONVERSION_FAILED then
-		-- Guard this because MINGW64's iconv can't handle closing invalid descriptors
-		return iconv.bindings.iconv_close(descriptor)
-	end
-
-	return nil, iconv.errorMessages.INVALID_CONVERSION_HANDLE
+function iconv.strerror(result)
+	return ffi.string(iconv.bindings.iconv_strerror(result))
 end
 
 return iconv

--- a/Runtime/Bindings/FFI/iconv/iconv_exports.h
+++ b/Runtime/Bindings/FFI/iconv/iconv_exports.h
@@ -1,15 +1,43 @@
-typedef struct iconv_result_t {
-	uint8_t status_code;
-	size_t num_bytes_written;
-	const char* message;
+typedef enum iconv_result_t {
+	ICONV_RESULT_OK,
+	ICONV_INVALID_REQUEST,
+	ICONV_INVALID_DESCRIPTOR,
+	ICONV_INVALID_INPUT,
+	ICONV_INVALID_OUTPUT,
+	ICONV_CONVERSION_FAILED,
+	ICONV_INCOMPLETE_INPUT,
+	ICONV_WRITEBUFFER_FULL,
+	ICONV_RESULT_LAST,
 } iconv_result_t;
 
+typedef char* iconv_cursor_t;
+typedef const char* iconv_encoding_t; // Aliased for now, replace with enum later
+
+typedef struct iconv_memory_t {
+	iconv_encoding_t charset;
+	iconv_cursor_t buffer;
+	size_t length;
+	size_t remaining;
+} iconv_memory_t;
+
+typedef struct iconv_request_t {
+	iconv_memory_t input;
+	iconv_memory_t output;
+	iconv_t handle;
+} iconv_request_t;
+
 struct static_iconv_exports_table {
-	iconv_result_t (*iconv_convert)(char* input, size_t input_size, const char* input_encoding, const char* output_encoding, char* output, size_t output_size);
+
+	// Exports from iconv.h
 	iconv_t (*iconv_open)(const char* input_encoding, const char* output_encoding);
 	int (*iconv_close)(iconv_t conversion_descriptor);
 	size_t (*iconv)(iconv_t conversion_descriptor, char** input, size_t* input_size, char** output, size_t* output_size);
 
-	// Shared constants
-	size_t CHARSET_CONVERSION_FAILED;
+	// Charset conversion API
+	iconv_result_t (*iconv_convert)(iconv_request_t* conversion_details);
+	iconv_result_t (*iconv_try_close)(iconv_request_t* request);
+
+	// Utility methods
+	const char* (*iconv_strerror)(iconv_result_t status);
+	bool (*iconv_check_result)(iconv_t handle);
 };

--- a/Runtime/Bindings/FFI/iconv/iconv_ffi.cpp
+++ b/Runtime/Bindings/FFI/iconv/iconv_ffi.cpp
@@ -15,7 +15,7 @@ namespace iconv_ffi {
 		return reinterpret_cast<size_t>(handle) != ICONV_INVALID_HANDLE;
 	}
 
-	inline bool sanity_check_buffer(iconv_memory_t* workload) {
+	inline bool sanity_check_buffer(const iconv_memory_t* workload) {
 		if(workload->buffer == nullptr) return false;
 
 		ASSUME(workload->remaining >= workload->length, "Cursors should never escape the memory field");

--- a/Runtime/Bindings/FFI/iconv/iconv_ffi.cpp
+++ b/Runtime/Bindings/FFI/iconv/iconv_ffi.cpp
@@ -7,98 +7,98 @@
 
 #include <iconv.h>
 
-constexpr size_t ICONV_INVALID_HANDLE = SIZE_MAX;
-constexpr size_t ICONV_INVALID_SIZE = SIZE_MAX;
-bool sanity_check_descriptor(const iconv_t& handle) {
-	return reinterpret_cast<size_t>(handle) != ICONV_INVALID_HANDLE;
-}
-
-inline bool sanity_check_buffer(iconv_memory_t* workload) {
-	if(workload->buffer == nullptr) return false;
-
-	ASSUME(workload->remaining >= workload->length, "Cursors should never escape the memory field");
-	if(workload->remaining > workload->length) return false;
-
-	return true;
-}
-
-const char* iconv_strerror(iconv_result_t status) {
-	status = std::min(status, ICONV_RESULT_LAST);
-	// Compilation seems to always fail for nontrivial initializers, but maybe that'll change in the future...
-	ASSUME(iconv_error_strings[status] != nullptr, "Error strings should be defined for all possible results");
-	return iconv_error_strings[status];
-}
-
-bool iconv_check_result(iconv_t handle) {
-	return sanity_check_descriptor(handle);
-}
-
-iconv_result_t iconv_check_errno() {
-	auto status = errno;
-
-	// 1. An invalid multibyte sequence is encountered in the input
-	// 2. A multibyte sequence is encountered that is valid but that cannot be translated
-	// Apparently there's no way to differentiate between these two failure scenarios :/
-	if(status == EILSEQ) return ICONV_CONVERSION_FAILED;
-	// 4. An incomplete multibyte sequence is encountered in the input [and there are no more bytes available]
-	if(status == EINVAL) return ICONV_INCOMPLETE_INPUT;
-	// 5. The output buffer has no more room for the next converted character
-	if(status == E2BIG) return ICONV_WRITEBUFFER_FULL;
-
-	// Fall through to help detect API contract violations
-	return ICONV_RESULT_LAST;
-}
-
-iconv_result_t iconv_convert(iconv_request_t* request) {
-	if(request == nullptr) return ICONV_INVALID_REQUEST;
-
-	if(!sanity_check_buffer(&request->input)) {
-		return ICONV_INVALID_INPUT;
-	};
-
-	if(!sanity_check_buffer(&request->output)) {
-		return ICONV_INVALID_OUTPUT;
-	};
-
-	// This currently fails if an invalid charset identifier is provided -> Fix later so the error is unique
-	request->handle = iconv_open(request->output.charset, request->input.charset);
-	if(!sanity_check_descriptor(request->handle)) {
-		return iconv_check_errno(); // TODO check errno?
-	}
-
-	size_t numBytesIrreversiblyWritten = iconv(request->handle, &request->input.buffer, &request->input.remaining, &request->output.buffer, &request->output.remaining);
-	if(numBytesIrreversiblyWritten == ICONV_INVALID_SIZE) {
-		return iconv_check_errno();
-	}
-
-	if(!sanity_check_descriptor(request->handle)) {
-		// Clearly the handle was valid before, so the request couldn't be completed (caller should close or retry)
-		auto result = iconv_check_errno();
-		ASSUME(iconv_try_close(request) == ICONV_INVALID_DESCRIPTOR, "Closing an invalid handle should be a NOOP");
-		return result;
-	}
-	auto result = iconv_try_close(request);
-	ASSUME(result == ICONV_RESULT_OK, "Closing a valid handle should never fail");
-	return ICONV_RESULT_OK;
-}
-
-iconv_result_t iconv_try_close(iconv_request_t* request) {
-	if(request == nullptr) return ICONV_INVALID_REQUEST;
-	if(request->handle == nullptr) return ICONV_INVALID_DESCRIPTOR;
-
-	// MINGW64's iconv implementation can't handle closing invalid descriptors
-	if(!sanity_check_descriptor(request->handle)) {
-		return ICONV_INVALID_DESCRIPTOR;
-	}
-
-	int result = iconv_close(request->handle);
-	ASSUME(result == 0, "Calling iconv_close should never fail");
-	if(result != 0) return iconv_check_errno(); // Shouldn't be possible, but you never know...
-
-	return ICONV_RESULT_OK;
-}
-
 namespace iconv_ffi {
+
+	constexpr size_t ICONV_INVALID_HANDLE = SIZE_MAX;
+	constexpr size_t ICONV_INVALID_SIZE = SIZE_MAX;
+	bool sanity_check_descriptor(const iconv_t& handle) {
+		return reinterpret_cast<size_t>(handle) != ICONV_INVALID_HANDLE;
+	}
+
+	inline bool sanity_check_buffer(iconv_memory_t* workload) {
+		if(workload->buffer == nullptr) return false;
+
+		ASSUME(workload->remaining >= workload->length, "Cursors should never escape the memory field");
+		if(workload->remaining > workload->length) return false;
+
+		return true;
+	}
+
+	bool iconv_check_result(iconv_t handle) {
+		return sanity_check_descriptor(handle);
+	}
+
+	const char* iconv_strerror(iconv_result_t status) {
+		status = std::min(status, ICONV_RESULT_LAST);
+		// Compilation seems to always fail for nontrivial initializers, but maybe that'll change in the future...
+		ASSUME(iconv_error_strings[status] != nullptr, "Error strings should be defined for all possible results");
+		return iconv_error_strings[status];
+	}
+
+	iconv_result_t iconv_check_errno() {
+		auto status = errno;
+
+		// 1. An invalid multibyte sequence is encountered in the input
+		// 2. A multibyte sequence is encountered that is valid but that cannot be translated
+		// Apparently there's no way to differentiate between these two failure scenarios :/
+		if(status == EILSEQ) return ICONV_CONVERSION_FAILED;
+		// 4. An incomplete multibyte sequence is encountered in the input [and there are no more bytes available]
+		if(status == EINVAL) return ICONV_INCOMPLETE_INPUT;
+		// 5. The output buffer has no more room for the next converted character
+		if(status == E2BIG) return ICONV_WRITEBUFFER_FULL;
+
+		// Fall through to help detect API contract violations
+		return ICONV_RESULT_LAST;
+	}
+
+	iconv_result_t iconv_try_close(iconv_request_t* request) {
+		if(request == nullptr) return ICONV_INVALID_REQUEST;
+		if(request->handle == nullptr) return ICONV_INVALID_DESCRIPTOR;
+
+		// MINGW64's iconv implementation can't handle closing invalid descriptors
+		if(!sanity_check_descriptor(request->handle)) {
+			return ICONV_INVALID_DESCRIPTOR;
+		}
+
+		int result = iconv_close(request->handle);
+		ASSUME(result == 0, "Calling iconv_close should never fail");
+		if(result != 0) return iconv_check_errno(); // Shouldn't be possible, but you never know...
+
+		return ICONV_RESULT_OK;
+	}
+
+	iconv_result_t iconv_convert(iconv_request_t* request) {
+		if(request == nullptr) return ICONV_INVALID_REQUEST;
+
+		if(!sanity_check_buffer(&request->input)) {
+			return ICONV_INVALID_INPUT;
+		};
+
+		if(!sanity_check_buffer(&request->output)) {
+			return ICONV_INVALID_OUTPUT;
+		};
+
+		// This currently fails if an invalid charset identifier is provided -> Fix later so the error is unique
+		request->handle = iconv_open(request->output.charset, request->input.charset);
+		if(!sanity_check_descriptor(request->handle)) {
+			return iconv_check_errno();
+		}
+
+		size_t numBytesIrreversiblyWritten = iconv(request->handle, &request->input.buffer, &request->input.remaining, &request->output.buffer, &request->output.remaining);
+		if(numBytesIrreversiblyWritten == ICONV_INVALID_SIZE) {
+			return iconv_check_errno();
+		}
+
+		if(!sanity_check_descriptor(request->handle)) {
+			// Clearly the handle was valid before, so the request couldn't be completed (caller should close or retry)
+			auto result = iconv_check_errno();
+			ASSUME(iconv_try_close(request) == ICONV_INVALID_DESCRIPTOR, "Closing an invalid handle should be a NOOP");
+			return result;
+		}
+		auto result = iconv_try_close(request);
+		ASSUME(result == ICONV_RESULT_OK, "Closing a valid handle should never fail");
+		return ICONV_RESULT_OK;
+	}
 
 	void* getExportsTable() {
 

--- a/Runtime/Bindings/FFI/iconv/iconv_ffi.cpp
+++ b/Runtime/Bindings/FFI/iconv/iconv_ffi.cpp
@@ -97,7 +97,7 @@ namespace iconv_ffi {
 		}
 		auto result = iconv_try_close(request);
 		ASSUME(result == ICONV_RESULT_OK, "Closing a valid handle should never fail");
-		return ICONV_RESULT_OK;
+		return result;
 	}
 
 	void* getExportsTable() {

--- a/Runtime/Bindings/FFI/iconv/iconv_ffi.cpp
+++ b/Runtime/Bindings/FFI/iconv/iconv_ffi.cpp
@@ -29,6 +29,7 @@ namespace iconv_ffi {
 	}
 
 	const char* iconv_strerror(iconv_result_t status) {
+		if(status < ICONV_RESULT_OK) status = ICONV_RESULT_LAST;
 		status = std::min(status, ICONV_RESULT_LAST);
 		// Compilation seems to always fail for nontrivial initializers, but maybe that'll change in the future...
 		ASSUME(iconv_error_strings[status] != nullptr, "Error strings should be defined for all possible results");

--- a/Runtime/Bindings/FFI/iconv/iconv_ffi.cpp
+++ b/Runtime/Bindings/FFI/iconv/iconv_ffi.cpp
@@ -1,61 +1,121 @@
 #include "iconv_ffi.hpp"
+#include "macros.hpp"
+
 #include <iostream>
+#include <stdint.h>
 #include <string.h>
 
 #include <iconv.h>
 
-iconv_result_t iconv_convert(char* input, size_t input_length, const char* input_encoding, const char* output_encoding, char* output, size_t output_size) {
+constexpr size_t ICONV_INVALID_HANDLE = SIZE_MAX;
+constexpr size_t ICONV_INVALID_SIZE = SIZE_MAX;
+bool sanity_check_descriptor(const iconv_t& handle) {
+	return reinterpret_cast<size_t>(handle) != ICONV_INVALID_HANDLE;
+}
 
-	iconv_result_t result {
-		.status_code = EINVAL,
-		.num_bytes_written = 0,
-		.message = strerror(EINVAL),
+inline bool sanity_check_buffer(iconv_memory_t* workload) {
+	if(workload->buffer == nullptr) return false;
+
+	ASSUME(workload->remaining >= workload->length, "Cursors should never escape the memory field");
+	if(workload->remaining > workload->length) return false;
+
+	return true;
+}
+
+const char* iconv_strerror(iconv_result_t status) {
+	status = std::min(status, ICONV_RESULT_LAST);
+	// Compilation seems to always fail for nontrivial initializers, but maybe that'll change in the future...
+	ASSUME(iconv_error_strings[status] != nullptr, "Error strings should be defined for all possible results");
+	return iconv_error_strings[status];
+}
+
+bool iconv_check_result(iconv_t handle) {
+	return sanity_check_descriptor(handle);
+}
+
+iconv_result_t iconv_check_errno() {
+	auto status = errno;
+
+	// 1. An invalid multibyte sequence is encountered in the input
+	// 2. A multibyte sequence is encountered that is valid but that cannot be translated
+	// Apparently there's no way to differentiate between these two failure scenarios :/
+	if(status == EILSEQ) return ICONV_CONVERSION_FAILED;
+	// 4. An incomplete multibyte sequence is encountered in the input [and there are no more bytes available]
+	if(status == EINVAL) return ICONV_INCOMPLETE_INPUT;
+	// 5. The output buffer has no more room for the next converted character
+	if(status == E2BIG) return ICONV_WRITEBUFFER_FULL;
+
+	// Fall through to help detect API contract violations
+	return ICONV_RESULT_LAST;
+}
+
+iconv_result_t iconv_convert(iconv_request_t* request) {
+	if(request == nullptr) return ICONV_INVALID_REQUEST;
+
+	if(!sanity_check_buffer(&request->input)) {
+		return ICONV_INVALID_INPUT;
 	};
 
-	if(output == nullptr || input == nullptr) return result;
-	if(output_size == 0) return result;
+	if(!sanity_check_buffer(&request->output)) {
+		return ICONV_INVALID_OUTPUT;
+	};
 
-	size_t num_input_bytes_left = input_length;
-
-	iconv_t conversion_descriptor = iconv_open(output_encoding, input_encoding);
-	if(reinterpret_cast<size_t>(conversion_descriptor) == iconv_ffi::CHARSET_CONVERSION_FAILED) {
-		result.message = strerror(errno);
-		result.status_code = errno;
-		result.num_bytes_written = 0;
-		return result;
+	// This currently fails if an invalid charset identifier is provided -> Fix later so the error is unique
+	request->handle = iconv_open(request->output.charset, request->input.charset);
+	if(!sanity_check_descriptor(request->handle)) {
+		return iconv_check_errno(); // TODO check errno?
 	}
 
-	size_t num_output_bytes_left = output_size;
-	if(iconv(conversion_descriptor, &input, &num_input_bytes_left, &output, &num_output_bytes_left) == (size_t)-1) {
-		iconv_close(conversion_descriptor);
-		result.message = strerror(errno);
-		result.status_code = errno;
-		result.num_bytes_written = output_size - num_output_bytes_left;
+	size_t numBytesIrreversiblyWritten = iconv(request->handle, &request->input.buffer, &request->input.remaining, &request->output.buffer, &request->output.remaining);
+	if(numBytesIrreversiblyWritten == ICONV_INVALID_SIZE) {
+		return iconv_check_errno();
+	}
+
+	if(!sanity_check_descriptor(request->handle)) {
+		// Clearly the handle was valid before, so the request couldn't be completed (caller should close or retry)
+		auto result = iconv_check_errno();
+		ASSUME(iconv_try_close(request) == ICONV_INVALID_DESCRIPTOR, "Closing an invalid handle should be a NOOP");
 		return result;
 	}
-	iconv_close(conversion_descriptor);
-	*output = '\0'; // Null-terminate the output buffer
+	auto result = iconv_try_close(request);
+	ASSUME(result == ICONV_RESULT_OK, "Closing a valid handle should never fail");
+	return ICONV_RESULT_OK;
+}
 
-	const size_t num_processed_bytes = output_size - num_output_bytes_left;
+iconv_result_t iconv_try_close(iconv_request_t* request) {
+	if(request == nullptr) return ICONV_INVALID_REQUEST;
+	if(request->handle == nullptr) return ICONV_INVALID_DESCRIPTOR;
 
-	result.message = strerror(0);
-	result.status_code = 0;
-	result.num_bytes_written = num_processed_bytes;
+	// MINGW64's iconv implementation can't handle closing invalid descriptors
+	if(!sanity_check_descriptor(request->handle)) {
+		return ICONV_INVALID_DESCRIPTOR;
+	}
 
-	return result;
+	int result = iconv_close(request->handle);
+	ASSUME(result == 0, "Calling iconv_close should never fail");
+	if(result != 0) return iconv_check_errno(); // Shouldn't be possible, but you never know...
+
+	return ICONV_RESULT_OK;
 }
 
 namespace iconv_ffi {
 
 	void* getExportsTable() {
+
 		static struct static_iconv_exports_table exports = {
-			.iconv_convert = &iconv_convert,
+
+			// Exports from iconv.h
 			.iconv_open = &iconv_open,
 			.iconv_close = &iconv_close,
 			.iconv = &iconv,
 
-			// Shared constants
-			.CHARSET_CONVERSION_FAILED = CHARSET_CONVERSION_FAILED,
+			// Charset conversion API
+			.iconv_convert = &iconv_convert,
+			.iconv_try_close = &iconv_try_close,
+
+			// Utility methods
+			.iconv_strerror = &iconv_strerror,
+			.iconv_check_result = &iconv_check_result,
 		};
 
 		return &exports;

--- a/Runtime/Bindings/FFI/iconv/iconv_ffi.hpp
+++ b/Runtime/Bindings/FFI/iconv/iconv_ffi.hpp
@@ -6,8 +6,21 @@
 #include <iconv.h>
 #include "iconv_exports.h"
 
+constexpr static const char* iconv_error_strings[ICONV_RESULT_LAST + 1] = {
+	[ICONV_RESULT_OK] = "Success: Not an error",
+	[ICONV_INVALID_REQUEST] = "Failed: Invalid conversion request",
+	[ICONV_INVALID_DESCRIPTOR] = "Failed: Not a valid conversion descriptor",
+	[ICONV_INVALID_INPUT] = "Failed: The provided input buffer is invalid, uninitialized, or has been corrupted",
+	[ICONV_INVALID_OUTPUT] = "Failed: The provided output buffer is invalid, uninitialized, or has been corrupted",
+	[ICONV_CONVERSION_FAILED] = "Failed: An invalid multibyte sequence was encountered within the input",
+	[ICONV_INCOMPLETE_INPUT] = "Failed: The input ended prematurely or with an incomplete multibyte sequence",
+	[ICONV_WRITEBUFFER_FULL] = "Failed: The provided output buffer is too small to store the conversion result",
+	[ICONV_RESULT_LAST] = "Undefined: This should never happen",
+};
+
+iconv_result_t iconv_try_close(iconv_request_t* request);
+
 namespace iconv_ffi {
-	constexpr std::size_t CHARSET_CONVERSION_FAILED = static_cast<size_t>(-1);
 
 	void* getExportsTable();
 }

--- a/Runtime/Bindings/FFI/iconv/iconv_ffi.hpp
+++ b/Runtime/Bindings/FFI/iconv/iconv_ffi.hpp
@@ -6,21 +6,19 @@
 #include <iconv.h>
 #include "iconv_exports.h"
 
-constexpr static const char* iconv_error_strings[ICONV_RESULT_LAST + 1] = {
-	[ICONV_RESULT_OK] = "Success: Not an error",
-	[ICONV_INVALID_REQUEST] = "Failed: Invalid conversion request",
-	[ICONV_INVALID_DESCRIPTOR] = "Failed: Not a valid conversion descriptor",
-	[ICONV_INVALID_INPUT] = "Failed: The provided input buffer is invalid, uninitialized, or has been corrupted",
-	[ICONV_INVALID_OUTPUT] = "Failed: The provided output buffer is invalid, uninitialized, or has been corrupted",
-	[ICONV_CONVERSION_FAILED] = "Failed: An invalid multibyte sequence was encountered within the input",
-	[ICONV_INCOMPLETE_INPUT] = "Failed: The input ended prematurely or with an incomplete multibyte sequence",
-	[ICONV_WRITEBUFFER_FULL] = "Failed: The provided output buffer is too small to store the conversion result",
-	[ICONV_RESULT_LAST] = "Undefined: This should never happen",
-};
-
-iconv_result_t iconv_try_close(iconv_request_t* request);
-
 namespace iconv_ffi {
+
+	constexpr static const char* iconv_error_strings[ICONV_RESULT_LAST + 1] = {
+		[ICONV_RESULT_OK] = "Success: Not an error",
+		[ICONV_INVALID_REQUEST] = "Failed: Invalid conversion request",
+		[ICONV_INVALID_DESCRIPTOR] = "Failed: Not a valid conversion descriptor",
+		[ICONV_INVALID_INPUT] = "Failed: The provided input buffer is invalid, uninitialized, or has been corrupted",
+		[ICONV_INVALID_OUTPUT] = "Failed: The provided output buffer is invalid, uninitialized, or has been corrupted",
+		[ICONV_CONVERSION_FAILED] = "Failed: An invalid multibyte sequence was encountered within the input",
+		[ICONV_INCOMPLETE_INPUT] = "Failed: The input ended prematurely or with an incomplete multibyte sequence",
+		[ICONV_WRITEBUFFER_FULL] = "Failed: The provided output buffer is too small to store the conversion result",
+		[ICONV_RESULT_LAST] = "Undefined: This should never happen",
+	};
 
 	void* getExportsTable();
 }

--- a/Runtime/macros.hpp
+++ b/Runtime/macros.hpp
@@ -1,6 +1,15 @@
 #pragma once
 
+#include <cassert>
+
 #define EXPAND_AS_STRING(x) #x
 #define TOSTRING(x) EXPAND_AS_STRING(x)
 
 #define FROM_HERE __FILE__ ":" TOSTRING(__LINE__)
+
+// Silence [-Wunused-value] compiler warnings by adding (void)
+#ifdef NDEBUG
+#define ASSUME(condition, message) ((void)0)
+#else
+#define ASSUME(condition, failureMessage) assert((void(failureMessage), condition))
+#endif

--- a/Tests/BDD/iconv-library.spec.lua
+++ b/Tests/BDD/iconv-library.spec.lua
@@ -203,4 +203,55 @@ describe("iconv", function()
 			assertThrows(convertWithInvalidOutputEncoding, expectedErrorMessage)
 		end)
 	end)
+
+	describe("strerror", function()
+		it("should return human-readable error strings for all known result types", function()
+			local firstValidOffset = tonumber(ffi.C.ICONV_RESULT_OK)
+			local lastValidOffset = tonumber(ffi.C.ICONV_RESULT_LAST)
+
+			local numCheckedMembers = 0
+			for relativeOffset = firstValidOffset, lastValidOffset do
+				local nextOffset = firstValidOffset + relativeOffset
+				local messageString = iconv.strerror(nextOffset)
+				assertEquals(type(messageString), "string")
+				numCheckedMembers = numCheckedMembers + 1
+			end
+
+			assertEquals(numCheckedMembers, lastValidOffset + 1)
+		end)
+
+		it("should clamp error numbers to the last valid result type", function()
+			local firstValidOffset = tonumber(ffi.C.ICONV_RESULT_OK)
+			local lastValidOffset = tonumber(ffi.C.ICONV_RESULT_LAST)
+			local lastMessageString = iconv.strerror(lastValidOffset)
+
+			local numCheckedMembers = 0
+			for relativeOffset = lastValidOffset, 255 do
+				local nextOffset = firstValidOffset + relativeOffset
+				local messageString = iconv.strerror(nextOffset)
+				assertEquals(type(messageString), "string")
+				assertEquals(messageString, lastMessageString)
+				numCheckedMembers = numCheckedMembers + 1
+			end
+
+			assertEquals(numCheckedMembers, 255 - lastValidOffset + 1)
+		end)
+
+		it("should map negative error numbers to the last valid result type", function()
+			local firstValidOffset = tonumber(ffi.C.ICONV_RESULT_OK)
+			local lastValidOffset = tonumber(ffi.C.ICONV_RESULT_LAST)
+			local lastMessageString = iconv.strerror(lastValidOffset)
+
+			local numCheckedMembers = 0
+			for relativeOffset = firstValidOffset + 1, 255 do
+				local nextOffset = firstValidOffset - relativeOffset
+				local messageString = iconv.strerror(nextOffset)
+				assertEquals(type(messageString), "string")
+				assertEquals(messageString, lastMessageString)
+				numCheckedMembers = numCheckedMembers + 1
+			end
+
+			assertEquals(numCheckedMembers, 255)
+		end)
+	end)
 end)


### PR DESCRIPTION
The original version contained a lot of hacks and inefficiencies. I took another stab at the interface and decided to make some changes to how the C++ wrapper works, which may or may not make for a better overall experience (TBD):

## Aggregating `iconv_convert` parameters

This is one of two breaking changes to the API, although the functionality is mostly the same:

* Instead of taking six primitive arguments, the `iconv.convert` binding now takes a single struct pointer
* These represent the status of an ongoing charset conversion request, which is obscured by libiconv's API
* For the typical use case, there's no drawback - except for a `ffi.new` that can be cached (see benchmarks)
* Advantages are a shorter signature, plus the ability to implement APis on top (for async/streaming, later)

## Error handling updates for `iconv_convert`

Previously the error handling was mostly "pray it works or debug iconv error codes". Now it's a little better:

* The `iconv_convert` interface always returns a `iconv_result_t` (enum value) with corresponding error strings
* This is a lot more granular and matches other APIs with saner behavior, like libuv/luv (see `iconv.strerror`)
* Unfortunately not all types of errors can be differentiated, because libiconv only uses three (?) error codes
* There's also some cases where libiconv will do nothing or reset the handle, which the runtime can't detect

## `iconv_try_close` moved to the C++ layer

This is just because detecting the iconv error code via typecasts is annoying, and doing it twice even more so.

## `CHARSET_CONVERSION_FAILED` shared constant removed

This was a hack to more easily detect conversion failures, because libiconv's error handling demands it. Constants shouldn't be stored in the static exports tables, because the runtime checks they're populated with function pointers (that aren't `nullptr`) on startup. This implicitly assumes only pointers are stored in the structure, and all members are uniform. In this case it wasn't a problem as the constant was the very last member. However, it seems like a footgun best avoided.

It's also completely redundant if the constants are exported as `cdefs` and can be used from the FFI directly.

## Utility methods for error handling and validation

The bindings don't export all of them yet (some use C++ types in their signature/are inlined/NOOPs if optimized):

* `iconv_strerror` works exactly like `uv_strerror`; it could become the default way of handling errors everywhere
* It allows checking enum values with `ffi.C.ICONV_RESULT_OK` and translating to Lua failure tuples easily
* Custom errors are independent of libiconv returns - they cover all `errnor` codes and then some
* `iconv_check_result` and `iconv_check_errno` are basically more readable versions of the previous unit test assertions

## NYI: Character encoding types (`iconv_encoding_t` placeholder)

The API still uses string (`const char*`) identifiers for the libiconv encodings. Which ones are available depends on the libiconv implementation and the system itself. The API currently makes no guarantees as to which can be used. ideally, it should not only do that for all supported encodings (with unit tests), but also enable specific errors when an encoding isn't supported by the implementation or is completely unknown. That's something to be added in a future patch.

## Performance improvements and benchmarks

The benchmarks are an afterthought and clearly there's a lot of work needed in that domain still. For now, I removed a bunch of unneeded allocations and cached the largest time-wasters (I/O buffer allocations) via upvalues, to make sure all of the bindings are roughly equivalent. I'm keeping an eye on this part but it isn't a primary focus right now.

## New `ASSUME` macro for non- `NDEBUG` builds

There's not currently any way to easily turn this on (requires Ninja build updates, separate issue). I haven't settled on a way to verify assumptions at runtime because all of the available options seemed a bit meh at best. This approach is an experiment which seemed to work well in my testing. It's just C `assert` with some sugar - we'll see how that goes.

---

The actual libiconv interface is of course unchanged; it's still not very user-friendly but I can't help that.