### PR TITLE
Bump the macOS deployment target to 13.4

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -27,7 +27,7 @@ jobs:
           - os: macos-15
             arch: M1
     env:
-        MACOSX_DEPLOYMENT_TARGET: 13.3
+        MACOSX_DEPLOYMENT_TARGET: 13.4
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1 # Prevent brew updates in the ccache setup step (~2GB download ...)
 
     steps:


### PR DESCRIPTION
Apparently `std::format` requires 13.4 now, even though it worked perfectly fine on 13.3 before.