### PR TITLE
Replace CURLVERSION_NOW with a function

### DIFF
--- a/Runtime/Bindings/FFI/curl/curl.lua
+++ b/Runtime/Bindings/FFI/curl/curl.lua
@@ -163,7 +163,7 @@ typedef enum {
 
 struct static_curl_exports_table {
 	// Exports from curl.h
-	CURLversion CURLVERSION_NOW;
+	CURLversion (*curl_version_now)(void);
 	curl_version_info_data* (*curl_version_info)(CURLversion);
 	void (*curl_free)(void*);
 
@@ -179,7 +179,7 @@ struct static_curl_exports_table {
 		CURLUPart what,
 		const char* part,
 		unsigned int flags);
-	const char* (*curl_url_strerror)(CURLUcode errno);
+	const char* (*curl_url_strerror)(CURLUcode status);
 };
 
 ]]
@@ -301,7 +301,7 @@ function curl.url_strerror(errorCode)
 end
 
 function curl.version_info(age)
-	age = age or curl.bindings.CURLVERSION_NOW
+	age = age or curl.bindings.curl_version_now()
 	local versionInfo = curl.bindings.curl_version_info(age)
 
 	local infoTable = {
@@ -340,9 +340,9 @@ function curl.version_info(age)
 end
 
 function curl.version(age)
-	age = age or curl.bindings.CURLVERSION_NOW
+	age = age or curl.bindings.curl_version_now()
 	local infoTable = curl.version_info(age)
-	return infoTable.version, infoTable.version_num, tonumber(curl.bindings.CURLVERSION_NOW)
+	return infoTable.version, infoTable.version_num, tonumber(curl.bindings.curl_version_now())
 end
 
 return curl

--- a/Runtime/Bindings/FFI/curl/curl_exports.h
+++ b/Runtime/Bindings/FFI/curl/curl_exports.h
@@ -1,6 +1,6 @@
 struct static_curl_exports_table {
 	// Exports from curl.h
-	CURLversion CURLVERSION_NOW;
+	CURLversion (*curl_version_now)(void);
 	curl_version_info_data* (*curl_version_info)(CURLversion);
 	void (*curl_free)(void*);
 

--- a/Runtime/Bindings/FFI/curl/curl_ffi.cpp
+++ b/Runtime/Bindings/FFI/curl/curl_ffi.cpp
@@ -1,10 +1,14 @@
 #include "curl_ffi.hpp"
 
 namespace curl_ffi {
+	CURLversion curl_version_now() {
+		return CURLVERSION_NOW;
+	}
+
 	void* getExportsTable() {
 		static struct static_curl_exports_table exports = {
 			// Exports from curl.h
-			.CURLVERSION_NOW = CURLVERSION_NOW,
+			.curl_version_now = curl_version_now,
 			.curl_version_info = curl_version_info,
 			.curl_free = curl_free,
 

--- a/Tests/BDD/curl-library.spec.lua
+++ b/Tests/BDD/curl-library.spec.lua
@@ -336,7 +336,7 @@ describe("curl", function()
 			assertEquals(versionInfo.version, versionString)
 			assertEquals(versionInfo.version_num, versionNumber)
 			assertEquals(versionInfo.age, revision)
-			assertEquals(versionInfo.age, tonumber(curl.bindings.CURLVERSION_NOW))
+			assertEquals(versionInfo.age, tonumber(curl.bindings.curl_version_now()))
 
 			assertTrue(type(versionNumber) == "number")
 			local firstMatchedCharacterIndex, lastMatchedCharacterIndex = string.find(versionString, "%d+.%d+.%d+")


### PR DESCRIPTION
Same issue as `CHARSET_CONVERSION_FAILED` in the iconv bindings (see https://github.com/evo-lua/evo-runtime/pull/662).

Only function pointers should be stored in the exports table. It doesn't make much of a difference anyway.

(Looks like I forgot to sync the cdefs, hence the unrelated parameter name change in `curl_url_strerror`)