### PR TITLE
Substitute buildin IDs for more readable names when reporting test failures

### DIFF
--- a/Runtime/Extensions/debugx.lua
+++ b/Runtime/Extensions/debugx.lua
@@ -12,7 +12,8 @@ local DEFAULT_OPTIONS = {
 	indent = "\t",
 	silent = false,
 }
-local LUAJIT_BUILTIN_PATTERN = "%[?builtin#(%d+)%]?"
+local LUAJIT_BUILTIN_TOSTRING_PATTERN = "builtin#(%d+)"
+local LUAJIT_BUILTIN_TRACEBACK_PATTERN = "%[builtin#(%d+)%]"
 
 local function dump(object, options)
 	if type(object) == "userdata" then
@@ -52,9 +53,15 @@ end
 
 function debug.tostring(what)
 	local stringified = tostring(what)
-	return stringified:gsub(LUAJIT_BUILTIN_PATTERN, function(builtinID)
+	stringified = stringified:gsub(LUAJIT_BUILTIN_TOSTRING_PATTERN, function(builtinID)
 		return vmdef.ffnames[tonumber(builtinID)]
 	end)
+
+	stringified = stringified:gsub(LUAJIT_BUILTIN_TRACEBACK_PATTERN, function(builtinID)
+		return vmdef.ffnames[tonumber(builtinID)]
+	end)
+
+	return stringified
 end
 
 debug.dump = dump

--- a/Runtime/Extensions/debugx.lua
+++ b/Runtime/Extensions/debugx.lua
@@ -1,6 +1,8 @@
 local inspect = require("inspect")
+local vmdef = require("vmdef")
 
 local print = print
+local tostring = tostring
 local format = string.format
 local tinsert = table.insert
 
@@ -10,6 +12,7 @@ local DEFAULT_OPTIONS = {
 	indent = "\t",
 	silent = false,
 }
+local LUAJIT_BUILTIN_PATTERN = "%[?builtin#(%d+)%]?"
 
 local function dump(object, options)
 	if type(object) == "userdata" then
@@ -45,6 +48,13 @@ function debug.sbuf(sbuf)
 	local isEmpty = (#sbuf == 0)
 	local bytes = isEmpty and "" or table.concat(hexBytes, " ")
 	return format("%s [%s]", "Buffer", bytes)
+end
+
+function debug.tostring(what)
+	local stringified = tostring(what)
+	return stringified:gsub(LUAJIT_BUILTIN_PATTERN, function(builtinID)
+		return vmdef.ffnames[tonumber(builtinID)]
+	end)
 end
 
 debug.dump = dump

--- a/Runtime/Libraries/assertions.lua
+++ b/Runtime/Libraries/assertions.lua
@@ -4,7 +4,7 @@ local ffi = require("ffi")
 local error = error
 local pairs = pairs
 local pcall = pcall
-local tostring = tostring
+local tostring = debug.tostring
 local type = type
 local format = string.format
 local debug_getinfo = debug.getinfo
@@ -99,7 +99,7 @@ function assertions.assertCallsFunction(codeUnderTest, targetFunction)
 	codeUnderTest()
 	debug_sethook()
 	if calledFn ~= targetFunction then
-		error("ASSERTION FAILURE: Expected function " .. tostring(targetFunction) .. " to be called but it was not", 0)
+		error("ASSERTION FAILURE: Expected " .. tostring(targetFunction) .. " to be called but it was not", 0)
 	end
 end
 

--- a/Runtime/Libraries/bdd.lua
+++ b/Runtime/Libraries/bdd.lua
@@ -15,7 +15,6 @@ local validateTable = validation.validateTable
 local dofile = dofile
 local print = print
 
-local debug_traceback = debug.traceback
 local format = string.format
 local string_rep = string.rep
 local table_insert = table.insert
@@ -101,10 +100,11 @@ local function errorHandler(errorMessage)
 		return
 	end
 
+	local stackTrace = debug.traceback(errorMessage, 3)
 	-- Level 3 strips this error handler and the [C] error call
 	return {
-		stackTrace = debug_traceback(errorMessage, 3),
 		message = debug.tostring(errorMessage),
+		stackTrace = debug.tostring(stackTrace),
 	}
 end
 

--- a/Runtime/Libraries/bdd.lua
+++ b/Runtime/Libraries/bdd.lua
@@ -103,8 +103,8 @@ local function errorHandler(errorMessage)
 
 	-- Level 3 strips this error handler and the [C] error call
 	return {
-		message = errorMessage,
 		stackTrace = debug_traceback(errorMessage, 3),
+		message = debug.tostring(errorMessage),
 	}
 end
 

--- a/Tests/BDD/debug-library.spec.lua
+++ b/Tests/BDD/debug-library.spec.lua
@@ -1,3 +1,14 @@
+local ffi = require("ffi")
+local vmdef = require("vmdef")
+
+local function table_find(where, what)
+	for key, value in pairs(where) do
+		if value == what then
+			return key
+		end
+	end
+end
+
 describe("debug", function()
 	describe("sbuf", function()
 		it("should return a human-readable representation if an empty buffer was passed", function()
@@ -17,6 +28,21 @@ describe("debug", function()
 			assertEquals(type(temporaryFileHandle), "userdata")
 			assertEquals(debug.sbuf(temporaryFileHandle), tostring(temporaryFileHandle))
 			temporaryFileHandle:close()
+		end)
+	end)
+
+	describe("tostring", function()
+		it("should translate VM builtins to human-readable names", function()
+			local arbitraryBuiltinFunction = ffi.gc
+			local builtinID = assert(table_find(vmdef.ffnames, "ffi.gc"))
+
+			local defaultName = tostring(arbitraryBuiltinFunction)
+			local expectedDefaultName = "function: builtin#" .. builtinID
+			assertEquals(defaultName, expectedDefaultName)
+
+			local debugName = debug.tostring(arbitraryBuiltinFunction)
+			local expectedDebugName = "function: ffi.gc"
+			assertEquals(debugName, expectedDebugName)
 		end)
 	end)
 end)

--- a/Tests/BDD/debug-library.spec.lua
+++ b/Tests/BDD/debug-library.spec.lua
@@ -32,7 +32,7 @@ describe("debug", function()
 	end)
 
 	describe("tostring", function()
-		it("should translate VM builtins to human-readable names", function()
+		it("should translate VM builtins in tostring format to human-readable names", function()
 			local arbitraryBuiltinFunction = ffi.gc
 			local builtinID = assert(table_find(vmdef.ffnames, "ffi.gc"))
 
@@ -42,6 +42,14 @@ describe("debug", function()
 
 			local debugName = debug.tostring(arbitraryBuiltinFunction)
 			local expectedDebugName = "function: ffi.gc"
+			assertEquals(debugName, expectedDebugName)
+		end)
+
+		it("should translate VM builtins in traceback format to human-readable names", function()
+			local builtinID = assert(table_find(vmdef.ffnames, "dofile"))
+			local defaultName = format("[builtin#%d]:", builtinID)
+			local debugName = debug.tostring(defaultName)
+			local expectedDebugName = "[dofile]:"
 			assertEquals(debugName, expectedDebugName)
 		end)
 	end)

--- a/Tests/Fixtures/failing-sections.spec.lua
+++ b/Tests/Fixtures/failing-sections.spec.lua
@@ -15,3 +15,10 @@ assertEquals(1, 1)
 it("should even support standalone it blocks (questionable)", function()
 	error("meep", 0)
 end)
+
+it("should translate builtin functions to human-readable names in error reports", function()
+	local arbitraryBuiltinFunction = tostring
+	-- Beware: Passing the function itself will be interpreted as an error object (no __tostring = glitched)
+	local message = format("This reference should be resolved to '%s'", arbitraryBuiltinFunction)
+	error(message, 0)
+end)

--- a/Tests/SmokeTests/assertions-library/test-assert-calls-function.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-calls-function.lua
@@ -1,4 +1,5 @@
 local assertions = require("assertions")
+local ffi = require("ffi")
 local assertCallsFunction = assertions.assertCallsFunction
 
 local function testFunctionCallsFunctionCase()
@@ -19,8 +20,17 @@ local function testFunctionDoesNotCallAnyFunctionCase()
 	local success, errorMessage = pcall(assertCallsFunction, function() end, NOOP_FUNCTION)
 	assert(not success, "assertCallsFunction should throw if no function is called")
 	assert(
-		string.match(errorMessage, "^ASSERTION FAILURE: Expected function .* to be called but it was not$"),
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected .* to be called but it was not$"),
 		"assertCallsFunction should throw the expected error if no function is called"
+	)
+end
+
+local function testFunctionDoesNotCallBuildinFunctionCase()
+	local success, errorMessage = pcall(assertCallsFunction, function() end, ffi.gc)
+	assert(not success, "assertCallsFunction should throw if the expected builtin is not called")
+	assert(
+		errorMessage == "ASSERTION FAILURE: Expected function: ffi.gc to be called but it was not",
+		"assertCallsFunction should use human-readable names if a builtin was expected to be called"
 	)
 end
 
@@ -37,7 +47,7 @@ local function testFunctionCallsDifferentFunctionCase()
 	local success, errorMessage = pcall(assertCallsFunction, functionThatCallsSomeOtherFunction, NOOP_FUNCTION)
 	assert(not success, "assertCallsFunction should throw if the expected function is not called")
 	assert(
-		string.match(errorMessage, "^ASSERTION FAILURE: Expected function .* to be called but it was not$"),
+		string.match(errorMessage, "^ASSERTION FAILURE: Expected function: .* to be called but it was not$"),
 		"assertCallsFunction should throw the expected error if the expected function is not called"
 	)
 end
@@ -45,6 +55,7 @@ end
 local function testAssertCallsFunction()
 	testFunctionCallsFunctionCase()
 	testFunctionDoesNotCallAnyFunctionCase()
+	testFunctionDoesNotCallBuildinFunctionCase()
 	testFunctionCallsDifferentFunctionCase()
 end
 

--- a/Tests/SmokeTests/assertions-library/test-assert-equal-functions.lua
+++ b/Tests/SmokeTests/assertions-library/test-assert-equal-functions.lua
@@ -10,9 +10,9 @@ end
 local function testDifferentFunctionsCase()
 	local success, errorMessage = pcall(assertEqualFunctions, print, tostring)
 	local expectedErrorMessage = "^ASSERTION FAILURE: Expected "
-		.. tostring(tostring)
+		.. debug.tostring(tostring)
 		.. " but got "
-		.. tostring(print)
+		.. debug.tostring(print)
 		.. "$"
 
 	assert(not success, "assertEqualFunctions(print, tostring) should throw")

--- a/Tests/SmokeTests/bdd-library/test-start-runner.lua
+++ b/Tests/SmokeTests/bdd-library/test-start-runner.lua
@@ -268,7 +268,7 @@ local function testDetailedFailingSectionsCase()
 	bdd.setDetailedReportMode()
 
 	local numFailingTests = startTestRunner({ "Tests/Fixtures/failing-sections.spec.lua" })
-	assertEquals(numFailingTests, 3)
+	assertEquals(numFailingTests, 4)
 	local icon = brightRed("✗")
 	local lines = {
 		bold("top-level describe blocks"),
@@ -276,6 +276,7 @@ local function testDetailedFailingSectionsCase()
 		"  " .. bold("nested describe blocks"),
 		"    " .. icon .. " " .. brightRed("should also work"),
 		icon .. " " .. brightRed("should even support standalone it blocks (questionable)"),
+		icon .. " " .. brightRed("should translate builtin functions to human-readable names in error reports"),
 		bdd.getSectionsReportString(),
 		"",
 	}
@@ -297,6 +298,10 @@ local function testDetailedFailingSectionsCase()
 	assertEquals(errorDetails[3].specFile, "Tests/Fixtures/failing-sections.spec.lua")
 	assertEquals(errorDetails[3].message, "meep")
 	assertEquals(type(errorDetails[3].stackTrace), "string")
+
+	assertEquals(errorDetails[4].specFile, "Tests/Fixtures/failing-sections.spec.lua")
+	assertEquals(errorDetails[4].message, "This reference should be resolved to 'function: tostring'")
+	assertEquals(type(errorDetails[4].stackTrace), "string")
 end
 
 local function testSetupTeardownHookNestingCase()

--- a/Tests/SmokeTests/bdd-library/test-start-runner.lua
+++ b/Tests/SmokeTests/bdd-library/test-start-runner.lua
@@ -299,9 +299,15 @@ local function testDetailedFailingSectionsCase()
 	assertEquals(errorDetails[3].message, "meep")
 	assertEquals(type(errorDetails[3].stackTrace), "string")
 
+	local expectedMessage = "This reference should be resolved to 'function: tostring'"
 	assertEquals(errorDetails[4].specFile, "Tests/Fixtures/failing-sections.spec.lua")
-	assertEquals(errorDetails[4].message, "This reference should be resolved to 'function: tostring'")
+	assertEquals(errorDetails[4].message, expectedMessage)
 	assertEquals(type(errorDetails[4].stackTrace), "string")
+	assertEquals(errorDetails[4].stackTrace:sub(1, #expectedMessage), expectedMessage)
+
+	local LUAJIT_BUILTIN_PATTERN = "%[?builtin#(%d+)%]?"
+	assertNil(errorDetails[4].stackTrace:find(LUAJIT_BUILTIN_PATTERN))
+	assert(errorDetails[4].stackTrace:find("%[dofile%]"))
 end
 
 local function testSetupTeardownHookNestingCase()


### PR DESCRIPTION
It'd be more robust to do this at the VM level, but that requires replacing the `debug` library or substituting all traces/errors.
This is much less invasive and probably good enough for the test runner, which is where most of the value lies anyway.