### PR TITLE
Fix oversights in the high-level iconv wrapper

### DIFF
--- a/Runtime/Bindings/FFI/iconv/iconv.lua
+++ b/Runtime/Bindings/FFI/iconv/iconv.lua
@@ -73,9 +73,10 @@ function iconv.convert(input, inputEncoding, outputEncoding)
 	readBuffer = readBuffer or buffer.new(256)
 	writeBuffer = writeBuffer or buffer.new(256)
 
+	readBuffer:reset()
 	readBuffer:put(input)
 	local readCursor = readBuffer:ref()
-	request.input.charset = "CP949"
+	request.input.charset = inputEncoding
 	request.input.buffer = readCursor
 	request.input.length = #input
 	request.input.remaining = #input
@@ -85,7 +86,7 @@ function iconv.convert(input, inputEncoding, outputEncoding)
 
 	writeBuffer:reset()
 	local writeCursor, writeBufferCapacity = writeBuffer:reserve(maxRequiredWriteBufferSize)
-	request.output.charset = "UTF-8"
+	request.output.charset = outputEncoding
 	request.output.buffer = writeCursor
 	request.output.length = writeBufferCapacity
 	request.output.remaining = writeBufferCapacity

--- a/Tests/BDD/iconv-library.spec.lua
+++ b/Tests/BDD/iconv-library.spec.lua
@@ -166,14 +166,16 @@ describe("iconv", function()
 			local input = "유저인터페이스"
 			assertFailure(function()
 				return iconv.convert(input, "INVALID_ENCODING", "UTF-8")
-			end, iconv.strerror(ffi.C.ICONV_CONVERSION_FAILED))
+				-- TBD: This is what the library returns - even though it's misleading at best (?)
+			end, iconv.strerror(ffi.C.ICONV_INCOMPLETE_INPUT))
 		end)
 
 		it("should fail if given an invalid output encoding", function()
 			local input = "유저인터페이스"
 			assertFailure(function()
-				return iconv.convert(input, "UTF-8", "INVALID_ENCODING")
-			end, iconv.strerror(ffi.C.ICONV_CONVERSION_FAILED))
+				return iconv.convert(input, "CP949", "INVALID_ENCODING")
+				-- TBD: This is what the library returns - even though it's  misleading at best (?)
+			end, iconv.strerror(ffi.C.ICONV_INCOMPLETE_INPUT))
 		end)
 
 		it("should throw if a non-string input was passed", function()
@@ -201,6 +203,16 @@ describe("iconv", function()
 			local expectedErrorMessage =
 				"Expected argument outputEncoding to be a string value, but received a number value instead"
 			assertThrows(convertWithInvalidOutputEncoding, expectedErrorMessage)
+		end)
+
+		it("should be able to convert multiple inputs using the same buffer", function()
+			local output, result = iconv.convert("First", "ASCII", "UTF-8")
+			assertEquals(output, "First")
+			assertEquals(result, iconv.strerror(ffi.C.ICONV_RESULT_OK))
+
+			output, result = iconv.convert("Second", "ASCII", "UTF-8")
+			assertEquals(output, "Second")
+			assertEquals(result, iconv.strerror(ffi.C.ICONV_RESULT_OK))
 		end)
 	end)
 


### PR DESCRIPTION
When converting multiple inputs using the same read buffer, appending to it without first resetting the cursor ensures the result is garbled. It also looks like the default values for input and output encoding were accidentally hardcoded.
